### PR TITLE
Added support for asset loading on Android.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,11 +6,13 @@
 	* Headers/Foundation/NSBundle.h:
 	* Source/NSBundle.m:
 	Added methods for passing Android asset manager from Java to GNUstep
-	and for getting AAsset/AAssetDir for given path in main bundle. Skip
-	app bundle suffix check on Android. Extended bundle resource paths
-	backbone to check for known paths directly on Android as we can't
-	enumerate directories. Extracted path cache cleaning into separate
-	method.
+	and for getting AAsset/AAssetDir for given path in main bundle.
+	Skip app bundle suffix check on Android. Extended bundle resource
+	paths backbone to check for known paths directly on Android as we
+	can't enumerate directories.
+	Extended -localizations method to check for known localizations
+	directly (requires setting userLanguages in NSUserDefaults).
+	Extracted path cache cleaning into separate method.
 	* Source/GSFileHandle.h:
 	* Source/GSFileHandle.m:
 	Added file handle support for reading Android assets from main bundle.

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,8 +22,9 @@
 	-initWithContentsOfFile: and related methods from other classes.
 	* Source/NSFileManager.m:
 	Added support for Android assets from main bundle in
-	fileExistsAtPath:isDirectory:, isReadableFileAtPath:, and
-	NSDirectoryEnumerator.
+	fileExistsAtPath:isDirectory:, isReadableFileAtPath:,
+	NSDirectoryEnumerator, and copying from assets. Extended
+	GSAttrDictionary with basic support for Android assets.
 	* Source/NSProcessInfo.m:
 	Added +initialize method to auto-initialize NSProcessInfo on Android
 	using fake executable path "/data/data/<app identifier>/exe" (Android

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,32 @@
+2019-05-23  Frederik Seiffert <frederik@algoriddim.com>
+
+	* configure:
+	* configure.ac:
+	Link against libandroid on Android.
+	* Headers/Foundation/NSBundle.h:
+	* Source/NSBundle.m:
+	Added methods for passing Android asset manager from Java to GNUstep
+	and for getting AAsset/AAssetDir for given path in main bundle. Skip
+	app bundle suffix check on Android. Extended bundle resource paths
+	backbone to check for known paths directly on Android as we can't
+	enumerate directories. Extracted path cache cleaning into separate
+	method.
+	* Source/GSFileHandle.h:
+	* Source/GSFileHandle.m:
+	Added file handle support for reading Android assets from main bundle.
+	* Source/NSData.m:
+	Added support for reading Android assets from main bundle in
+	readContentsOfFile(). This is also used by all other
+	-initWithContentsOfFile: and related methods from other classes.
+	* Source/NSFileManager.m:
+	Added support for Android assets from main bundle in
+	fileExistsAtPath:isDirectory:, isReadableFileAtPath:, and
+	NSDirectoryEnumerator.
+	* Source/NSProcessInfo.m:
+	Added +initialize method to auto-initialize NSProcessInfo on Android
+	using fake executable path "/data/data/<app identifier>/exe" (Android
+	apps don't have a real executable path).
+
 2019-05-20  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSLog.m: Have all logs go to syslog on android.

--- a/Headers/Foundation/NSBundle.h
+++ b/Headers/Foundation/NSBundle.h
@@ -36,6 +36,10 @@ extern "C" {
 #import	<Foundation/NSObject.h>
 #import	<Foundation/NSString.h>
 
+#ifdef __ANDROID__
+#include <android/asset_manager_jni.h>
+#endif
+
 @class NSString;
 @class NSArray;
 @class NSDictionary;
@@ -539,6 +543,38 @@ GS_EXPORT NSString* const NSLoadedClasses;
 + (NSString*) pathForLibraryResource: (NSString*)name
 			      ofType: (NSString*)extension
 			 inDirectory: (NSString*)bundlePath;
+
+/** Cleans up the path cache for the bundle. */
+- (void) cleanPathCache;
+
+#ifdef __ANDROID__
+
+/**
+ * Sets the Java Android asset manager.
+ * The developer can call this method to enable asset loading via NSBundle.
+ */
++ (void) setJavaAssetManager:(jobject)jassetManager withJNIEnv:(JNIEnv *)env;
+
+/**
+ * Returns the native Android asset manager.
+ */
++ (AAssetManager *) assetManager;
+
+/**
+ * Returns the Android asset for the given path if path is in main bundle
+ * resources and asset exists.
+ * The returned object must be released using AAsset_close().
+ */
++ (AAsset *)assetForPath:(NSString *)path;
+
+/**
+ * Returns the Android asset dir for the given path if path is in main bundle
+ * resources and the asset directory exists.
+ * The returned object must be released using AAssetDir_close().
+ */
++ (AAssetDir *)assetDirForPath:(NSString *)path;
+
+#endif /* __ANDROID__ */
 
 @end
 

--- a/Headers/Foundation/NSBundle.h
+++ b/Headers/Foundation/NSBundle.h
@@ -563,9 +563,18 @@ GS_EXPORT NSString* const NSLoadedClasses;
 /**
  * Returns the Android asset for the given path if path is in main bundle
  * resources and asset exists.
+ * Uses `AASSET_MODE_UNKNOWN` to open the asset if it exists.
  * The returned object must be released using AAsset_close().
  */
 + (AAsset *)assetForPath:(NSString *)path;
+
+/**
+ * Returns the Android asset for the given path if path is in main bundle
+ * resources and asset exists.
+ * Uses the given mode to open the AAsset if it exists.
+ * The returned object must be released using AAsset_close().
+ */
++ (AAsset *)assetForPath:(NSString *)path withMode:(int)mode;
 
 /**
  * Returns the Android asset dir for the given path if path is in main bundle

--- a/Source/GSFileHandle.h
+++ b/Source/GSFileHandle.h
@@ -35,6 +35,10 @@
 #include <zlib.h>
 #endif
 
+#ifdef __ANDROID__
+#include <android/asset_manager_jni.h>
+#endif
+
 struct sockaddr_in;
 
 /**
@@ -68,6 +72,9 @@ struct sockaddr_in;
 #endif
 #if	defined(_WIN32)
   WSAEVENT  		event;
+#endif
+#ifdef __ANDROID__
+  AAsset		*asset;
 #endif
 #endif
 }

--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -285,6 +285,13 @@ static GSTcpTune        *tune = nil;
 
   do
     {
+#ifdef __ANDROID__
+      if (asset)
+      {
+        result = AAsset_read(asset, buf, len);
+      }
+      else
+#endif
 #if	USE_ZLIB
       if (gzDescriptor != 0)
 	{
@@ -379,6 +386,14 @@ static GSTcpTune        *tune = nil;
   [self ignoreReadDescriptor];
   [self ignoreWriteDescriptor];
 
+#ifdef __ANDROID__
+  if (asset)
+  {
+    AAsset_close(asset);
+    asset = NULL;
+  }
+  else
+#endif
   if (closeOnDealloc == YES && descriptor != -1)
     {
       [self closeFile];
@@ -1075,6 +1090,14 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 
   if (d < 0)
     {
+#ifdef __ANDROID__
+      asset = [NSBundle assetForPath:path];
+      if (asset) {
+        readOK = YES;
+        return self;
+      }
+#endif
+      
       DESTROY(self);
       return nil;
     }
@@ -1645,6 +1668,13 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 {
   off_t	result = -1;
 
+#ifdef __ANDROID__
+  if (asset)
+  {
+    result = AAsset_seek(asset, 0, SEEK_CUR);
+  }
+  else
+#endif
   if (isStandardFile && descriptor >= 0)
     {
 #if	USE_ZLIB
@@ -1669,6 +1699,13 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 {
   off_t	result = -1;
 
+#ifdef __ANDROID__
+  if (asset)
+  {
+    result = AAsset_seek(asset, 0, SEEK_END);
+  }
+  else
+#endif
   if (isStandardFile && descriptor >= 0)
     {
 #if	USE_ZLIB
@@ -1693,6 +1730,13 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 {
   off_t	result = -1;
 
+#ifdef __ANDROID__
+  if (asset)
+  {
+    result = AAsset_seek(asset, (off_t)pos, SEEK_SET);
+  }
+  else
+#endif
   if (isStandardFile && descriptor >= 0)
     {
 #if	USE_ZLIB
@@ -1726,6 +1770,15 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   [self ignoreWriteDescriptor];
 
   [self setNonBlocking: NO];
+  
+#ifdef __ANDROID__
+  if (asset)
+  {
+    AAsset_close(asset);
+    asset = NULL;
+  }
+  else
+#endif
 #if	USE_ZLIB
   if (gzDescriptor != 0)
     {

--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -1091,7 +1091,7 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   if (d < 0)
     {
 #ifdef __ANDROID__
-      asset = [NSBundle assetForPath:path];
+      asset = [NSBundle assetForPath:path withMode:AASSET_MODE_RANDOM];
       if (asset) {
         readOK = YES;
         return self;

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -3287,6 +3287,11 @@ IF_NO_GC(
 
 + (AAsset *)assetForPath:(NSString *)path
 {
+  return [self assetForPath:path withMode:AASSET_MODE_UNKNOWN];
+}
+
++ (AAsset *)assetForPath:(NSString *)path withMode:(int)mode
+{
   AAsset *asset = NULL;
   
   if (_assetManager && _mainBundle)
@@ -3298,7 +3303,7 @@ IF_NO_GC(
       NSString *assetPath = [path substringFromIndex:[resourcePath length]+1];
 
       asset = AAssetManager_open(_assetManager,
-        [assetPath fileSystemRepresentation], AASSET_MODE_BUFFER);
+        [assetPath fileSystemRepresentation], mode);
     }
   }
   

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -2137,7 +2137,7 @@ IF_NO_GC(
       enumerate = [languages objectEnumerator];
       while ((language = [enumerate nextObject])) {
         primary = [subPathPrimary stringByAppendingPathComponent:
-          [localization stringByAppendingPathExtension:@"lproj"]];
+          [language stringByAppendingPathExtension:@"lproj"]];
         contents = bundle_directory_readable(primary);
         addBundlePath(array, contents, primary, nil, nil);
       }
@@ -2152,7 +2152,7 @@ IF_NO_GC(
     enumerate = [languages objectEnumerator];
     while ((language = [enumerate nextObject])) {
       primary = [originalPrimary stringByAppendingPathComponent:
-        [localization stringByAppendingPathExtension:@"lproj"]];
+        [language stringByAppendingPathExtension:@"lproj"]];
       contents = bundle_directory_readable(primary);
       addBundlePath(array, contents, primary, nil, nil);
     }

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -2540,10 +2540,23 @@ IF_NO_GC(
       locale = [[locale lastPathComponent] stringByDeletingPathExtension];
       [array addObject: locale];
     }
+
 #ifdef __ANDROID__
-    // TODO: check known languages for existance directly, as AAssetDir and thereby
-    // NSDirectoryEnumerator doesn't list directories
-#endif
+    // Android: Check known languages for localizations directly, as AAssetDir
+    // and thereby NSDirectoryEnumerator doesn't list directories and the above
+    // call to list lproj resources will therefore come up empty.
+    NSArray *languages = [[NSUserDefaults standardUserDefaults]
+      stringArrayForKey: @"NSLanguages"];
+    
+    for (locale in languages) {
+      NSString *path = [self pathForResource:@"Localizable" ofType:@"strings"
+        inDirectory:nil forLocalization:locale];
+      if (path) {
+        [array addObject: locale];
+      }
+    }
+#endif /* __ANDROID__ */
+
   return GS_IMMUTABLE(array);
 }
 

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -245,7 +245,7 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
   
 #ifdef __ANDROID__
   // Android: try using asset manager if path is in main bundle resources
-  AAsset *asset = [NSBundle assetForPath:path];
+  AAsset *asset = [NSBundle assetForPath:path withMode:AASSET_MODE_BUFFER];
   if (asset) {
     fileLength = AAsset_getLength(asset);
 

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -242,17 +242,6 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
   void		*tmp = 0;
   int		c;
   off_t         fileLength;
-
-#if defined(_WIN32)
-  thePath = (const unichar*)[path fileSystemRepresentation];
-#else
-  thePath = [path fileSystemRepresentation];
-#endif
-  if (thePath == 0)
-    {
-      NSWarnFLog(@"Open (%@) attempt failed - bad path", path);
-      return NO;
-    }
   
 #ifdef __ANDROID__
   // Android: try using asset manager if path is in main bundle resources
@@ -282,6 +271,17 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
     return YES;
   }
 #endif /* __ANDROID__ */
+
+#if defined(_WIN32)
+  thePath = (const unichar*)[path fileSystemRepresentation];
+#else
+  thePath = [path fileSystemRepresentation];
+#endif
+  if (thePath == 0)
+    {
+      NSWarnFLog(@"Open (%@) attempt failed - bad path", path);
+      return NO;
+    }
 
   att = [mgr fileAttributesAtPath: path traverseLink: YES];
   if (nil == att)

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -253,6 +253,35 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
       NSWarnFLog(@"Open (%@) attempt failed - bad path", path);
       return NO;
     }
+  
+#ifdef __ANDROID__
+  // Android: try using asset manager if path is in main bundle resources
+  AAsset *asset = [NSBundle assetForPath:path];
+  if (asset) {
+    fileLength = AAsset_getLength(asset);
+
+    tmp = NSZoneMalloc(zone, fileLength);
+    if (tmp == 0) {
+      NSLog(@"Malloc failed for file (%@) of length %jd - %@", path,
+        (intmax_t)fileLength, [NSError _last]);
+      AAsset_close(asset);
+      goto failure;
+    }
+
+    int result = AAsset_read(asset, tmp, fileLength);
+    AAsset_close(asset);
+    
+    if (result < 0) {
+      NSWarnFLog(@"read of file (%@) contents failed - %@", path,
+        [NSError errorWithDomain:NSPOSIXErrorDomain code:result userInfo:nil]);
+      goto failure;
+    }
+    
+    *buf = tmp;
+    *len = fileLength;
+    return YES;
+  }
+#endif /* __ANDROID__ */
 
   att = [mgr fileAttributesAtPath: path traverseLink: YES];
   if (nil == att)

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -943,6 +943,31 @@ extern char **__libc_argv;
     }
 }
 
