### PR TITLE
Include CoreFoundation and libdispatch in Foundation.h if available.

### DIFF
--- a/Headers/Foundation/Foundation.h
+++ b/Headers/Foundation/Foundation.h
@@ -150,4 +150,13 @@
 #import	<Foundation/NSXMLParser.h>
 #import	<Foundation/NSZone.h>
 
+#ifdef __has_include
+#  if __has_include(<CoreFoundation/CoreFoundation.h>)
+#    include <CoreFoundation/CoreFoundation.h>
+#  endif
+#  if __has_include(<dispatch/dispatch.h>)
+#    include <dispatch/dispatch.h>
+#  endif
+#endif
+
 #endif /* __Foundation_h_GNUSTEP_BASE_INCLUDE */


### PR DESCRIPTION
This more closely aligns Foundation.h with the Apple version if CoreBase and/or libdispatch are available.

The _has_include_ operator is supported by GCC 5 and later and clang, but we check for its availability in order to not break compatibility with other compilers.