### PR TITLE
NSObjCRuntime: add availability macro definitions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+
+	* Headers/Foundation/NSObjCRuntime.h:	
+	Add empty definitions for OSX Availability macros for compatibility
+	purposes.
+
 2017-07-10  Wolfgang Lux  <wolfgang.lux@gmail.com>
 
 	* Source/GSString.m (lengthUTF8):

--- a/Headers/Foundation/NSObjCRuntime.h
+++ b/Headers/Foundation/NSObjCRuntime.h
@@ -286,13 +286,20 @@ DEFINE_BLOCK_TYPE(NSComparator, NSComparisonResult, id, id);
 /**
  * Declare Apple availability macros for compatibility purposes as no-ops.
  */
-#ifndef NS_CLASS_AVAILABLE
-#define NS_CLASS_AVAILABLE(x, y)
-#endif
-
-#ifndef NS_AVAILABLE
-#define NS_AVAILABLE(x, y)
-#endif
+#define NS_CLASS_AVAILABLE(...)
+#define NS_AVAILABLE(...)
+#define NS_AVAILABLE_MAC(...)
+#define NS_DEPRECATED(...)
+#define NS_DEPRECATED_MAC(...)
+#define NS_ENUM_AVAILABLE(...)
+#define NS_ENUM_AVAILABLE_MAC(...)
+#define NS_ENUM_DEPRECATED(...)
+#define NS_ENUM_DEPRECATED_MAC(...)
+#define NS_CLASS_AVAILABLE(...)
+#define NS_CLASS_DEPRECATED(...)
+#define NS_CLASS_AVAILABLE_MAC(...)
+#define NS_CLASS_DEPRECATED_MAC(...)
+#define NS_UNAVAILABLE
 
 /* Define root class NS macro */
 #ifndef NS_ROOT_CLASS


### PR DESCRIPTION
Add empty definitions for OSX Availability macros for compatibility
purposes.