+#elif defined(__ANDROID__)
+
++ (void) initialize
+{
+  if (nil == procLock) procLock = [NSRecursiveLock new];
+  if (self == [NSProcessInfo class]
+    && !_gnu_processName && !_gnu_arguments && !_gnu_environment)
+    {
+      FILE *f = fopen("/proc/self/cmdline", "r");
+      if (f) {
+        char identifier[BUFSIZ];
+        fgets(identifier, sizeof(identifier), f);
+        fclose(f);
+        
+        // construct fake executable path
+        char *arg0;
+        asprintf(&arg0, "/data/data/%s/exe", identifier);
+
+        char *argv[] = { arg0 };
+        _gnu_process_args(sizeof(argv)/sizeof(char *), argv, NULL);
+      } else {
+        fprintf(stderr, "Failed to read cmdline\n");
+      }
+    }
+}
 
 #else
 + (void) initialize

--- a/configure
+++ b/configure
@@ -5996,6 +5996,9 @@ case "$target_os" in
 		LDFLAGS="$LDFLAGS -L/usr/local/lib";;
   netbsd*)	CPPFLAGS="$CPPFLAGS -I/usr/pkg/include"
 		LDFLAGS="$LDFLAGS -Wl,-R/usr/pkg/lib -L/usr/pkg/lib";;
