### PR TITLE
Fix CI for runtime ABI 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
           env: LIBRARY_COMBO=gnu-gnu-gnu
 sudo: required
 before_install:
-    - ls /usr/local/bin
     - sudo apt-get -qq update
     - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev libblocksruntime-dev
     - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: xenial
 compiler:
     - clang
     - gcc
@@ -34,7 +34,11 @@ before_install:
           fi;
           sudo apt-get install -y libobjc-4.8-dev;
         else
-          sudo apt-get install -y libkqueue-dev libpthread-workqueue-dev;
+          curl -s -o - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -;
+          sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" && sudo apt-get update -qq;
+          sudo apt-get install -y clang-9 libkqueue-dev libpthread-workqueue-dev;
+          export CC=clang-9;
+          export CXX=clang++-9;
         fi;
 install: ./travis-deps.sh
 before_script: >
@@ -50,5 +54,5 @@ before_script: >
     export GNUSTEP_MAKEFILES=$HOME/staging/share/GNUstep/Makefiles;
     . $HOME/staging/share/GNUstep/Makefiles/GNUstep.sh;
 script: >
-    ./configure $BASE_ABI;
+    ./configure $BASE_ABI || (cat config.log && false);
     make && make install && make check || (cat Tests/tests.log && false);

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ before_install:
           sudo update-alternatives   --install /usr/bin/clang   clang   /usr/bin/clang-9   10 \
                                      --slave   /usr/bin/clang++ clang++ /usr/bin/clang++-9;
           export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/clang-7.0.0\/bin//');
+          if [ "$RUNTIME_VERSION" = "gnustep-2.0" ];
+          then
+             sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10;
+          fi;
         fi;
 install: ./travis-deps.sh
 before_script: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
           env: LIBRARY_COMBO=gnu-gnu-gnu
 sudo: required
 before_install:
+    - ls /usr/local/bin
     - sudo apt-get -qq update
     - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev libblocksruntime-dev
     - >
@@ -37,8 +38,9 @@ before_install:
           curl -s -o - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -;
           sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" && sudo apt-get update -qq;
           sudo apt-get install -y clang-9 libkqueue-dev libpthread-workqueue-dev;
-          export CC=clang-9;
-          export CXX=clang++-9;
+          sudo update-alternatives   --install /usr/bin/clang   clang   /usr/bin/clang-9   10 \
+                                     --slave   /usr/bin/clang++ clang++ /usr/bin/clang++-9;
+          export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/clang-7.0.0\/bin//');
         fi;
 install: ./travis-deps.sh
 before_script: >


### PR DESCRIPTION
Travis isn't currently *really* running Ci for base built with the 2.0 runtime ABI. This PR fixes that. The magic sauce here is to use at least clang 8 and some linker which is not ld.bfd.

I've also fixed one of the blocks related NSArray tests which wasn't accounting for concurrency properly.