### PR TITLE
* Source/NSString.m: Attempt to make calls to GSICUCollatorOpen()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-07  Fred Kiefer <fredkiefer@gmx.de>
+
+	* Source/NSString.m: Attempt to make calls to GSICUCollatorOpen()
+	more consistent and correct for ICU 65.
+
 2020-03-06  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Resources/Languages/Locale.canonical:


### PR DESCRIPTION
more consistent and correct for ICU 65.

The old code resulted in numerical comparisons failing with ICU65, because the code was just ignoring the system locale. I moved the tow different preprocessing instructions into the  function GSICUCollatorOpen and removed the obviously wrong code path.
The code is at least better than the previous version, I am not sure whether it is already correct for all cases. 