### PR TITLE
Updated NSDate to use instancetype.

### DIFF
--- a/Headers/Foundation/NSDate.h
+++ b/Headers/Foundation/NSDate.h
@@ -62,7 +62,7 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
 
 /** Returns an autoreleased instance with the current date/time.
  */
-+ (id) date;
++ (instancetype) date;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /** Returns an autoreleased instance representing the date and time given
@@ -70,7 +70,7 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
  * specified by the preferences in the user defaults database, allowing
  * phrases like 'last tuesday'
  */
-+ (id) dateWithNaturalLanguageString: (NSString*)string;
++ (instancetype) dateWithNaturalLanguageString: (NSString*)string;
 
 /**
  * <p>Returns an autoreleased instance representing the date and time given
@@ -119,47 +119,48 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
  *   </desc>
  * </deflist>
  */
-+ (id) dateWithNaturalLanguageString: (NSString*)string
-                              locale: (NSDictionary*)locale;
++ (instancetype) dateWithNaturalLanguageString: (NSString*)string
+                                        locale: (NSDictionary*)locale;
 #endif
 
 /** Returns an autoreleased instance with the date and time value given
  * by the string using the ISO standard format YYYY-MM-DD HH:MM:SS +/-HHHMM
  * (all the fields of which must be present).
  */
-+ (id) dateWithString: (NSString*)description;
++ (instancetype) dateWithString: (NSString*)description;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST)
 /** Returns an autoreleased NSDate instance whose value is offset from
  * that of the given date by the specified interval in seconds.
  */
-+ (id) dateWithTimeInterval: (NSTimeInterval)seconds sinceDate: (NSDate*)date;
++ (instancetype) dateWithTimeInterval: (NSTimeInterval)seconds
+                            sinceDate: (NSDate*)date;
 #endif
 
 /** Returns an autoreleased instance with the offset from the unix system
  * reference date of 1 January 1970, GMT.
  */
-+ (id) dateWithTimeIntervalSince1970: (NSTimeInterval)seconds;
++ (instancetype) dateWithTimeIntervalSince1970: (NSTimeInterval)seconds;
 
 /** Returns an autoreleased instance with the offset from the current
  * date/time given by seconds (which may be fractional).
  */
-+ (id) dateWithTimeIntervalSinceNow: (NSTimeInterval)seconds;
++ (instancetype) dateWithTimeIntervalSinceNow: (NSTimeInterval)seconds;
 
 /** Returns an autoreleased instance with the offset from the OpenStep
  * reference date of 1 January 2001, GMT.
  */
-+ (id) dateWithTimeIntervalSinceReferenceDate: (NSTimeInterval)seconds;
++ (instancetype) dateWithTimeIntervalSinceReferenceDate: (NSTimeInterval)seconds;
 
 /** Returns an autoreleased instance with the date/time set in the far
  * past.
  */
-+ (id) distantPast;
++ (instancetype) distantPast;
 
 /** Returns an autoreleased instance with the date/time set in the far
  * future.
  */
-+ (id) distantFuture;
++ (instancetype) distantFuture;
 
 /** Returns the time interval between the reference date and the current
  * time.
@@ -169,7 +170,7 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
 /** Returns an autorelease date instance formed by adding the specified
  * time interval in seconds to the receiver's time interval.
  */
-- (id) addTimeInterval: (NSTimeInterval)seconds;
+- (instancetype) addTimeInterval: (NSTimeInterval)seconds;
 
 /** Returns the time interval between the receivers value and the
  * OpenStep reference date of 1 Jan 2001 GMT.
@@ -180,7 +181,7 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
 /** Returns an autoreleased NSDate instance whose value is offset from
  * that of the receiver by the specified interval.
  */
-- (id) dateByAddingTimeInterval: (NSTimeInterval)ti;
+- (instancetype) dateByAddingTimeInterval: (NSTimeInterval)ti;
 #endif
 
 /** Returns an autoreleased instance of the [NSCalendarDate] class whose
@@ -214,35 +215,35 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
 
 /** Returns an instance initialised with the current date/time.
  */
