### PR TITLE
Updated NSUUID to use instancetype.

### DIFF
--- a/Headers/Foundation/NSUUID.h
+++ b/Headers/Foundation/NSUUID.h
@@ -50,9 +50,9 @@ typedef uint8_t gsuuid_t[16];
   gsuuid_t uuid;
 }
 
-+ (id)UUID;
-- (id)initWithUUIDString:(NSString *)string;
-- (id)initWithUUIDBytes:(gsuuid_t)bytes;
++ (instancetype)UUID;
+- (instancetype)initWithUUIDString:(NSString *)string;
+- (instancetype)initWithUUIDBytes:(gsuuid_t)bytes;
 - (NSString *)UUIDString;
 - (void)getUUIDBytes:(gsuuid_t)bytes;
 

--- a/Source/NSUUID.m
+++ b/Source/NSUUID.m
@@ -43,7 +43,7 @@ static const int kUUIDByteCount = 16;
  */
 @implementation NSUUID
 
-+ (id) UUID
++ (instancetype) UUID
 {
   id    u;
 
@@ -51,7 +51,7 @@ static const int kUUIDByteCount = 16;
   return AUTORELEASE(u);
 }
 
-- (id) init
+- (instancetype) init
 {
   gsuuid_t      localUUID;
   int           result;
@@ -65,7 +65,7 @@ static const int kUUIDByteCount = 16;
   return [self initWithUUIDBytes: localUUID];
 }
 
-- (id) initWithUUIDString: (NSString *)string
+- (instancetype) initWithUUIDString: (NSString *)string
 {
   gsuuid_t      localUUID;
   const char    *cString;
@@ -81,7 +81,7 @@ static const int kUUIDByteCount = 16;
   return [self initWithUUIDBytes: localUUID];
 }
 
-- (id) initWithUUIDBytes: (gsuuid_t)bytes
+- (instancetype) initWithUUIDBytes: (gsuuid_t)bytes
 {
   if (nil != (self = [super init]))
     {


### PR DESCRIPTION
Matches Apple’s implementation and enables using the dot syntax with NSUUID e.g. like this: `NSUUID.UUID.UUIDString`.