### PR TITLE
Fix generics definition of NSMutableArray and NSMutableOrderedSet

### DIFF
--- a/Headers/Foundation/NSArray.h
+++ b/Headers/Foundation/NSArray.h
@@ -301,7 +301,7 @@ DEFINE_BLOCK_TYPE(GSPredicateBlock, BOOL, GS_GENERIC_TYPE(ElementT), NSUInteger,
 @end
 
 
-@interface GS_GENERIC_CLASS(NSMutableArray, ElementT) : NSArray
+@interface GS_GENERIC_CLASS(NSMutableArray, ElementT) : GS_GENERIC_CLASS(NSArray, ElementT)
 
 + (instancetype) arrayWithCapacity: (NSUInteger)numItems;
 

--- a/Headers/Foundation/NSOrderedSet.h
+++ b/Headers/Foundation/NSOrderedSet.h
@@ -159,7 +159,7 @@ extern "C" {
 @end
 
 // Mutable Ordered Set
-@interface GS_GENERIC_CLASS(NSMutableOrderedSet, __covariant ElementT) : NSOrderedSet
+@interface GS_GENERIC_CLASS(NSMutableOrderedSet, ElementT) : GS_GENERIC_CLASS(NSOrderedSet, ElementT)
 // Creating a Mutable Ordered Set
 + (instancetype)orderedSetWithCapacity: (NSUInteger)capacity;
 - (instancetype)initWithCapacity: (NSUInteger)capacity;


### PR DESCRIPTION
The generic element was not passed on to the superclass.

This meant that any method from the superclass would not have the generics information. For example, calling `objectAtIndex:` (defined in NSArray) on an NSMutableArray instance would not return the generic type.

This also removes the `__covariant` annotation on NSMutableOrderedSet, which I think is only needed on the superclass NSOrderedSet (same for NSArray, matches the Apple headers).