### PR TITLE
Always use syslog for NSLog on Android

### DIFF
--- a/Source/NSLog.m
+++ b/Source/NSLog.m
@@ -181,8 +181,10 @@ _NSLog_standard_printf_handler(NSString* message)
 #else
 
 #if	defined(HAVE_SYSLOG)
+#ifndef __ANDROID__ // always use syslog on Android (no stdout/stderr)
   if (GSPrivateDefaultsFlag(GSLogSyslog) == YES
     || write(_NSLogDescriptor, buf, len) != (int)len)
+#endif
     {
       null_terminated_buf = malloc(sizeof (char) * (len + 1));
       strncpy (null_terminated_buf, buf, len);


### PR DESCRIPTION
As there is no way to access stdout/stderr on Android, and syslog is available and outputs to the system log (accesible using "adb logcat"), this improves the developer experience when developing for Android by enabling NSLog output without having to set the "GSLogSyslog" flag.