### PR TITLE
Set up libobjc2's git submodules for travis CI

### DIFF
--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -22,6 +22,7 @@ install_ng_runtime() {
     cd $DEP_SRC
     git clone https://github.com/gnustep/libobjc2.git
     cd libobjc2
+    git submodule init
     git submodule sync
     git submodule update
     cd ..

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -30,6 +30,7 @@ install_ng_runtime() {
     cd libobjc2/build
     export CC="clang"
     export CXX="clang++"
+    export CXXFLAGS="-std=c++11"
     cmake -DTESTS=off -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGNUSTEP_INSTALL_TYPE=NONE -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging ../
     make install
 }

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -21,6 +21,10 @@ install_gnustep_make() {
 install_ng_runtime() {
     cd $DEP_SRC
     git clone https://github.com/gnustep/libobjc2.git
+    cd libobjc2
+    git submodule sync
+    git submodule update
+    cd ..
     mkdir libobjc2/build
     cd libobjc2/build
     export CC="clang"


### PR DESCRIPTION
Adding setup for libobjc2 submodules, if builds correctly can be merged into #84