### PR TITLE
Added support for data directory on Android.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2019-09-25  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSProcessInfo.h:
+	* Source/NSPathUtilities.m:
+	* Source/NSProcessInfo.m:
+	Added support for data directory on Android. This makes GNUstep use
+	the path returned by Context.getFilesDir() as the basis for storing
+	data (e.g. NSUserDefaults) and when querying system directory paths
+	(NSLibraryDirectory, NSApplicationSupportDirectory, etc.). Requires
+	calling a new GSInitializeProcessAndroid() initialization function.
+
 2019-09-25  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSArray.m: [-removeObjectsInArray:] add checks to prevent

--- a/Headers/Foundation/NSProcessInfo.h
+++ b/Headers/Foundation/NSProcessInfo.h
@@ -30,6 +30,10 @@
 
 #import	<Foundation/NSObject.h>
 
+#ifdef __ANDROID__
+#include <jni.h>
+#endif
+
 #if	defined(__cplusplus)
 extern "C" {
 #endif
@@ -265,6 +269,12 @@ DEFINE_BLOCK_TYPE(GSPerformExpiringActivityBlock, void, BOOL);
 + (void) initializeWithArguments: (char**)argv
                            count: (int)argc
                      environment: (char**)env;
+
+#ifdef __ANDROID__
+- (jobject) androidContext;
+- (NSString *) androidFilesDir;
+#endif
+
 @end
 
 /**
@@ -277,6 +287,16 @@ DEFINE_BLOCK_TYPE(GSPerformExpiringActivityBlock, void, BOOL);
  * to do when using GNUstep libraries embedded within other frameworks.
  */
 GS_EXPORT void GSInitializeProcess(int argc, char **argv, char **envp);
+
+#ifdef __ANDROID__
+/**
+ * Android process initialization function.
+ * This should be called on Android to initialize GNUstep with the JNI
+ * environment and application context, which is used to set up support
+ * for the Android data directory and asset loading via NSBundle.
+ */
+GS_EXPORT void GSInitializeProcessAndroid(JNIEnv *env, jobject context);
+#endif
 
 /**
  * Function for rapid testing to see if a debug level is set.<br />

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -1740,7 +1740,9 @@ NSHomeDirectoryForUser(NSString *loginName)
 {
   NSString	*s = nil;
 
-#if !defined(_WIN32)
+#ifdef __ANDROID__
+  s = [[NSProcessInfo processInfo] androidFilesDir];
+#elif !defined(_WIN32)
 #if     defined(HAVE_GETPWNAM_R)
   struct passwd pw;
   struct passwd *p;


### PR DESCRIPTION
This makes GNUstep use the path returned by `Context.getFilesDir()` as the basis for storing data (e.g. NSUserDefaults) and when querying system directory paths (NSLibraryDirectory, NSApplicationSupportDirectory, etc.).

Requires calling a new `GSInitializeProcessAndroid()` initialization function on Android to enable this support.