### PR TITLE
Remove use of NSDecrementRefCountWasZero.

### DIFF
--- a/Source/NSMessagePort.m
+++ b/Source/NSMessagePort.m
@@ -1148,8 +1148,12 @@ typedef	struct {
       NSEnumerator	*files;
 
       messagePortClass = self;
+#ifdef OBJC_CAP_ARC
+      messagePortMap = [[NSMapTable strongToWeakObjectsMapTable] retain];
+#else
       messagePortMap = NSCreateMapTable(NSNonRetainedObjectMapKeyCallBacks,
 	NSNonOwnedPointerMapValueCallBacks, 0);
+#endif
 
       messagePortLock = [GSLazyRecursiveLock new];
 
@@ -1710,6 +1714,7 @@ typedef	struct {
     }
 }
 
+#ifndef OBJC_CAP_ARC
 - (oneway void) release
 {
   M_LOCK(messagePortLock);
@@ -1727,6 +1732,7 @@ typedef	struct {
       M_UNLOCK(messagePortLock);
     }
 }
+#endif
 
 - (void) removeHandle: (GSMessageHandle*)handle
 {

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -1654,6 +1654,9 @@ static id gs_weak_load(id obj)
  */
 - (id) autorelease
 {
+#ifdef OBJC_CAP_ARC
+  return objc_autorelease(self);
+#else
   if (double_release_check_enabled)
     {
       NSUInteger release_count;
@@ -1669,6 +1672,7 @@ static id gs_weak_load(id obj)
 
   (*autorelease_imp)(autorelease_class, autorelease_sel, self);
   return self;
+#endif
 }
 
 /**
@@ -1893,13 +1897,14 @@ static id gs_weak_load(id obj)
  */
 - (oneway void) release
 {
+#  ifdef OBJC_CAP_ARC
+  objc_release(self);
+#  else
   if (NSDecrementExtraRefCountWasZero(self))
     {
-#  ifdef OBJC_CAP_ARC
-      objc_delete_weak_refs(self);
-#  endif
       [self dealloc];
     }
+#  endif
 }
 
 /**
@@ -1958,7 +1963,11 @@ static id gs_weak_load(id obj)
  */
 - (id) retain
 {
+#if OBJC_CAP_ARC
+  objc_retain(self);
+#else
   NSIncrementExtraRefCount(self);
+#endif
   return self;
 }
 

--- a/Source/NSPort.m
+++ b/Source/NSPort.m
@@ -173,16 +173,13 @@ static Class	NSPort_concrete_class;
   return 0;
 }
 
-- (id) retain
-{
-  return [super retain];
-}
 
-- (id) autorelease
+#ifdef OBJC_CAP_ARC
+- (void)dealloc
 {
-  return [super autorelease];
+  [self invalidate];
 }
-
+#else
 - (oneway void) release
 {
   if (_is_valid && [self retainCount] == 1)
@@ -198,6 +195,7 @@ static Class	NSPort_concrete_class;
     }
   [super release];
 }
+#endif
 
 - (void) setDelegate: (id) anObject
 {

--- a/Source/NSProxy.m
+++ b/Source/NSProxy.m
@@ -58,6 +58,9 @@
  * but is not a subclass of NSObject.</p>
  */
 @implementation NSProxy
+#ifdef OBJC_CAP_ARC
+- (void)_ARCCompliantRetainRelease {}
+#endif
 
 /**
  * Allocates and returns an NSProxy instance in the default zone.
@@ -217,8 +220,12 @@
  */
 - (id) autorelease
 {
+#ifdef OBJC_CAP_ARC
+  return objc_autorelease(self);
+#else
   [NSAutoreleasePool addObject: self];
   return self;
+#endif
 }
 
 /**
@@ -453,13 +460,14 @@
  */
 - (oneway void) release
 {
+#ifdef OBJC_CAP_ARC
+  objc_release(self);
+#else
   if (NSDecrementExtraRefCountWasZero(self))
     {
-#  ifdef OBJC_CAP_ARC
-      objc_delete_weak_refs(self);
-#  endif
       [self dealloc];
     }
+#endif
 }
 
 /**
@@ -521,8 +529,12 @@
  */
 - (id) retain
 {
+#ifdef OBJC_CAP_ARC
+  return objc_retain(self);
+#else
   NSIncrementExtraRefCount(self);
   return self;
+#endif
 }
 
 /**

--- a/Source/NSSocketPort.m
+++ b/Source/NSSocketPort.m
@@ -1707,11 +1707,17 @@ static Class		tcpPortClass;
 		   * No known ports with this port number -
 		   * create the map table to add the new port to.
 		   */
+#ifdef OBJC_CAP_ARC
+		  thePorts = [NSMapTable strongToWeakObjectsMapTable];
+		  NSMapInsert(tcpPortMap, (void*)(uintptr_t)port->portNum,
+		    (void*)thePorts);
+#else
 		  thePorts = NSCreateMapTable(NSObjectMapKeyCallBacks,
 		    NSNonOwnedPointerMapValueCallBacks, 0);
 		  NSMapInsert(tcpPortMap, (void*)(uintptr_t)port->portNum,
 		    (void*)thePorts);
                   RELEASE(thePorts);
+#endif
 		}
 	      /*
 	       * Ok - now add the port for the host
@@ -1734,6 +1740,17 @@ static Class		tcpPortClass;
 	       * No known ports within this port number -
 	       * create the map table to add the new port to.
 	       */
