### PR TITLE
Fixed NSOperation completion block memory management.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-04-07  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSOperation.m: Fix completion block memory management.
+
 2020-04-05  Ivan Vucica <ivan@vucica.net>
 
 	* ANNOUNCE:

--- a/Source/NSOperation.m
+++ b/Source/NSOperation.m
@@ -217,6 +217,7 @@ static NSArray	*empty = nil;
       RELEASE(internal->dependencies);
       RELEASE(internal->cond);
       RELEASE(internal->lock);
+      RELEASE(internal->completionBlock);
       GS_DESTROY_INTERNAL(NSOperation);
     }
   [super dealloc];
@@ -381,7 +382,7 @@ static NSArray	*empty = nil;
 
 - (void) setCompletionBlock: (GSOperationCompletionBlock)aBlock
 {
-  internal->completionBlock = aBlock;
+  ASSIGNCOPY(internal->completionBlock, aBlock);
 }
 
 - (void) setQueuePriority: (NSOperationQueuePriority)pri


### PR DESCRIPTION
The NSOperation completion block was not being copied/retained or released.

I’m not totally sure if it’s better to use the Block_copy()/Block_release() functions here, or if I should/can use e.g. the ASSIGNCOPY()/RELEASE() macros instead. GSNotificationObserver uses to former, which is why I went with them.