### PR TITLE
Extend NSBundle test to check for framework resource loading.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-03-01  Fred Kiefer <fredkiefer@gmx.de>
+
+	* Tests/base/NSBundle/TestInfo,
+	* Tests/base/NSBundle/GNUmakefile.preamble,
+	* Tests/base/NSBundle/resources2.m: Extend test to check for
+	framework resource loading.
+
 2020-02-24  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/objc-load.m: update GSPrivateSymbolPath() so that, on the

--- a/Tests/base/NSBundle/GNUmakefile.preamble
+++ b/Tests/base/NSBundle/GNUmakefile.preamble
@@ -1,7 +1,7 @@
 
 ADDITIONAL_INCLUDE_DIRS += -I../GenericTests/ -I../../..
 ADDITIONAL_OBJCFLAGS += -Wall
-
+resources2_LDFLAGS += -Wl,-rpath -Wl,$(CURDIR)/Resources/TestFramework.framework/Versions/Current/$(GNUSTEP_TARGET_LDIR)
 resources2_LIB_DIRS += -L./Resources/TestFramework.framework/$(GNUSTEP_TARGET_LDIR)
 resources2_TOOL_LIBS += -lTestFramework
 

--- a/Tests/base/NSBundle/GNUmakefile.preamble
+++ b/Tests/base/NSBundle/GNUmakefile.preamble
@@ -2,6 +2,9 @@
 ADDITIONAL_INCLUDE_DIRS += -I../GenericTests/ -I../../..
 ADDITIONAL_OBJCFLAGS += -Wall
 
+resources2_LIB_DIRS += -L./Resources/TestFramework.framework/$(GNUSTEP_TARGET_LDIR)
+resources2_TOOL_LIBS += -lTestFramework
+
 $(GNUSTEP_INSTANCE)_SUBPROJECTS = ../GenericTests
 
 SUBPROJECTS = ../GenericTests Resources

--- a/Tests/base/NSBundle/Resources/GNUmakefile
+++ b/Tests/base/NSBundle/Resources/GNUmakefile
@@ -16,7 +16,7 @@ TestFramework_OBJC_FILES = TestFramework.m
 TestFramework_RESOURCE_FILES = NonLocalRes.txt
 TestFramework_LANGUAGES = English French de
 TestFramework_LOCALIZED_RESOURCE_FILES = TextRes.txt
-
+TestFramework_CURRENT_VERSION_NAME = 2
 
 include $(GNUSTEP_MAKEFILES)/bundle.make
 include $(GNUSTEP_MAKEFILES)/framework.make

--- a/Tests/base/NSBundle/TestInfo
+++ b/Tests/base/NSBundle/TestInfo
@@ -1,1 +1,0 @@
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./Resources/TestFramework.framework/Versions/2/

--- a/Tests/base/NSBundle/TestInfo
+++ b/Tests/base/NSBundle/TestInfo
@@ -1,1 +1,1 @@
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./Resources/TestFramework.framework/Versions/0/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./Resources/TestFramework.framework/Versions/2/

--- a/Tests/base/NSBundle/TestInfo
+++ b/Tests/base/NSBundle/TestInfo
@@ -1,0 +1,1 @@
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./Resources/TestFramework.framework/Versions/0/

--- a/Tests/base/NSBundle/resources2.m
+++ b/Tests/base/NSBundle/resources2.m
@@ -10,6 +10,8 @@
 - (NSString*)test;
 @end
 
+@interface TestFramework: NSObject
+@end
 
 static void _testBundle(NSBundle* bundle, NSString* path, NSString* className)
 {
@@ -101,6 +103,10 @@ int main()
   END_SET("Bundle")
 
   START_SET("Framework")
+  /* This method call is required to ensure that the linker does not decide to
+   * elide the framework linkage.
+   */
+  [TestFramework class];
   bundle = [NSBundle bundleForClass: NSClassFromString(@"TestFramework")];
   path = [bundle bundlePath];
   _testBundle(bundle, path, @"TestFramework");

--- a/Tests/base/NSBundle/resources2.m
+++ b/Tests/base/NSBundle/resources2.m
@@ -11,15 +11,11 @@
 @end
 
 
-static void _testBundle(NSString* name, NSString* className)
+static void _testBundle(NSBundle* bundle, NSString* path, NSString* className)
 {
-  NSBundle *bundle;
   NSArray  *arr, *carr;
-  NSString *path, *localPath;
-  path = [[[[[NSFileManager defaultManager] currentDirectoryPath]
-    stringByStandardizingPath] stringByAppendingPathComponent: @"Resources"]
-      stringByAppendingPathComponent: name];
-  bundle = [NSBundle bundleWithPath: path];
+  NSString *localPath;
+
   arr = [bundle pathsForResourcesOfType: @"txt" inDirectory: nil];
   PASS((arr && [arr count]),
     "-pathsForResourcesOfType:inDirectory: returns an array");
@@ -89,12 +85,24 @@ static void _testBundle(NSString* name, NSString* className)
 int main()
 {
   NSAutoreleasePool   *arp = [NSAutoreleasePool new];
+  NSString *path;
+  NSBundle *bundle;
+
   START_SET("Bundle")
-  _testBundle(@"TestBundle.bundle", @"TestBundle");
+  path = [[[[[NSFileManager defaultManager] currentDirectoryPath]
+    stringByStandardizingPath] stringByAppendingPathComponent: @"Resources"]
+      stringByAppendingPathComponent: @"TestBundle.bundle"];
+  bundle = [NSBundle bundleWithPath: path];
+  _testBundle(bundle, path, @"TestBundle");
   END_SET("Bundle")
+
   START_SET("Framework")
-  _testBundle(@"TestFramework.framework", @"TestFramework");
+  bundle = [NSBundle bundleForClass: NSClassFromString(@"TestFramework")];
+  path = [bundle bundlePath];
+  _testBundle(bundle, path, @"TestFramework");
+  PASS(0 == [bundle bundleVersion], "bundleVersion is zero");
   END_SET("Framework");
+
   [arp release]; arp = nil;
   return 0;
 }

--- a/Tests/base/NSBundle/resources2.m
+++ b/Tests/base/NSBundle/resources2.m
@@ -16,6 +16,10 @@ static void _testBundle(NSBundle* bundle, NSString* path, NSString* className)
   NSArray  *arr, *carr;
   NSString *localPath;
 
+  PASS((bundle != nil),
+    "bundle was found");
+  PASS((path != nil),
+    "path of bundle was found");
   arr = [bundle pathsForResourcesOfType: @"txt" inDirectory: nil];
   PASS((arr && [arr count]),
     "-pathsForResourcesOfType:inDirectory: returns an array");


### PR DESCRIPTION
I was trying to write a test that would allow to automatically test the clang libobjc2 issue we are currently fixing on make. As I do not use this environment myself this is just a blind guess. 

For this I reused a test by Niels and rewrote that to load the framework differently, hoping that this will trigger the issue.