### PR TITLE
Fixed NSURLComponents setURL: throwing exceptions.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-10  Frederik Seiffert <frederik@algoriddim.com>
+
+    * Source/NSURL.m: fix –[NSURLComponents setURL:] throwing
+    exception for URLs that don't have all parts.
+
 2020-03-01  Fred Kiefer <fredkiefer@gmx.de>
 
 	* Tests/base/NSBundle/TestInfo,

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -2236,6 +2236,15 @@ static NSUInteger	urlAlign;
   if (self != nil)
     {
       GS_CREATE_INTERNAL(NSURLComponents);
+      
+      internal->_rangeOfFragment = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfHost     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPassword = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPath     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPort     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfQuery    = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfScheme   = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfUser     = NSMakeRange(NSNotFound, 0);
     }
   return self;
 }
@@ -2352,14 +2361,18 @@ static NSUInteger	urlAlign;
                          [NSCharacterSet URLUserAllowedCharacterSet]]];
 
   // Find ranges
-  internal->_rangeOfFragment   = [[url absoluteString] rangeOfString: internal->_fragment];
-  internal->_rangeOfHost       = [[url absoluteString] rangeOfString: internal->_host];
-  internal->_rangeOfPassword   = [[url absoluteString] rangeOfString: internal->_password];
-  internal->_rangeOfPath       = [[url absoluteString] rangeOfString: internal->_path];
-  internal->_rangeOfPort       = [[url absoluteString] rangeOfString: [internal->_port stringValue]];
-  internal->_rangeOfQuery      = [[url absoluteString] rangeOfString: internal->_query];
-  internal->_rangeOfScheme     = [[url absoluteString] rangeOfString: internal->_scheme];
-  internal->_rangeOfUser       = [[url absoluteString] rangeOfString: internal->_user];
+  NSString *urlString = [url absoluteString];
+#define URL_COMPONENT_RANGE(part) \
+  (part ? [urlString rangeOfString:part] : NSMakeRange(NSNotFound, 0))
+  internal->_rangeOfFragment = URL_COMPONENT_RANGE(internal->_fragment);
+  internal->_rangeOfHost     = URL_COMPONENT_RANGE(internal->_host);
+  internal->_rangeOfPassword = URL_COMPONENT_RANGE(internal->_password);
+  internal->_rangeOfPath     = URL_COMPONENT_RANGE(internal->_path);
+  internal->_rangeOfPort     = URL_COMPONENT_RANGE([internal->_port stringValue]);
+  internal->_rangeOfQuery    = URL_COMPONENT_RANGE(internal->_query);
+  internal->_rangeOfScheme   = URL_COMPONENT_RANGE(internal->_scheme);
+  internal->_rangeOfUser     = URL_COMPONENT_RANGE(internal->_user);
+#undef URL_COMPONENT_RANGE
 }
 
 - (NSURL *)URLRelativeToURL: (NSURL *)baseURL


### PR DESCRIPTION
This happened when setting an URL that didn't have all the different parts like fragment or query, as rangeOfString: throws for nil values.

Also correctly initializes rangeOf* properties with `{NSNotFound, 0}`.