### PR TITLE
Add compatibility for Swift corelibs libdispatch release

### DIFF
--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -216,6 +216,9 @@
 /* Define to 1 if you have the `dispatch_main_queue_drain_np' function. */
 #undef HAVE_DISPATCH_MAIN_QUEUE_DRAIN_NP
 
+/* Define to 1 if you have the <dispatch/private.h> header file. */
+#undef HAVE_DISPATCH_PRIVATE_H
+
 /* Define to 1 if you have the `dladdr' function. */
 #undef HAVE_DLADDR
 
@@ -766,6 +769,14 @@
 
 /* Define to 1 if you have the `_Block_copy' function. */
 #undef HAVE__BLOCK_COPY
+
+/* Define to 1 if you have the `_dispatch_get_main_queue_handle_4CF' function.
+   */
+#undef HAVE__DISPATCH_GET_MAIN_QUEUE_HANDLE_4CF
+
+/* Define to 1 if you have the `_dispatch_main_queue_callback_4CF' function.
+   */
+#undef HAVE__DISPATCH_MAIN_QUEUE_CALLBACK_4CF
 
 /* Define to 1 if you have the `__builtin_extract_return_address' function. */
 #undef HAVE___BUILTIN_EXTRACT_RETURN_ADDRESS

--- a/Source/NSRunLoop.m
+++ b/Source/NSRunLoop.m
@@ -62,10 +62,12 @@
 #include <math.h>
 #include <time.h>
 
-#if HAVE_DISPATCH_GET_MAIN_QUEUE_HANDLE_NP && HAVE_DISPATCH_MAIN_QUEUE_DRAIN_NP
+#if HAVE_LIBDISPATCH_RUNLOOP
 #  define RL_INTEGRATE_DISPATCH 1
 #  ifdef HAVE_DISPATCH_H
 #    include <dispatch.h>
+#  elif HAVE_DISPATCH_PRIVATE_H
+#    include <dispatch/private.h>
 #  elif HAVE_DISPATCH_DISPATCH_H
 #    include <dispatch/dispatch.h>
 #  endif
@@ -398,7 +400,13 @@ static inline BOOL timerInvalidated(NSTimer *t)
 @implementation GSMainQueueDrainer
 + (void*) mainQueueFileDescriptor
 {
+#if HAVE_DISPATCH_GET_MAIN_QUEUE_HANDLE_NP
   return (void*)(uintptr_t)dispatch_get_main_queue_handle_np();
+#elif HAVE__DISPATCH_GET_MAIN_QUEUE_HANDLE_4CF
+  return (void*)_dispatch_get_main_queue_handle_4CF();
+#else
+#error libdispatch missing main queue handle function
+#endif
 }
 
 - (void) receivedEvent: (void*)data
@@ -406,7 +414,13 @@ static inline BOOL timerInvalidated(NSTimer *t)
 		             extra: (void*)extra
 	             forMode: (NSString*)mode
 {
+#if HAVE_DISPATCH_MAIN_QUEUE_DRAIN_NP
   dispatch_main_queue_drain_np();
+#elif HAVE__DISPATCH_MAIN_QUEUE_CALLBACK_4CF
+  _dispatch_main_queue_callback_4CF(NULL)
+#else
+#error libdispatch missing main queue callback function
+#endif
 }
 @end
 #endif

--- a/configure
+++ b/configure
@@ -12412,6 +12412,20 @@ fi
 
 done
 
+    # check for private header which includes runloop integration functions in
+    # the Swift corelibs libdispatch release
+    for ac_header in dispatch/private.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "dispatch/private.h" "ac_cv_header_dispatch_private_h" "$ac_includes_default"
+if test "x$ac_cv_header_dispatch_private_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DISPATCH_PRIVATE_H 1
+_ACEOF
+
+fi
+
+done
+
   fi
   if test "$have_dispatch" = "yes"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dispatch_queue_create in -ldispatch" >&5
@@ -12515,10 +12529,24 @@ _ACEOF
 fi
 done
 
-  if test "$ac_cv_func_dispatch_main_queue_drain_np" = "no"; then
+  if test "$ac_cv_func_dispatch_main_queue_drain_np" = "yes" && test "$ac_cv_func_dispatch_get_main_queue_handle_np" = "yes"; then
     HAVE_LIBDISPATCH_RUNLOOP=1
   fi
-  if test "$ac_cv_func_dispatch_get_main_queue_handle_np" = "no"; then
+  # Check for "_4CF" variants of runloop integration functions provided by the
+  # Swift corelibs libdispatch release
+  for ac_func in _dispatch_main_queue_callback_4CF _dispatch_get_main_queue_handle_4CF
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+  if test "$ac_cv_func__dispatch_main_queue_callback_4CF" = "yes" && test "$ac_cv_func__dispatch_get_main_queue_handle_4CF" = "yes"; then
     HAVE_LIBDISPATCH_RUNLOOP=1
   fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3357,6 +3357,9 @@ if test $enable_libdispatch = yes; then
   AC_CHECK_HEADERS(dispatch.h, have_dispatch=yes, have_dispatch=no)
   if test "$have_dispatch" = "no"; then
     AC_CHECK_HEADERS(dispatch/dispatch.h, have_dispatch=yes, have_dispatch=no)
+    # check for private header which includes runloop integration functions in
+    # the Swift corelibs libdispatch release
+    AC_CHECK_HEADERS(dispatch/private.h)
   fi
   if test "$have_dispatch" = "yes"; then
     AC_CHECK_LIB(dispatch, dispatch_queue_create, have_dispatch=yes, have_dispatch=no)
@@ -3388,10 +3391,13 @@ if test $HAVE_LIBDISPATCH = 1; then
   # We check whether we have a variant of libdispatch that allows runloop
   # integration
   AC_CHECK_FUNCS(dispatch_main_queue_drain_np dispatch_get_main_queue_handle_np)
-  if test "$ac_cv_func_dispatch_main_queue_drain_np" = "no"; then
+  if test "$ac_cv_func_dispatch_main_queue_drain_np" = "yes" && test "$ac_cv_func_dispatch_get_main_queue_handle_np" = "yes"; then
     HAVE_LIBDISPATCH_RUNLOOP=1
   fi
-  if test "$ac_cv_func_dispatch_get_main_queue_handle_np" = "no"; then
+  # Check for "_4CF" variants of runloop integration functions provided by the
+  # Swift corelibs libdispatch release
+  AC_CHECK_FUNCS(_dispatch_main_queue_callback_4CF _dispatch_get_main_queue_handle_4CF)
+  if test "$ac_cv_func__dispatch_main_queue_callback_4CF" = "yes" && test "$ac_cv_func__dispatch_get_main_queue_handle_4CF" = "yes"; then
     HAVE_LIBDISPATCH_RUNLOOP=1
   fi
 fi


### PR DESCRIPTION
This updates the libdispatch runloop integration to be compatible with Apple’s [Swift corelibs libdispatch](https://github.com/apple/swift-corelibs-libdispatch) release, which to my knowledge is the most up-to-date and actively maintained release of libdispatch.

In that release, the main queue handle and drain functions have been renamed with a "_4CF" (for CoreFoundation) suffix and have moved to private.h, so we now check for the existance of this header and function names.

Note that libdispatch must be compiled with `INSTALL_PRIVATE_HEADERS=YES`. Please let me know if there is a good place to document this.

Also fixes the checks for the `HAVE_LIBDISPATCH_RUNLOOP` define (was inverted) and ensures that both the handle and drain functions are available (as expected by NSRunLoop.m).