### PR TITLE
Fixed parsing of NSURLResponse content type header.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-12  Frederik Seiffert <frederik@algoriddim.com>
+
+    * Source/NSURLResponse.m: Fix parsing of NSURLResponse content type
+    header.
+
 2020-03-10  Frederik Seiffert <frederik@algoriddim.com>
 
     * Source/NSURL.m: fix –[NSURLComponents setURL:] throwing

--- a/Source/NSURLResponse.m
+++ b/Source/NSURLResponse.m
@@ -81,7 +81,8 @@ typedef struct {
 	}
       s = [NSScanner scannerWithString: v];
       p = [GSMimeParser new];
-      c = AUTORELEASE([GSMimeHeader new]);
+      c = AUTORELEASE([[GSMimeHeader alloc] initWithName: @"content-type"
+                                                   value: nil]);
       /* We just set the header body, so we know it will scan and don't need
        * to check the retrurn type.
        */


### PR DESCRIPTION
When creating an instance of  NSHTTPURLResponse using:
`[NSHTTPURLResponse initWithURL:statusCode:HTTPVersion:headerFields:]`, the `MIMEType` property currently returns the content-type header value including any attributes in the header fields (e.g. `application/json;charset=utf-8`), whereas it should just return `application/json`.

This patch forces the content-type header parsing down the correct route in GSMime.m so that `MIMEType` returns the correct value.