-- (id) init;
+- (instancetype) init;
 
 /** Returns an instance with the date and time value given
  * by the string using the ISO standard format YYYY-MM-DD HH:MM:SS +/-HHHMM
  * (all the fields of which must be present).
  */
-- (id) initWithString: (NSString*)description;
+- (instancetype) initWithString: (NSString*)description;
 
 /** Returns an instance with the given offset from anotherDate.
  */
-- (id) initWithTimeInterval: (NSTimeInterval)secsToBeAdded
-		  sinceDate: (NSDate*)anotherDate;
+- (instancetype) initWithTimeInterval: (NSTimeInterval)secsToBeAdded
+                            sinceDate: (NSDate*)anotherDate;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /** Returns an instance with the offset from the unix system
  * reference date of 1 January 1970, GMT.
  */
-- (id) initWithTimeIntervalSince1970: (NSTimeInterval)seconds;
+- (instancetype) initWithTimeIntervalSince1970: (NSTimeInterval)seconds;
 #endif
 
 /** Returns an instance with the offset from the current date/time.
  */
-- (id) initWithTimeIntervalSinceNow: (NSTimeInterval)secsToBeAdded;
+- (instancetype) initWithTimeIntervalSinceNow: (NSTimeInterval)secsToBeAdded;
 
 /** <init />
  * Returns an instance with the given offset from the OpenStep
  * reference date of 1 January 2001, GMT.
  */
-- (id) initWithTimeIntervalSinceReferenceDate: (NSTimeInterval)secs;
+- (instancetype) initWithTimeIntervalSinceReferenceDate: (NSTimeInterval)secs;
 
 /** Returns NO if other is not a date, otherwise returns the result of
  * calling the -isEqualtoDate: method.

--- a/Source/NSDate.m
+++ b/Source/NSDate.m
@@ -159,7 +159,7 @@ otherTime(NSDate* other)
   return NSAllocateObject(self, 0, z);
 }
 
-+ (id) date
++ (instancetype) date
 {
   return AUTORELEASE([[self allocWithZone: NSDefaultMallocZone()]
     initWithTimeIntervalSinceReferenceDate: GSPrivateTimeNow()]);
@@ -171,14 +171,14 @@ otherTime(NSDate* other)
  * specified by the preferences in the user defaults database, allowing
  * phrases like 'last tuesday'
  */
-+ (id) dateWithNaturalLanguageString: (NSString*)string
++ (instancetype) dateWithNaturalLanguageString: (NSString*)string
 {
   return [self dateWithNaturalLanguageString: string
 				      locale: nil];
 }
 
-+ (id) dateWithNaturalLanguageString: (NSString*)string
-                              locale: (NSDictionary*)locale
++ (instancetype) dateWithNaturalLanguageString: (NSString*)string
+                                        locale: (NSDictionary*)locale
 {
   NSCharacterSet	*ws;
   NSCharacterSet	*digits;
@@ -885,35 +885,36 @@ otherTime(NSDate* other)
     }
 }
 
-+ (id) dateWithString: (NSString*)description
++ (instancetype) dateWithString: (NSString*)description
 {
   return AUTORELEASE([[self alloc] initWithString: description]);
 }
 
-+ (id) dateWithTimeInterval: (NSTimeInterval)seconds sinceDate: (NSDate*)date
++ (instancetype) dateWithTimeInterval: (NSTimeInterval)seconds
+                            sinceDate: (NSDate*)date
 {
   return AUTORELEASE([[self alloc] initWithTimeInterval: seconds
                                               sinceDate: date]);
 }
 
-+ (id) dateWithTimeIntervalSince1970: (NSTimeInterval)seconds
++ (instancetype) dateWithTimeIntervalSince1970: (NSTimeInterval)seconds
 {
   return AUTORELEASE([[self alloc] initWithTimeIntervalSinceReferenceDate:
     seconds - NSTimeIntervalSince1970]);
 }
 
-+ (id) dateWithTimeIntervalSinceNow: (NSTimeInterval)seconds
++ (instancetype) dateWithTimeIntervalSinceNow: (NSTimeInterval)seconds
 {
   return AUTORELEASE([[self alloc] initWithTimeIntervalSinceNow: seconds]);
 }
 
