### PR TITLE
NSPropertyList.h: mention base64 encoding

### DIFF
--- a/Headers/Foundation/NSPropertyList.h
+++ b/Headers/Foundation/NSPropertyList.h
@@ -164,13 +164,13 @@ typedef NSUInteger NSPropertyListFormat;
  *       }
  *     </example>
  *     In XML format, a dictionary is an element whose name is
- *     <code>dictionary</code> and whose content consists of pairs of
- *     strings and other <em>property list</em> objects.
+ *     <code>dict</code> and whose content consists of pairs of
+ *     string <code>key</code> and other <em>property list</em> objects.
  *     <example>
- *       &lt;dictionary&gt;
- *         &lt;string&gt;key1&lt;/string&gt;
+ *       &lt;dict&gt;
+ *         &lt;key&gt;key1&lt;/key&gt;
  *         &lt;string&gt;value1&lt;/string&gt;
- *       &lt;/dictionary&gt;
+ *       &lt;/dict&gt;
  *     </example>
  *   </desc>
  *   <term>[NSNumber]</term>

--- a/Headers/Foundation/NSPropertyList.h
+++ b/Headers/Foundation/NSPropertyList.h
@@ -117,11 +117,15 @@ typedef NSUInteger NSPropertyListFormat;
  *   </desc>
  *   <term>[NSData]</term>
  *   <desc>
- *     An array is represented as a series of pairs of hexadecimal characters
- *     (each pair representing a byte of data) enclosed in angle brackets.
- *     Spaces are ignored).
+ *     A data object is represented as a series of pairs of hexadecimal
+ *     characters (each pair representing a byte of data) enclosed in angle
+ *     brackets. (Spaces are ignored).
  *     <example>
  *       &lt; 54637374 696D67 &gt;
+ *     </example>
+ *     Base64 can be used since Base 1.24.9:
+ *     <example>
+ *       &lt;[VGNzdGltZw==]&gt;
  *     </example>
  *     In XML format, a data object is an element whose name is
  *     <code>data</code> and whose content is a stream of base64 encoded bytes.


### PR DESCRIPTION
Base64 parsing is supported since 3f2fa9ddfe507b68fd92843c345c7994b1c1adc8 and it is the default since 9aa5d4cd0403c2d990262c15884181da5d1e32ae. We should definitely document that.