### PR TITLE
fix bug #51592: do not assert on nonexistent files when copying

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2017-11-26  Graham Lee  <leeg@trilby>
+
+	* Source/NSFileManager.m: on copying a file, when the source file
+	doesn't exist or its attributes can't be read, report an error to
+	the handler instead of triggering an assertion failure. Fixes bug
+	#51592. Additionally fix an incorrect method signature.
+
+	* Tests/base/NSFileManager/general.m: Test for above.
+
 2017-11-16  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSArray.m: Fix for bug reported on github by zneak.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2017-11-26  Graham Lee  <leeg@trilby>
+2017-11-26  Graham Lee  <graham@iamleeg.com>
 
 	* Source/NSFileManager.m: on copying a file, when the source file
 	doesn't exist or its attributes can't be read, report an error to

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -361,7 +361,7 @@ static NSStringEncoding	defaultEncoding;
   return _delegate;
 }
 
-- (void) setDelegate: (NSFileManager *)delegate {
+- (void) setDelegate: (id <NSFileManagerDelegate>)delegate {
   _delegate = delegate;
 }
 
@@ -2821,13 +2821,15 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
   int		wbytes;
   char		buffer[bufsize];
 
-  /* Assumes source is a file and exists! */
-  NSAssert1 ([self fileExistsAtPath: source],
-    @"source file '%@' does not exist!", source);
-
   attributes = [self fileAttributesAtPath: source traverseLink: NO];
-  NSAssert1 (attributes, @"could not get the attributes for file '%@'",
-    source);
+  if (attributes == nil)
+    {
+      return [self _proceedAccordingToHandler: handler
+				     forError: @"could not get attributes for source file"
+				       inPath: source
+				     fromPath: source
+				       toPath: destination];
+    }
 
   fileSize = [attributes fileSize];
   fileMode = [attributes filePosixPermissions];

--- a/Tests/base/NSFileManager/general.m
+++ b/Tests/base/NSFileManager/general.m
@@ -128,6 +128,11 @@ int main()
     PASS([str1 isEqualToString: str2],"NSFileManager moved file contents match");
   }
 
+  PASS(![mgr copyPath: @"NSFMFile"
+	       toPath: @"NSFMDestination"
+	      handler: nil],
+       "NSFileManager does not copy nonexistent file");
+
   if ([[NSProcessInfo processInfo] operatingSystem]
     != NSWindowsNTOperatingSystem)
     {


### PR DESCRIPTION
I agree with the reporter that these should not be assertions: the filesystem is not under the developer's control so it is unreasonable for the developer to make any expectations about its state. Additionally, there was a time-of-check to time-of-use issue - the method fails early if the file doesn't exist, but it might exist when the check is made and then be unlinked before opening it is attempted.

I have therefore completely removed the test for the source file's existence: if it didn't exist then, it still won't exist when we try to read its attributes. I have changed the assertion on failure to read the file's attributes into a report to the handler, so that the application can deal with the error.

Additionally I noticed when building that the method signature was wrong for `-setDelegate:` and changed that.