### PR TITLE
Use UTF-8 as default encoding on Android.

### DIFF
--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -2865,7 +2865,12 @@ GSPrivateCStringEncoding(const char *encoding)
 
   if (enc == GSUndefinedEncoding)
     {
+#ifdef __ANDROID__
+      // Android uses UTF-8 as default encoding (e.g. for file paths)
+      enc = NSUTF8StringEncoding;
+#else
       enc = NSISOLatin1StringEncoding;
+#endif
     }
   else if (GSPrivateIsEncodingSupported(enc) == NO)
     {


### PR DESCRIPTION
Android uses UTF-8 as default encoding, e.g. for file paths.

This fixes file handling support for paths containing non-ASCII characters on Android, which would previously throw an exception as they couldn't be converted to C strings using ISO Latin 1 encoding.

(Please let me know if there’s a better place than in GSPrivateCStringEncoding() to make this change.)