### PR TITLE
Added FoundationLegacySwiftCompatibility.h to Foundation headers

### DIFF
--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -405,6 +405,7 @@ tzfile.h
 FOUNDATION_HEADERS = \
 Foundation.h \
 FoundationErrors.h \
+FoundationLegacySwiftCompatibility.h \
 NSAffineTransform.h \
 NSAppleEventDescriptor.h \
 NSAppleEventManager.h \


### PR DESCRIPTION
This header is included in Foundation.h but was not exported.