### PR TITLE
fix CI build for gnustep ABI < 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ compiler:
     - gcc
 env:
     - LIBRARY_COMBO=gnu-gnu-gnu
-    - LIBRARY_COMBO=ng-gnu-gnu
-    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
+    - LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9
+    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-1.9
     - LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
     - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-2.0
 matrix:
     exclude:
         - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9
         - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi
+          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-1.9
         - compiler: gcc
           env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
         - compiler: gcc

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -11,10 +11,12 @@ install_gnustep_make() {
     cd tools-make
     if [ -n "$RUNTIME_VERSION" ]
     then
-        echo "RUNTIME_VERSION=$RUNTIME_VERSION" > GNUstep.conf
+        WITH_RUNTIME_ABI="--with-runtime-abi=${RUNTIME_VERSION}"
+    else
+        WITH_RUNTIME_ABI=""
     fi
-    ./configure --prefix=$DEP_ROOT --with-library-combo=$LIBRARY_COMBO --with-user-config-file=$PWD/GNUstep.conf
-	make install
+    ./configure --prefix=$DEP_ROOT --with-library-combo=$LIBRARY_COMBO $WITH_RUNTIME_ABI
+    make install
     echo Objective-C build flags: `$HOME/staging/bin/gnustep-config --objc-flags`
 }
 


### PR DESCRIPTION
The CI jobs for the older GNUstep Objective-C ABI were failing because newer gnustep-make versions were implicitly upgrading the build to the gnustep-2.0 ABI. This PR fixes that by stating explicitly which runtime ABI should be used. 