### PR TITLE
GSTLS.h: Change guard to check for /value/ of GS_USE_GNUTLS.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-02-12  Ivan Vucica <ivan@vucica.net>
+
+	* Headers/GNUstepBase/GSTLS.h: Change guard to check for value of
+	GS_USE_GNUTLS and not for its defined state. This preprocessor
+	constant might be defined with a zero value indicating desire not to
+	use GnuTLS, which would still pass the old check.
+
 2019-02-11  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSObject.m: Improve thread safety with NSZombie particularly

--- a/Headers/GNUstepBase/GSTLS.h
+++ b/Headers/GNUstepBase/GSTLS.h
@@ -39,7 +39,7 @@ extern NSString * const GSTLSRevokeFile;
 extern NSString * const GSTLSServerName;
 extern NSString * const GSTLSVerify;
 
-#if     defined(GS_USE_GNUTLS)
+#if GS_USE_GNUTLS
 /* Temporarily redefine 'id' in case the headers use the objc reserved word.
  */
 #define	id	GNUTLSID


### PR DESCRIPTION
Previously, code checked for whether its defined or not. This
preprocessor  constant might be defined with a zero value
indicating desire not to use GnuTLS, which would still pass the
old check.

Hey, @rfm, can you take a look if this change makes sense? It helps when crosscompiling for a platform that has no GnuTLS, and I /think/ (but didn't check) it won't break our usual platforms. 