### PR TITLE
Fix runloop integration for libdispatch from swift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: xenial
 compiler:
     - clang
     - gcc
@@ -24,7 +24,7 @@ matrix:
 sudo: required
 before_install:
     - sudo apt-get -qq update
-    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev libblocksruntime-dev
+    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev
     - >
         if [ $LIBRARY_COMBO = 'gnu-gnu-gnu' ];
         then
@@ -32,14 +32,23 @@ before_install:
           then
             sudo apt-get install -y gobjc;
           fi;
-          sudo apt-get install -y libobjc-4.8-dev;
+          sudo apt-get install -y libobjc-4.8-dev libblocksruntime-dev;
         else
           sudo apt-get install -y libkqueue-dev libpthread-workqueue-dev;
         fi;
+    # libdispatch requires a fairly recent version of cmake
+    - >
+        if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ];
+        then
+          curl -LO https://cmake.org/files/v3.15/cmake-3.15.5-Linux-x86_64.tar.gz;
+          tar xf cmake-3.15.5-Linux-x86_64.tar.gz;
+          mv cmake-3.15.5-Linux-x86_64 $HOME/cmake;
+          export PATH=$HOME/cmake/:$HOME/cmake/bin:$PATH
+        fi;
 install: ./travis-deps.sh
 before_script: >
-    export LIBRARY_PATH=$HOME/staging/lib:$LIBRARY_PATH;
-    export LD_LIBRARY_PATH=$HOME/staging/lib:$LD_LIBRARY_PATH;
+    export LIBRARY_PATH=$HOME/staging/lib:$HOME/staging/lib64:$LIBRARY_PATH;
+    export LD_LIBRARY_PATH=$HOME/staging/lib:$HOME/staging/lib64:$LD_LIBRARY_PATH;
     if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ];
     then
       export CPATH=$HOME/staging/include;

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-11-26  Niels Grewe <niels.grewe@halbordnung.de>
+
+	* Source/NSRunLoop.m:
+	* Tests/base/NSRunLoop/dispatch.m:
+	Fix runloop integration for libdispatch from swift-corelibs
+	* .travis.yml:
+	* travis-deps.yml:
+	Fix CI related to libdispatch.
+
 2019-11-15  Frederik Seiffert <frederik@algoriddim.com>
 
 	* configure.ac: check for unwind.h

--- a/Source/NSRunLoop.m
+++ b/Source/NSRunLoop.m
@@ -62,7 +62,7 @@
 #include <math.h>
 #include <time.h>
 
-#if HAVE_LIBDISPATCH_RUNLOOP
+#if GS_USE_LIBDISPATCH_RUNLOOP
 #  define RL_INTEGRATE_DISPATCH 1
 #  ifdef HAVE_DISPATCH_H
 #    include <dispatch.h>
@@ -403,7 +403,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
 #if HAVE_DISPATCH_GET_MAIN_QUEUE_HANDLE_NP
   return (void*)(uintptr_t)dispatch_get_main_queue_handle_np();
 #elif HAVE__DISPATCH_GET_MAIN_QUEUE_HANDLE_4CF
-  return (void*)_dispatch_get_main_queue_handle_4CF();
+  return (void*)(uintptr_t)_dispatch_get_main_queue_handle_4CF();
 #else
 #error libdispatch missing main queue handle function
 #endif
@@ -417,7 +417,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
 #if HAVE_DISPATCH_MAIN_QUEUE_DRAIN_NP
   dispatch_main_queue_drain_np();
 #elif HAVE__DISPATCH_MAIN_QUEUE_CALLBACK_4CF
-  _dispatch_main_queue_callback_4CF(NULL)
+  _dispatch_main_queue_callback_4CF(NULL);
 #else
 #error libdispatch missing main queue callback function
 #endif

--- a/Tests/base/NSRunLoop/dispatch.m
+++ b/Tests/base/NSRunLoop/dispatch.m
@@ -8,14 +8,12 @@
 
 const NSTimeInterval kDelay = 0.01;
 