-+ (id) dateWithTimeIntervalSinceReferenceDate: (NSTimeInterval)seconds
++ (instancetype) dateWithTimeIntervalSinceReferenceDate: (NSTimeInterval)seconds
 {
   return AUTORELEASE([[self alloc] initWithTimeIntervalSinceReferenceDate:
     seconds]);
 }
 
-+ (id) distantPast
++ (instancetype) distantPast
 {
   if (_distantPast == nil)
     {
@@ -922,7 +923,7 @@ otherTime(NSDate* other)
   return _distantPast;
 }
 
-+ (id) distantFuture
++ (instancetype) distantFuture
 {
   if (_distantFuture == nil)
     {
@@ -940,7 +941,7 @@ otherTime(NSDate* other)
   return GSPrivateTimeNow();
 }
 
-- (id) addTimeInterval: (NSTimeInterval)seconds
+- (instancetype) addTimeInterval: (NSTimeInterval)seconds
 {
   return [self dateByAddingTimeInterval: seconds];
 }
@@ -976,7 +977,7 @@ otherTime(NSDate* other)
   return abstractClass;
 }
 
-- (id) dateByAddingTimeInterval: (NSTimeInterval)ti
+- (instancetype) dateByAddingTimeInterval: (NSTimeInterval)ti
 {
   return [[self class] dateWithTimeIntervalSinceReferenceDate:
     otherTime(self) + ti];
@@ -1069,7 +1070,7 @@ otherTime(NSDate* other)
   return (NSUInteger)[self timeIntervalSinceReferenceDate];
 }
 
-- (id) initWithCoder: (NSCoder*)coder
+- (instancetype) initWithCoder: (NSCoder*)coder
 {
   NSTimeInterval	interval;
   id			o;
@@ -1099,12 +1100,12 @@ otherTime(NSDate* other)
   return o;
 }
 
-- (id) init
+- (instancetype) init
 {
   return [self initWithTimeIntervalSinceReferenceDate: GSPrivateTimeNow()];
 }
 
-- (id) initWithString: (NSString*)description
+- (instancetype) initWithString: (NSString*)description
 {
   // Easiest to just have NSCalendarDate do the work for us
   NSCalendarDate	*d = [calendarClass alloc];
@@ -1123,8 +1124,8 @@ otherTime(NSDate* other)
     }
 }
 
-- (id) initWithTimeInterval: (NSTimeInterval)secsToBeAdded
-		  sinceDate: (NSDate*)anotherDate
+- (instancetype) initWithTimeInterval: (NSTimeInterval)secsToBeAdded
+                            sinceDate: (NSDate*)anotherDate
 {
   if (anotherDate == nil)
     {
@@ -1137,20 +1138,20 @@ otherTime(NSDate* other)
     otherTime(anotherDate) + secsToBeAdded];
 }
 
-- (id) initWithTimeIntervalSince1970: (NSTimeInterval)seconds
+- (instancetype) initWithTimeIntervalSince1970: (NSTimeInterval)seconds
 {
   return [self initWithTimeIntervalSinceReferenceDate:
     seconds - NSTimeIntervalSince1970];
 }
 
-- (id) initWithTimeIntervalSinceNow: (NSTimeInterval)secsToBeAdded
+- (instancetype) initWithTimeIntervalSinceNow: (NSTimeInterval)secsToBeAdded
 {
   // Get the current time, add the secs and init thyself
   return [self initWithTimeIntervalSinceReferenceDate:
     GSPrivateTimeNow() + secsToBeAdded];
 }
 
-- (id) initWithTimeIntervalSinceReferenceDate: (NSTimeInterval)secs
+- (instancetype) initWithTimeIntervalSinceReferenceDate: (NSTimeInterval)secs
 {
   [self subclassResponsibility: _cmd];
   return self;


### PR DESCRIPTION
Matches Apple platform implementations and enables using property syntax like `NSDate.date.timeIntervalSince1970`.