### PR TITLE
Travis fixes and gnustep-2.0 runtime support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ compiler:
 env:
     - LIBRARY_COMBO=gnu-gnu-gnu
     - LIBRARY_COMBO=ng-gnu-gnu
-    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixed-abi
+    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
 matrix:
     exclude:
         - compiler: gcc
           env: LIBRARY_COMBO=ng-gnu-gnu
         - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixed-abi
+          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
         - compiler: clang
           env: LIBRARY_COMBO=gnu-gnu-gnu
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,18 @@ env:
     - LIBRARY_COMBO=gnu-gnu-gnu
     - LIBRARY_COMBO=ng-gnu-gnu
     - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
+    - LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
+    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-2.0
 matrix:
     exclude:
         - compiler: gcc
           env: LIBRARY_COMBO=ng-gnu-gnu
         - compiler: gcc
           env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
+        - compiler: gcc
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
+        - compiler: gcc
+          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-2.0
         - compiler: clang
           env: LIBRARY_COMBO=gnu-gnu-gnu
 sudo: required

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -14,6 +14,7 @@ install_gnustep_make() {
     fi
     ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO --with-user-config-file=$PWD/GNUstep.conf
 	make install
+    echo Objective-C build flags: `$HOME/staging/bin/gnustep-config --objc-flags`
 }
 
 install_ng_runtime() {

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -6,15 +6,9 @@ DEP_SRC=$HOME/dependency_source/
 
 install_gnustep_make() {
     cd $DEP_SRC
-    git clone https://github.com/gnustep/make.git
-    cd make
-    if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ]
-    then
-        ADDITIONAL_FLAGS="--enable-objc-nonfragile-abi"
-    else
-        ADDITIONAL_FLAGS=""
-    fi
-    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO $ADDITIONAL_FLAGS
+    git clone https://github.com/gnustep/tools-make.git
+    cd tools-make
+    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO
 	make install
 }
 

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -8,7 +8,11 @@ install_gnustep_make() {
     cd $DEP_SRC
     git clone https://github.com/gnustep/tools-make.git
     cd tools-make
-    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO
+    if [ -n "$RUNTIME_VERSION" ]
+    then
+        echo "RUNTIME_VERSION=$RUNTIME_VERSION" > GNUstep.conf
+    fi
+    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO --with-user-config-file=$PWD/GNUstep.conf
 	make install
 }
 


### PR DESCRIPTION
This updates the Travis CI with the following fixes and changes for builds using Clang and the `ng-gnu-gnu` library combo:

- Fixed `--disable-mixedabi` option spelling. The previous spelling was incorrect and ignored, as indicated by the following warning in the current travis builds:
`WARNING: unrecognized options: --disable-mixed-abi`
- Updated GNUstep make repository URL. The old URL was being redirected to the new URL by GitHub, so this does not change the repository.
- Removed obsolete --enable-objc-nonfragile-abi flag (was removed in https://github.com/gnustep/libs-base/commit/38fc2bde8226e7a88a9a3f21b104d2b2eb6c4bed).
- Adds builds using the gnustep-2.0 runtime (with and without mixed ABI).
- Adds output from `gnustep-config --objc-flags` so it’s possible to verify that the selected build options have taken effect (e.g. `-fobjc-runtime=gnustep-2.0` for RUNTIME_VERSION=gnustep-2.0).