### PR TITLE
Added tests for NSHashTable/NSMapTable weak objects support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-10-17  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Tests/base/NSHashTable/weakObjects.m:
+	* Tests/base/NSMapTable/weakObjects.m:
+	Added tests for [NSHashTable weakObjectsHashTable] and
+	[NSMapTable strongToWeakObjectsMapTable].
+
 2019-10-27  Fred Kiefer <fredkiefer@gmx.de>
 
 	* Headers/Foundation/NSUnit.h,

--- a/Tests/base/NSHashTable/weakObjects.m
+++ b/Tests/base/NSHashTable/weakObjects.m
@@ -1,9 +1,19 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSHashTable.h>
+#if __has_include(<objc/capabilities.h>)
+#include <objc/capabilities.h>
+#endif
 
 int main()
 {
+  START_SET("NSHashTable weak objects")
+#ifdef OBJC_CAP_ARC
+  if (!objc_test_capability(OBJC_CAP_ARC))
+#endif
+  {
+    SKIP("ARC support unavailable")
+  }
   NSAutoreleasePool *arp = [NSAutoreleasePool new];
   NSHashTable *hashTable = [NSHashTable weakObjectsHashTable];
 
@@ -18,5 +28,6 @@ int main()
   PASS([[hashTable allObjects] count] == 0, "Table removes dead weak reference");
 
   [arp release]; arp = nil;
+  END_SET("NSHashTable weak objects")
   return 0;
 }

--- a/Tests/base/NSHashTable/weakObjects.m
+++ b/Tests/base/NSHashTable/weakObjects.m
@@ -1,0 +1,22 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSHashTable.h>
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSHashTable *hashTable = [NSHashTable weakObjectsHashTable];
+
+  NSAutoreleasePool *arp2 = [NSAutoreleasePool new];
+
+  id testObj = [[[NSObject alloc] init] autorelease];
+  [hashTable addObject:testObj];
+  PASS([[hashTable allObjects] count] == 1, "Table retains active weak reference");
+
+  [arp2 release]; arp2 = nil;
+
+  PASS([[hashTable allObjects] count] == 0, "Table removes dead weak reference");
+
+  [arp release]; arp = nil;
+  return 0;
+}

--- a/Tests/base/NSMapTable/weakObjects.m
+++ b/Tests/base/NSMapTable/weakObjects.m
@@ -1,9 +1,19 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSMapTable.h>
+#if __has_include(<objc/capabilities.h>)
+#include <objc/capabilities.h>
+#endif
 
 int main()
 {
+  START_SET("NSMapTable weak objects")
+#ifdef OBJC_CAP_ARC
+  if (!objc_test_capability(OBJC_CAP_ARC))
+#endif
+  {
+    SKIP("ARC support unavailable")
+  }
   NSAutoreleasePool *arp = [NSAutoreleasePool new];
   NSMapTable *mapTable = [NSMapTable strongToWeakObjectsMapTable];
 
@@ -18,5 +28,6 @@ int main()
   PASS([mapTable objectForKey:@"test"] == nil, "Table removes dead weak reference");
 
   [arp release]; arp = nil;
+  END_SET("NSMapTable weak objects")
   return 0;
 }

--- a/Tests/base/NSMapTable/weakObjects.m
+++ b/Tests/base/NSMapTable/weakObjects.m
@@ -1,0 +1,22 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSMapTable.h>
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSMapTable *mapTable = [NSMapTable strongToWeakObjectsMapTable];
+
+  NSAutoreleasePool *arp2 = [NSAutoreleasePool new];
+
+  id testObj = [[[NSObject alloc] init] autorelease];
+  [mapTable setObject:testObj forKey:@"test"];
+  PASS([mapTable objectForKey:@"test"] != nil, "Table retains active weak reference");
+
+  [arp2 release]; arp2 = nil;
+
+  PASS([mapTable objectForKey:@"test"] == nil, "Table removes dead weak reference");
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
I wrote these tests in order to track down the issues we’re seeing with weak pointer support in NSHashTable and NSMapTable that I outlined on the mailing list:
https://lists.gnu.org/archive/html/discuss-gnustep/2019-10/msg00008.html

The tests pass when run against Apple’s Foundation, but are failing for me when run on Android. I’d like to understand whether other configurations are affected as well (e.g. the CI test builds).

If they are failing on the CI I’d appreciate any fixes or insights into why that is the case. If they pass, please feel free to merge – we will then know to look for the issue in our toolchain configuration.