### PR TITLE
Normalize annoucement file between core libraries

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -169,7 +169,29 @@ methods.
 The gnustep-base-1.27.0.tar.gz distribution file has been placed at
 <ftp://ftp.gnustep.org/pub/gnustep/core>.
 
-   Please log bug reports on the GNUstep project page
+   It is accompanied by gnustep-base-1.27.0.tar.gz.sig, a PGP signature
+which you can validate by putting both files in the same directory and
+using:
+
+     gpg --verify gnustep-base-1.27.0.tar.gz.sig
+
+   Signature has been created using the key with the following
+fingerprint:
+
+     83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
+
+   Read the INSTALL file or the GNUstep-HOWTO for installation
+instructions.
+
+1.4 Where do I send bug reports?
+================================
+
+Please log bug reports on the GNUstep project page
 <http://savannah.gnu.org/bugs/?group=gnustep> or send bug reports to
 <bug-gnustep@gnu.org>.
 
+1.5 Obtaining GNUstep Software
+==============================
+
+Check out the GNUstep web site.  (<http://www.gnustep.org/>) and the GNU
+web site.  (<http://www.gnu.org/>)

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,13 @@
 	nonfragile ABI (true for modern apple systems we may be interested in
 	using). Regenerate configure script.
 
+2020-04-13  Ivan Vucica <ivan@vucica.net>
+
+	* Documentation/announce.texi:
+	* ANNOUNCE:
+	Normalize the accompanying text for the release announcement across
+	core packages: standardize chapter name and GPG information.
+
 2020-04-13  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/Foundation/NSURLProtocol.h:

--- a/Documentation/announce.texi
+++ b/Documentation/announce.texi
@@ -1,3 +1,4 @@
+@c -*- texinfo -*-
 @chapter Announcement
 
 @c set the vars GNUSTEP-BASE-VERSION and GNUSTEP-BASE-GCC-VERSION
@@ -31,9 +32,31 @@ at @samp{http://www.gnustep.org}.
 @ifset GNUSTEP-BASE-FTP-MACHINE
 The gnustep-base-@value{GNUSTEP-BASE-VERSION}.tar.gz distribution file has 
 been placed at @url{ftp://@value{GNUSTEP-BASE-FTP-MACHINE}/@value{GNUSTEP-BASE-FTP-DIRECTORY}}.
+
+It is accompanied by gnustep-base-@value{GNUSTEP-BASE-VERSION}.tar.gz.sig, a
+PGP signature which you can validate by putting both files in the same
+directory and using:
+
+@example
+gpg --verify gnustep-base-@value{GNUSTEP-BASE-VERSION}.tar.gz.sig
+@end example
+
+Signature has been created using the key with the following fingerprint:
+
+@example
+83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
+@end example
 @end ifset
+
+Read the INSTALL file or the GNUstep-HOWTO for installation instructions.
+
+@section Where do I send bug reports?
 
 Please log bug reports on the GNUstep project page
 @url{http://savannah.gnu.org/bugs/?group=gnustep} or send bug
 reports to @email{bug-gnustep@@gnu.org}.
 
+@section Obtaining GNUstep Software
+
+Check out the GNUstep web site. (@url{http://www.gnustep.org/}) and the
+GNU web site. (@url{http://www.gnu.org/})


### PR DESCRIPTION
While preparing the email, I noticed the ANNOUNCE file for `-make` doesn't mention the GPG key, and there are other subtle differences.

I'm creating this pull request across `make`, `base`, `gui` and `back`.