+  linux-android* )
+		# link against libandroid for native application APIs
+		LIBS="$LIBS -landroid";;
 esac
 
 #--------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1246,6 +1246,9 @@ case "$target_os" in
 		LDFLAGS="$LDFLAGS -L/usr/local/lib";;
   netbsd*)	CPPFLAGS="$CPPFLAGS -I/usr/pkg/include"
 		LDFLAGS="$LDFLAGS -Wl,-R/usr/pkg/lib -L/usr/pkg/lib";;
+  linux-android* )
+		# link against libandroid for native application APIs
+		LIBS="$LIBS -landroid";;
 esac
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
This requires passing the Android activity's AssetManager object from Java to GNUstep by calling `+[NSBundle setJavaAssetManager:withJNIEnv:]`, which then enables the following features:

- NSBundle main bundle resource paths support for Android assets, e.g. for `pathForResource:ofType:`, `URLForResource:ofType:` and related methods.
- NSBundle main bundle info dictionary support if Info.plist exists in Android assets.
- `-initWithContentsOfFile:` and related methods support for reading Android assets from main bundle in various classes (e.g. NSData, NSDictionary, NSArray, etc.) by patching NSData `readContentsOfFile()` backbone method.
- NSFileManager `fileExistsAtPath:(isDirectory:)` and `isReadableFileAtPath:` return YES for main bundle asset / asset directory paths.
- NSFileHandle support for reading Android assets from main bundle.
- NSDirectoryEnumerator support for enumerating Android assets from main bundle. Note that recursion into subdirectories is currently not supported by the native Android asset manager API (see https://issuetracker.google.com/issues/37002833).

Also adds support for automatic NSProcessInfo initialization on Android with a fake executable path `/data/data/<app identifier>/exe` (as Android apps don't have a real executable path), and tweaks main bundle initialization to allow that path. Main bundle resource paths are prefixed by `/data/data/<app identifier>/Resources`.

I’d appreciate anyone’s feedback on this, and especially from people who previously worked with GNUstep on Android (@ivucica, @jordo). Thanks!