### PR TITLE
Refactor refcount usage.

### DIFF
--- a/Tests/base/NSProxy/basic.m
+++ b/Tests/base/NSProxy/basic.m
@@ -1,6 +1,9 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSProxy.h>
+#if __has_include(<objc/capabilities.h>
+#include <objc/capabilities.h>
+#endif
 
 int main()
 {
@@ -24,8 +27,10 @@ int main()
   
   obj1 = [NSProxy allocWithZone:testZone];
   PASS(obj1 != nil, "%s has working allocWithZone:",prefix);
+#ifndef OBJC_CAP_ARC
   PASS(NSZoneFromPointer(obj1) == testZone, "%s uses zone for alloc",prefix);
   PASS([obj1 zone] == testZone, "%s -zone works",prefix);
+#endif
   
   PASS([obj1 hash] != 0, "%s has working -hash",prefix);
   PASS([obj1 isEqual:obj1] == YES, "%s has working -isEqual:",prefix);

--- a/Tests/base/NSProxy/basic.m
+++ b/Tests/base/NSProxy/basic.m
@@ -1,7 +1,7 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSProxy.h>
-#if __has_include(<objc/capabilities.h>
+#if __has_include(<objc/capabilities.h>)
 #include <objc/capabilities.h>
 #endif
 


### PR DESCRIPTION
This makes it easier for the runtime to change how reference counts are
stored by removing any refcount manipulation from -base when the runtime
provides accessors.  This should have no functionality change with
existing runtimes, but will let newer runtimes drop in alternative
representations easily.