### PR TITLE
Guard inclusion of <malloc.h> as to not break FreeBSD

### DIFF
--- a/Source/Additions/NSObject+GNUstepBase.m
+++ b/Source/Additions/NSObject+GNUstepBase.m
@@ -31,7 +31,9 @@
 #import "GNUstepBase/NSDebug+GNUstepBase.h"
 #import "GNUstepBase/NSThread+GNUstepBase.h"
 
+#ifdef HAVE_MALLOC_H
 #include	<malloc.h>
+#endif
 
 /* This file contains methods which nominally return an id but in fact
  * always rainse an exception and never return.

--- a/Source/NSDebug.m
+++ b/Source/NSDebug.m
@@ -48,7 +48,9 @@
 #include        <execinfo.h>
 #endif
 
+#ifdef HAVE_MALLOC_H
 #include        <malloc.h>
+#endif
 
 typedef struct {
   Class		class;

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -53,7 +53,9 @@
 #include <locale.h>
 #endif
 
+#ifdef HAVE_MALLOC_H
 #include	<malloc.h>
+#endif
 
 #import "GSPThread.h"
 


### PR DESCRIPTION
In [dd368559] Richard forgot to include the <malloc.h> guards. I saw that in the past Riccardo added special guards for OpenBSD, but IMO this shouldn't be necessary.