### PR TITLE
Added libblocksruntime-dev to fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 sudo: required
 before_install:
     - sudo apt-get -qq update
-    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev
+    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev libblocksruntime-dev
     - >
         if [ $LIBRARY_COMBO = 'gnu-gnu-gnu' ];
         then


### PR DESCRIPTION
The CI tests on travis were failing after each commit because libblocksruntime-dev was not included.  This pull requests simply adds libblockruntime-dev to the installed dependencies.

