### PR TITLE
Rework some of the weak handling for NS{Map,Hash}Table.

### DIFF
--- a/Headers/GNUstepBase/GSIMap.h
+++ b/Headers/GNUstepBase/GSIMap.h
@@ -450,7 +450,7 @@ GSIMapAddNodeToMap(GSIMapTable map, GSIMapNode node)
 {
   GSIMapBucket	bucket;
 
-  bucket = GSIMapBucketForKey(map, node->key);
+  bucket = GSIMapBucketForKey(map, GSI_MAP_READ_KEY(map, &node->key));
   GSIMapAddNodeToBucket(bucket, node);
   map->nodeCount++;
 }
@@ -543,7 +543,7 @@ GSIMapRemangleBuckets(GSIMapTable map,
 		  GSIMapBucket	bkt;
 
 		  GSIMapRemoveNodeFromBucket(old_buckets, node);
-		  bkt = GSIMapPickBucket(GSI_MAP_HASH(map, node->key),
+		  bkt = GSIMapPickBucket(GSI_MAP_HASH(map, GSI_MAP_READ_KEY(map, &node->key)),
 		    new_buckets, new_bucketCount);
 		  GSIMapAddNodeToBucket(bkt, node);
 		}
@@ -561,7 +561,7 @@ GSIMapRemangleBuckets(GSIMapTable map,
 	  GSIMapBucket	bkt;
 
 	  GSIMapRemoveNodeFromBucket(old_buckets, node);
-	  bkt = GSIMapPickBucket(GSI_MAP_HASH(map, node->key),
+	  bkt = GSIMapPickBucket(GSI_MAP_HASH(map, GSI_MAP_READ_KEY(map, &node->key)),
 	    new_buckets, new_bucketCount);
 	  GSIMapAddNodeToBucket(bkt, node);
 	}

--- a/Source/NSConcreteMapTable.m
+++ b/Source/NSConcreteMapTable.m
@@ -81,6 +81,10 @@ typedef GSIMapNode_t *GSIMapNode;
 
 #define	GSI_MAP_KTYPES	GSUNION_PTR | GSUNION_OBJ
 #define	GSI_MAP_VTYPES	GSUNION_PTR | GSUNION_OBJ
+#define IS_WEAK_KEY(M) \
+  M->cb.pf.k.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
+#define IS_WEAK_VALUE(M) \
+  M->cb.pf.v.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
 #define GSI_MAP_HASH(M, X)\
  (M->legacy ? M->cb.old.k.hash(M, X.ptr) \
  : pointerFunctionsHash(&M->cb.pf.k, X.ptr))
@@ -116,10 +120,6 @@ typedef GSIMapNode_t *GSIMapNode;
 	else\
 	  pointerFunctionsAssign(&M->cb.pf.v, (void**)addr, (x).obj);
 */
-#define IS_WEAK_KEY(M) \
-  M->cb.pf.k.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
-#define IS_WEAK_VALUE(M) \
-  M->cb.pf.v.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
 #define GSI_MAP_WRITE_KEY(M, addr, x) \
 	if (M->legacy) \
           *(addr) = x;\


### PR DESCRIPTION
The existing code was assuming that weak object pointers were safe to
read directly, without going via the read barrier, which is incorrect.
It was also attempting to retain the result in some places.  The new
code is hopefully somewhat more correct.