### PR TITLE
Fixed NSOperation calling removeObserver more than once.

### DIFF
--- a/Source/NSOperation.m
+++ b/Source/NSOperation.m
@@ -206,7 +206,10 @@ static NSArray	*empty = nil;
     {
       NSOperation	*op;
 
-      [self removeObserver: self forKeyPath: @"isFinished"];
+      if (!internal->finished)
+        {
+          [self removeObserver: self forKeyPath: @"isFinished"];
+        }
       while ((op = [internal->dependencies lastObject]) != nil)
 	{
 	  [self removeDependency: op];


### PR DESCRIPTION
NSOperation was removing self as an observer of "isFinished" both in the KVO callback and in dealloc.

While this is a no-op with the current implementation of `-removeObserver:forKeyPath:`, it would cause an error if/when the implementation is changed to throw an error when unregistering non-registered observers (as is the case on Apple platforms).