### PR TITLE
Use pthread_setname_np result instead of errno.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-17  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSThread.m: Use pthread_setname_np result instead of errno,
+	which fixes setting thread name on platforms where errno is not set.
+
 2020-03-12  Fred Kiefer <fredkiefer@gmx.de>
 
 	* Source/NSURL.m: Fix compiler warnigns.

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -1241,12 +1241,7 @@ unregisterActiveThread(NSThread *thread)
         }
       while (i > 0)
         {
-          if (PTHREAD_SETNAME(buf) == 0)
-            {
-              break;    // Success
-            }
-
-          if (ERANGE == errno)
+          if (PTHREAD_SETNAME(buf) == ERANGE)
             {
               /* Name must be too long ... gnu/linux uses 15 characters
                */
@@ -1274,7 +1269,7 @@ unregisterActiveThread(NSThread *thread)
             }
           else
             {
-              break;    // Some other error
+              break;    // Success or some other error
             }
         }
     }


### PR DESCRIPTION
Fixes setting thread name on Android where errno is not set when the string is too long (`ERANGE`):
https://android.googlesource.com/platform/bionic/+/master/libc/bionic/pthread_setname_np.cpp#90

I think this change might also be needed for other platforms. E.g. glibc also doesn’t seem to set errno in this case:
https://github.com/bminor/glibc/blob/d614a75/sysdeps/unix/sysv/linux/pthread_setname.c#L39-L40

According to the [man page](http://man7.org/linux/man-pages/man3/pthread_setname_np.3.html), `pthread_setname_np` directly returns an error, so I think this should be portable:

> **Return value**
> On success, these functions return 0; on error, they return a nonzero error number.