+#ifdef OBJC_CAP_ARC
+		thePorts = [NSMapTable strongToWeakObjectsMapTable];
+		NSMapInsert(tcpPortMap, (void*)(uintptr_t)port->portNum,
+		  (void*)thePorts);
+#else
+		thePorts = NSCreateMapTable(NSObjectMapKeyCallBacks,
+		  NSNonOwnedPointerMapValueCallBacks, 0);
+		NSMapInsert(tcpPortMap, (void*)(uintptr_t)port->portNum,
+		  (void*)thePorts);
+                RELEASE(thePorts);
+#endif
 	      thePorts = NSCreateMapTable(NSIntegerMapKeyCallBacks,
 			      NSNonOwnedPointerMapValueCallBacks, 0);
 	      NSMapInsert(tcpPortMap,
@@ -2221,6 +2238,7 @@ static Class		tcpPortClass;
     }
 }
 
+#ifndef OBJC_CAP_ARC
 - (oneway void) release
 {
   M_LOCK(tcpPortLock);
@@ -2241,6 +2259,7 @@ static Class		tcpPortClass;
       M_UNLOCK(tcpPortLock);
     }
 }
+#endif
 
 
 /*

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -408,6 +408,15 @@ static NSURLProtocol	*placeholder = nil;
    */
   return;
 }
+- (id) retain
+{
+  return self;
+}
+
+- (id) autorelease
+{
+  return self;
+}
 @end
 
 @implementation	NSURLProtocol

--- a/Source/common.h
+++ b/Source/common.h
@@ -85,4 +85,8 @@
 #  endif
 #endif
 
+#if __has_include(<objc/capabilities.h>)
+#  include <objc/capabilities.h>
+#endif
+
 #endif /* COMMON_H */

--- a/Tests/base/NSBundle/general.m
+++ b/Tests/base/NSBundle/general.m
@@ -56,7 +56,6 @@ int main()
   TEST_FOR_CLASS(@"NSBundle",classBundle,
     "+bundleForClass: makes a bundle for us");
 
-  NSLog(@"%@", [classBundle principalClass]);
   PASS([classBundle principalClass] == [TestClass class], 
     "-principalClass returns TestClass for +bundleForClass:[TestClass class]");
 
@@ -68,6 +67,7 @@ int main()
       stringByAppendingPathComponent: @"TestBundle.bundle"];
 
   bundle = [NSBundle bundleWithPath: path];
+  PASS(bundle != nil, "bundleWithPath: returned non-nil bundle");
   PASS([bundle isKindOfClass:[NSBundle class]],
     "+bundleWithPath returns an NSBundle");
 

--- a/Tests/base/NSFileHandle/singleton.m
+++ b/Tests/base/NSFileHandle/singleton.m
@@ -21,6 +21,10 @@ int main(void)
   PASS_EXCEPTION([a release], NSGenericException, "Cannot dealloc stdin");
   PASS_EXCEPTION([b release], NSGenericException, "Cannot dealloc stdout");
   PASS_EXCEPTION([c release], NSGenericException, "Cannot dealloc stderr");
+  // The following are expected to fail with an ARC-supporting runtime.  ARC
+  // doesn't allow resurrection and the objc_retain() function will check for
+  // this so the [self retain] in GSFileHandle's -dealloc will not actually
+  // resurrect the object.
   PASS([a retainCount]> 0, "stdin persists");
   PASS([b retainCount]> 0, "stdout persists");
   PASS([c retainCount]> 0, "strerr persists");

--- a/Tests/base/NSOperation/threads.m
+++ b/Tests/base/NSOperation/threads.m
@@ -5,7 +5,9 @@
 #import <Foundation/NSNotification.h>
 #import <Foundation/NSAutoreleasePool.h>
 #import "ObjectTesting.h"
-
+#if __has_include(<objc/capabilities.h>)
+#include <objc/capabilities.h>
+#endif
 
 @interface      ThreadCounter : NSObject
 {
@@ -80,7 +82,7 @@
 {
   return thread;
 }
-
+#ifndef OBJC_CAP_ARC
 - (void) release
 {
   // NSLog(@"Will release %@ at %@", self, [NSThread callStackSymbols]);
@@ -92,6 +94,7 @@
   // NSLog(@"Will retain %@ at %@", self, [NSThread callStackSymbols]);
   return [super retain];
 }
+#endif
 
 @end
 


### PR DESCRIPTION
This function is unreliable and is impossible to implement safely in the
persence of ARC (even in other modules).  ARC requires that the runtime delete
all weak references before object deallocation and doesn't permit resurrection.

This change is initially motivated by the desire to steal a bit from the
refcount to indicate that an object has had weak references taken.