### PR TITLE
Added NSException support for libunwind

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-11-15  Frederik Seiffert <frederik@algoriddim.com>
+
+	* configure.ac: check for unwind.h
+	* configure: regenerate
+	* Source/NSException.m: Added support for backtrace symbolication
+	using libunwind, which will be used when backtrace() is unavailable.
+
 2019-11-14  Fred Kiefer <fredkiefer@gmx.de>
 
 	* Headers/Foundation/NSXPCConnection.h,

--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -737,6 +737,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define to 1 if you have the <unwind.h> header file. */
+#undef HAVE_UNWIND_H
+
 /* Define to 1 if you have the `usleep' function. */
 #undef HAVE_USLEEP
 

--- a/configure
+++ b/configure
@@ -9079,6 +9079,19 @@ fi
 done
 
 
+for ac_header in unwind.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "unwind.h" "ac_cv_header_unwind_h" "$ac_includes_default"
+if test "x$ac_cv_header_unwind_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_UNWIND_H 1
+_ACEOF
+
+fi
+
+done
+
+
 #--------------------------------------------------------------------
 # These headers/functions needed by NSLog.m
 #--------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -2321,6 +2321,8 @@ fi
 
 AC_CHECK_FUNCS(__builtin_extract_return_address)
 
+AC_CHECK_HEADERS(unwind.h)
+
 #--------------------------------------------------------------------
 # These headers/functions needed by NSLog.m
 #--------------------------------------------------------------------


### PR DESCRIPTION
Adds NSException backtrace support using libunwind for platforms where the other facilities like `backtrace()` are not available (e.g. Android).

While unfortunately the backtrace will not include Objective-C symbols (because `dladdr()` does not support these), it fixes the app crashing in `NSCountFrames()` on Android when an exception is thrown. If anyone has a pointer how to obtain Objective-C symbols please let me know.

Also contains a [small improvement](https://github.com/gnustep/libs-base/pull/83/files#diff-42146764331f4ac76b55f9724cc604f4R1302-R1303) in the symbol frame formatting for platforms without any of the supported backtrace libraries (previously the frame pointer would be printed as `{pointer=0x1234;}` instead of just `0x1234`).