### PR TITLE
Fixed mutable dictionary keyed subscript behavior.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-10-02  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSDictionary.m: fixed mutable dictionary keyed subscript
+	behavior: assigning nil value via keyed subscript now correctly
+	removes object for key.
+
 2019-09-25  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSProcessInfo.h:

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -1350,7 +1350,14 @@ compareIt(id o1, id o2, void* context)
 
 - (void) setObject: (id)anObject forKeyedSubscript: (id)aKey
 {
-  [self setObject: anObject forKey: aKey];
+  if (anObject == nil)
+    {
+      [self removeObjectForKey: aKey];
+    }
+  else
+    {
+      [self setObject: anObject forKey: aKey]; 
+    }
 }
 
 /**


### PR DESCRIPTION
Assigning nil value via keyed subscript now correctly removes object for key.

This matches the documented reference implementation:
https://developer.apple.com/documentation/foundation/nsmutabledictionary/1574187-setobject?language=objc