### PR TITLE
Fixing NSDictionary keysSortedByValueUsingComparator:

### DIFF
--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -29,6 +29,8 @@
 #import "common.h"
 #import "Foundation/NSDictionary.h"
 #import "Foundation/NSArray.h"
+#import "Foundation/NSMutableArray.h"
+#import "Foundation/NSOrderedSet.h"
 #import "Foundation/NSData.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSAutoreleasePool.h"
@@ -958,8 +960,13 @@ compareIt(id o1, id o2, void* context)
 - (NSArray *)keysSortedByValueWithOptions: (NSSortOptions)opts
 			  usingComparator: (NSComparator)cmptr
 {
-  return [[self allKeys] sortedArrayWithOptions: opts
-				usingComparator: cmptr];
+  NSArray* sortedValues = [[self allValues] sortedArrayWithOptions: opts usingComparator: cmptr];
+  NSArray* noDuplicates = [[NSOrderedSet orderedSetWithArray:sortedValues] array];
+  NSMutableArray* result = [[NSMutableArray alloc] initWithCapacity:[sortedValues length]];
+  for (NSObject* value in noDuplicates) {
+      [result addObjectsFromArray:[self allKeysForObject:value]];
+  }
+  return result;
 }
 
 /**

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -29,7 +29,6 @@
 #import "common.h"
 #import "Foundation/NSDictionary.h"
 #import "Foundation/NSArray.h"
-#import "Foundation/NSMutableArray.h"
 #import "Foundation/NSOrderedSet.h"
 #import "Foundation/NSData.h"
 #import "Foundation/NSException.h"

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -177,7 +177,8 @@ static SEL	appSel;
    GS_DISPATCH_CREATE_QUEUE_AND_GROUP_FOR_ENUMERATION(enumQueue, opts)
    FOR_IN(id, key, enumerator)
      obj = (*objectForKey)(self, objectForKeySelector, key);
-     GS_DISPATCH_SUBMIT_BLOCK(enumQueueGroup, enumQueue, if (shouldStop){return;};, return;, aBlock, key, obj, &shouldStop);
+     GS_DISPATCH_SUBMIT_BLOCK(enumQueueGroup, enumQueue,
+     if (shouldStop){return;};, return;, aBlock, key, obj, &shouldStop);
      if (YES == shouldStop)
        {
 	 break;
@@ -861,10 +862,10 @@ static SEL	appSel;
     }
 }
 
-- (void)getObjects: (__unsafe_unretained id[])objects
-           andKeys: (__unsafe_unretained id<NSCopying>[])keys
+- (void) getObjects: (__unsafe_unretained id[])objects
+            andKeys: (__unsafe_unretained id<NSCopying>[])keys
 {
-  NSUInteger i=0;
+  NSUInteger i = 0;
   FOR_IN(id, key, self)
     if (keys != NULL) keys[i] = key;
     if (objects != NULL) objects[i] = [self objectForKey: key];
@@ -950,22 +951,29 @@ compareIt(id o1, id o2, void* context)
   return k;
 }
 
-- (NSArray *)keysSortedByValueUsingComparator: (NSComparator)cmptr
+- (NSArray *) keysSortedByValueUsingComparator: (NSComparator)cmptr
 {
-  return [self keysSortedByValueWithOptions:0
-			    usingComparator:cmptr];
+  return [self keysSortedByValueWithOptions: 0
+			    usingComparator: cmptr];
 }
 
-- (NSArray *)keysSortedByValueWithOptions: (NSSortOptions)opts
-			  usingComparator: (NSComparator)cmptr
+- (NSArray *) keysSortedByValueWithOptions: (NSSortOptions)opts
+			   usingComparator: (NSComparator)cmptr
 {
-  NSArray* sortedValues = [[self allValues] sortedArrayWithOptions: opts usingComparator: cmptr];
-  NSArray* noDuplicates = [[NSOrderedSet orderedSetWithArray:sortedValues] array];
-  NSMutableArray* result = [[NSMutableArray alloc] initWithCapacity:[sortedValues count]];
-  for (NSObject* value in noDuplicates) {
-      [result addObjectsFromArray:[self allKeysForObject:value]];
-  }
-  return result;
+  CREATE_AUTORELEASE_POOL(arp);
+  NSArray		*sortedValues;
+  NSArray		*noDuplicates;
+  NSMutableArray	*result;
+
+  sortedValues = [[self allValues] sortedArrayWithOptions: opts
+					  usingComparator: cmptr];
+  noDuplicates = [[NSOrderedSet orderedSetWithArray: sortedValues] array];
+  result = [[NSMutableArray alloc] initWithCapacity: [sortedValues count]];
+  FOR_IN(NSObject*, value, noDuplicates)
+    [result addObjectsFromArray: [self allKeysForObject: value]];
+  END_FOR_IN(noDuplicates)
+  RELEASE(arp);
+  return AUTORELEASE(result);
 }
 
 /**

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -961,7 +961,7 @@ compareIt(id o1, id o2, void* context)
 {
   NSArray* sortedValues = [[self allValues] sortedArrayWithOptions: opts usingComparator: cmptr];
   NSArray* noDuplicates = [[NSOrderedSet orderedSetWithArray:sortedValues] array];
-  NSMutableArray* result = [[NSMutableArray alloc] initWithCapacity:[sortedValues length]];
+  NSMutableArray* result = [[NSMutableArray alloc] initWithCapacity:[sortedValues count]];
   for (NSObject* value in noDuplicates) {
       [result addObjectsFromArray:[self allKeysForObject:value]];
   }

--- a/Tests/base/NSDictionary/sort.m
+++ b/Tests/base/NSDictionary/sort.m
@@ -1,0 +1,41 @@
+#import "Testing.h"
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+
+int main()
+{
+  NSAutoreleasePool   *arp = [NSAutoreleasePool new];
+
+  NSArray* values = [NSArray arrayWithObjects:
+        [NSNumber numberWithFloat:2.0],
+        [NSNumber numberWithFloat:1.0],
+        [NSNumber numberWithFloat:3.0],
+        [NSNumber numberWithFloat:4.0],
+        nil];
+
+  NSArray* keys = [NSArray arrayWithObjects:
+        @"shouldSortToSecond",
+        @"shouldSortToFirst",
+        @"shouldSortToThird",
+        @"shouldSortToFourth",
+        nil];
+
+  NSDictionary *d = [NSDictionary dictionaryWithObjects:values forKeys:keys];
+  NSArray* keysOrderedByKeyedValue = [d keysSortedByValueUsingComparator:
+                      ^NSComparisonResult(id obj1, id obj2) {
+                              return [(NSNumber*)obj1 compare:(NSNumber*)obj2];
+                      }];
+
+  NSArray* expected = [NSArray arrayWithObjects:
+        @"shouldSortToFirst",
+        @"shouldSortToSecond",
+        @"shouldSortToThird",
+        @"shouldSortToFourth",
+        nil];
+
+  PASS([keysOrderedByKeyedValue isEqual:expected], "Can sort a dictionary's keys by its values");
+
+  [arp release]; arp = nil;
+  return 0;
+}

--- a/Tests/base/NSDictionary/sort.m
+++ b/Tests/base/NSDictionary/sort.m
@@ -7,37 +7,54 @@
 
 int main()
 {
-  NSAutoreleasePool   *arp = [NSAutoreleasePool new];
+  START_SET("NSDictionary Sorting")
+  NSDictionary  *d;
+  NSArray	*keysOrderedByKeyedValue;
 
-  NSArray* values = [NSArray arrayWithObjects:
-        [NSNumber numberWithFloat:2.0],
-        [NSNumber numberWithFloat:1.0],
-        [NSNumber numberWithFloat:3.0],
-        [NSNumber numberWithFloat:4.0],
-        nil];
+  NSArray	*values = [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 2.0],
+    [NSNumber numberWithFloat: 1.0],
+    [NSNumber numberWithFloat: 3.0],
+    [NSNumber numberWithFloat: 4.0],
+    nil];
 
-  NSArray* keys = [NSArray arrayWithObjects:
-        @"shouldSortToSecond",
-        @"shouldSortToFirst",
-        @"shouldSortToThird",
-        @"shouldSortToFourth",
-        nil];
+  NSArray	*keys = [NSArray arrayWithObjects:
+    @"shouldSortToSecond",
+    @"shouldSortToFirst",
+    @"shouldSortToThird",
+    @"shouldSortToFourth",
+    nil];
 
-  NSDictionary *d = [NSDictionary dictionaryWithObjects:values forKeys:keys];
-  NSArray* keysOrderedByKeyedValue = [d keysSortedByValueUsingComparator:
-                      ^NSComparisonResult(id obj1, id obj2) {
-                              return [(NSNumber*)obj1 compare:(NSNumber*)obj2];
-                      }];
+  NSArray	*expected = [NSArray arrayWithObjects:
+    @"shouldSortToFirst",
+    @"shouldSortToSecond",
+    @"shouldSortToThird",
+    @"shouldSortToFourth",
+    nil];
 
-  NSArray* expected = [NSArray arrayWithObjects:
-        @"shouldSortToFirst",
-        @"shouldSortToSecond",
-        @"shouldSortToThird",
-        @"shouldSortToFourth",
-        nil];
+  d = [NSDictionary dictionaryWithObjects: values forKeys: keys];
+  keysOrderedByKeyedValue = [d keysSortedByValueUsingSelector:
+    @selector(compare:)];
 
-  PASS([keysOrderedByKeyedValue isEqual:expected], "Can sort a dictionary's keys by its values");
+  PASS([keysOrderedByKeyedValue isEqual: expected],
+    "Can sort a dictionary's keys by its values using a selector");
+# ifndef __has_feature
+# define __has_feature(x) 0
+# endif
+# if __has_feature(blocks)
+  d = [NSDictionary dictionaryWithObjects: values forKeys: keys];
+  keysOrderedByKeyedValue = [d keysSortedByValueUsingComparator:
+    ^NSComparisonResult(id obj1, id obj2) {
+      return [(NSNumber*)obj1 compare: (NSNumber*)obj2];
+    }];
 
-  [arp release]; arp = nil;
+  PASS([keysOrderedByKeyedValue isEqual: expected],
+    "Can sort a dictionary's keys by its values using a comparator");
+# else
+  SKIP("No Blocks support in the compiler.")
+# endif
+
+  END_SET("NSDictionary Sorting")
+
   return 0;
 }

--- a/Tests/base/NSDictionary/sort.m
+++ b/Tests/base/NSDictionary/sort.m
@@ -2,6 +2,8 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSDictionary.h>
+#import <Foundation/NSValue.h>
+#import <Foundation/NSString.h>
 
 int main()
 {


### PR DESCRIPTION
NSDictionary keysSortedByValueUsingComparator: appears to have a bug.  It does not actually return the keys sorted by the values.  (Instead it appears to be sorting the keys based on their own value rather than the value each maps to in the dictionary...)
