### PR TITLE
Fix loss of buffer in NSJSONSerialization.

### DIFF
--- a/Source/NSJSONSerialization.m
+++ b/Source/NSJSONSerialization.m
@@ -468,11 +468,16 @@ parseNumber(ParserState *state)
     {\
       bufferSize *= 2;\
       if (number == numberBuffer)\
-	number = malloc(bufferSize);\
+        {\
+          number = malloc(bufferSize);\
+          memcpy(number, numberBuffer, sizeof(numberBuffer));\
+        }\
       else\
-	number = realloc(number, bufferSize);\
+        {\
+          number = realloc(number, bufferSize);\
+        }\
     }\
-    number[parsedSize++] = (char)x; } while (0)
+  number[parsedSize++] = (char)x; } while (0)
   // JSON numbers must start with a - or a digit
   if (!(c == '-' || isdigit(c)))
     {


### PR DESCRIPTION
## The problem
In NSJSONSerialization
When the buffer size exceeds 128, `parseNumber()` does not parse correctly.

### Example
When parse 12800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, **It's result in 0**.

## Cause

The first time `bufferSize` is extended, `number` loses the previously parsed characters in `numberBuffer` .

The probrem is here.

```c
      if (number == numberBuffer)\
	number = malloc(bufferSize);\
      else\
        number = realloc(number, bufferSize);\
```

Until the bufferSize reaches 128, number is the pointer to numberBuffer, and the parsed characters are stored in numberBuffer.
But here, `number` has lost characters in `numberBuffer` .

Return value of parseNumber() is generated from a `number` .

So, when the buffer size exceeds 128, `number` lose the characters in numberBuffer, and then generating return value will fail.

## What I did

After malloc the number, copy the numberBuffer to the number.

```c
      if (number == numberBuffer)\
        {\
          number = malloc(bufferSize);\
          memcpy(number, numberBuffer, sizeof(numberBuffer));\
        }\
      else\
        {\
          number = realloc(number, bufferSize);\
        }\
```

When parse 12800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, **It's result in 1.28e+127**.
