### PR TITLE
Fix NSArray and NSOrderedSet KVC method types to not use generic type.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-07-10  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSArray.h:
+	* Headers/Foundation/NSOrderedSet.h:
+	Fix generics definition of NSMutableArray and NSMutableOrderedSet.
+	Fix NSArray and NSOrderedSet KVC method types to not use generic type.
+
 2019-07-02  Wolfgang Lux  <wolfgang.lux@gmail.com>
 
 	* Tests/base/GSTLS/basic.m: Use fixed time zone.

--- a/Headers/Foundation/NSArray.h
+++ b/Headers/Foundation/NSArray.h
@@ -166,8 +166,8 @@ typedef NSUInteger NSBinarySearchingOptions;
 - (BOOL) writeToFile: (NSString*)path atomically: (BOOL)useAuxiliaryFile;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (BOOL) writeToURL: (NSURL*)url atomically: (BOOL)useAuxiliaryFile;
-- (GS_GENERIC_TYPE(ElementT)) valueForKey: (NSString*)key;
-- (void) setValue: (GS_GENERIC_TYPE(ElementT))value forKey: (NSString*)key;
+- (id) valueForKey: (NSString*)key;
+- (void) setValue: (id)value forKey: (NSString*)key;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)

--- a/Headers/Foundation/NSOrderedSet.h
+++ b/Headers/Foundation/NSOrderedSet.h
@@ -125,8 +125,8 @@ extern "C" {
               range: (NSRange)aRange;
 
 // Key value coding support
-- (void) setValue: (GS_GENERIC_TYPE(ElementT))value forKey: (NSString*)key;
-- (GS_GENERIC_TYPE(ElementT)) valueForKey: (NSString*)key; 
+- (void) setValue: (id)value forKey: (NSString*)key;
+- (id) valueForKey: (NSString*)key; 
 
 // Comparing Sets
 - (BOOL) isEqualToOrderedSet: (NSOrderedSet *)aSet;


### PR DESCRIPTION
These methods set/return properties of the elements, not the elements themselves.

Also updated change log with this and my previous change.