-#if HAVE_LIBDISPATCH_RUNLOOP && __has_feature(blocks)
+#if GS_USE_LIBDISPATCH_RUNLOOP && __has_feature(blocks)
 #  define DISPATCH_RL_INTEGRATION 1
-#  ifdef HAVE_DISPATCH_H
+#  if __has_include(<dispatch.h>)
 #    include <dispatch.h>
 #  else
-#    ifdef HAVE_DISPATCH_DISPATCH_H
-#      include <dispatch/dispatch.h>
-#    endif
+#    include <dispatch/dispatch.h>
 #  endif
 #endif
 

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -3,6 +3,7 @@
 set -ex
 
 DEP_SRC=$HOME/dependency_source/
+DEP_ROOT=$HOME/staging
 
 install_gnustep_make() {
     cd $DEP_SRC
@@ -12,7 +13,7 @@ install_gnustep_make() {
     then
         echo "RUNTIME_VERSION=$RUNTIME_VERSION" > GNUstep.conf
     fi
-    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO --with-user-config-file=$PWD/GNUstep.conf
+    ./configure --prefix=$DEP_ROOT --with-library-combo=$LIBRARY_COMBO --with-user-config-file=$PWD/GNUstep.conf
 	make install
     echo Objective-C build flags: `$HOME/staging/bin/gnustep-config --objc-flags`
 }
@@ -30,26 +31,27 @@ install_ng_runtime() {
     export CC="clang"
     export CXX="clang++"
     export CXXFLAGS="-std=c++11"
-    cmake -DTESTS=off -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGNUSTEP_INSTALL_TYPE=NONE -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging ../
+    cmake -DTESTS=off -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGNUSTEP_INSTALL_TYPE=NONE -DCMAKE_INSTALL_PREFIX:PATH=$DEP_ROOT ../
     make install
 }
 
 install_libdispatch() {
     cd $DEP_SRC
-    git clone https://github.com/ngrewe/libdispatch.git
-    mkdir libdispatch/build
-    cd libdispatch/build
+    # will reference upstream after https://github.com/apple/swift-corelibs-libdispatch/pull/534 is merged
+    git clone -b system-blocksruntime https://github.com/ngrewe/swift-corelibs-libdispatch.git
+    mkdir swift-corelibs-libdispatch/build
+    cd swift-corelibs-libdispatch/build
     export CC="clang"
     export CXX="clang++"
-    export LIBRARY_PATH=$HOME/staging/lib;
-    export LD_LIBRARY_PATH=$HOME/staging/lib:$LD_LIBRARY_PATH;
-    export CPATH=$HOME/staging/include;
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging ../
+    export LIBRARY_PATH=$DEP_ROOT/lib;
+    export LD_LIBRARY_PATH=$DEP_ROOT/lib:$LD_LIBRARY_PATH;
+    export CPATH=$DEP_ROOT/include;
+    cmake -DBUILD_TESTING=off -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging -DINSTALL_PRIVATE_HEADERS=1 -DBlocksRuntime_INCLUDE_DIR=$DEP_ROOT/include -DBlocksRuntime_LIBRARIES=$DEP_ROOT/lib/libobjc.so ../
     make install
 }
 
 mkdir -p $DEP_SRC
-if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ]
+if [ "$LIBRARY_COMBO" = 'ng-gnu-gnu' ]
 then
     install_ng_runtime
     install_libdispatch


### PR DESCRIPTION
It seems like the runloop integration for the libdispatch main queue broke down a bit – unfortunately in a quite symmetrical way so that both the implementation and the tests would never be built, even if a compatible version of libdispatch existed (it was checking for `HAVE_LIBDISPATCH_RUNLOOP` where it should have been using `GS_USE_LIBDISPATCH_RUNLOOP`).

That uncovered a few problems with libdispatch from swift-corelibs. Our side of that is fixed here (simple typos, mostly), the libdispatch side of things is addressed in apple/swift-corelibs-libdispatch#534.

I've also freshened up the Travis CI job a bit in the process so that this is continuously tested again.