### PR TITLE
Bugfix/nsurl components

### DIFF
--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -2116,17 +2116,26 @@ GS_PRIVATE_INTERNAL(NSURLQueryItem)
   return AUTORELEASE(newQueryItem);
 }
 
-- (instancetype)initWithName:(NSString *)name
-                       value:(NSString *)value
+- (instancetype) init
 {
   self = [super init];
-  if (self != nil)
-    {
-      GS_CREATE_INTERNAL(NSURLQueryItem);
-      
-      ASSIGNCOPY(internal->_name, name);
-      ASSIGNCOPY(internal->_value, value);
-    }
+  if(self != nil)
+  {
+    GS_CREATE_INTERNAL(NSURLQueryItem);
+    ASSIGN(internal->_name, @""); //OSX behaviour is to set an empty string for the name property
+  }
+  return self;
+}
+
+- (instancetype)initWithName:(NSString *)name 
+                       value:(NSString *)value
+{
+  self = [self init];
+  if(self != nil)
+  {
+    if(name)ASSIGNCOPY(internal->_name, name);
+    ASSIGNCOPY(internal->_value, value);
+  }
   return self;
 }
 

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -2225,14 +2225,14 @@ static NSCharacterSet	*queryItemCharSet = nil;
 // Creating URL components...
 + (instancetype) componentsWithString: (NSString *)urlString
 {
-  return [[NSURLComponents alloc] initWithString: urlString];
+  return  AUTORELEASE([[NSURLComponents alloc] initWithString: urlString]);
 }
 
 + (instancetype) componentsWithURL: (NSURL *)url 
            resolvingAgainstBaseURL: (BOOL)resolve
 {
-  return [[NSURLComponents alloc] initWithURL: url
-                      resolvingAgainstBaseURL: resolve];
+  return  AUTORELEASE([[NSURLComponents alloc] initWithURL: url
+                      resolvingAgainstBaseURL: resolve]);
 }
 
 - (instancetype) init

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -2256,12 +2256,10 @@ static NSCharacterSet	*queryItemCharSet = nil;
 
 - (instancetype) initWithString: (NSString *)URLString
 {
-  self = [self init];
-  if (self != nil)
-    {
-      [self setString: URLString];
-    }
-  return self;
+  //OSX behavior is to return nil for a string which cannot be used to initialize valid NSURL object
+  NSURL* url = [NSURL URLWithString:URLString];
+  if(url) return [self initWithURL:url resolvingAgainstBaseURL:NO];
+  else return nil;
 }
 
 - (instancetype) initWithURL: (NSURL *)url 
@@ -2454,7 +2452,7 @@ static NSCharacterSet	*queryItemCharSet = nil;
   [self setUser: [url user]];
   [self setPassword: [url password]];
   [self setPath: [url path]];
-  [self setQuery: [url query]];
+  [self setPercentEncodedQuery:[url query]];
   [self setFragment: [url fragment]];
 }
 

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -2118,22 +2118,29 @@ GS_PRIVATE_INTERNAL(NSURLQueryItem)
 
 - (instancetype) init
 {
-  self = [super init];
+  self = [self initWithName:nil value:nil];
   if(self != nil)
-  {
-    GS_CREATE_INTERNAL(NSURLQueryItem);
-    ASSIGN(internal->_name, @""); //OSX behaviour is to set an empty string for the name property
-  }
+    {
+    
+    }
   return self;
 }
 
 - (instancetype)initWithName:(NSString *)name 
                        value:(NSString *)value
 {
-  self = [self init];
+  self = [super init];
   if(self != nil)
   {
-    if(name)ASSIGNCOPY(internal->_name, name);
+    GS_CREATE_INTERNAL(NSURLQueryItem);
+    if(name)
+      {
+        ASSIGNCOPY(internal->_name, name);
+      }
+    else
+      {
+        ASSIGN(internal->_name, @""); //OSX behaviour is to set an empty string for nil name property
+      }
     ASSIGNCOPY(internal->_value, value);
   }
   return self;
@@ -2267,8 +2274,14 @@ static NSCharacterSet	*queryItemCharSet = nil;
 {
   //OSX behavior is to return nil for a string which cannot be used to initialize valid NSURL object
   NSURL* url = [NSURL URLWithString:URLString];
-  if(url) return [self initWithURL:url resolvingAgainstBaseURL:NO];
-  else return nil;
+  if(url)
+    {
+      return [self initWithURL:url resolvingAgainstBaseURL:NO];
+    }
+  else
+    {
+      return nil;
+    }
 }
 
 - (instancetype) initWithURL: (NSURL *)url 

--- a/Tests/base/NSURL/basic.m
+++ b/Tests/base/NSURL/basic.m
@@ -339,6 +339,23 @@ GSPathHandling("right");
   PASS_EQUAL([rel absoluteString], @"data:,$2A", "relative data URL works");
   PASS_EQUAL([rel baseURL], nil, "Base URL of relative data URL is nil");
 
+  ///NSURLQueryItem
+  
+  //OSX behavior is to return query item with an empty string name
+  NSURLQueryItem* item = [[NSURLQueryItem alloc] init];
+  PASS_EQUAL(item.name, @"", "NSURLQueryItem.name should not be nil");
+  PASS_EQUAL(item.value, nil, "NSURLQueryItem.value should be nil");
+    
+  //OSX behavior is to return query item with an empty string name
+  item = [[NSURLQueryItem alloc] initWithName:nil value:nil];
+  PASS_EQUAL(item.name, @"", "NSURLQueryItem.name should not be nil");
+  PASS_EQUAL(item.value, nil, "NSURLQueryItem.value should be nil");
+    
+  item = [[NSURLQueryItem alloc] initWithName:@"myName" value:@"myValue"];
+  PASS_EQUAL(item.name,  @"myName", "NSURLQueryItem.name should not be nil");
+  PASS_EQUAL(item.value, @"myValue", "NSURLQueryItem.value should be nil");
+
+    
   [arp release]; arp = nil;
   return 0;
 }

--- a/Tests/base/NSURL/basic.m
+++ b/Tests/base/NSURL/basic.m
@@ -353,7 +353,7 @@ GSPathHandling("right");
     
   item = [[NSURLQueryItem alloc] initWithName:@"myName" value:@"myValue"];
   PASS_EQUAL(item.name,  @"myName", "NSURLQueryItem.name should not be nil");
-  PASS_EQUAL(item.value, @"myValue", "NSURLQueryItem.value should be nil");
+  PASS_EQUAL(item.value, @"myValue", "NSURLQueryItem.value should not be nil");
 
     
   [arp release]; arp = nil;

--- a/Tests/base/NSURL/components.m
+++ b/Tests/base/NSURL/components.m
@@ -81,6 +81,23 @@ int main()
     "set query to item containing ampersand")
   PASS_EQUAL([components percentEncodedQuery], @"%26",
     "percent encoded query item encodes ampersand")
+    
+  //NSURLQueryItem percent encoding/decoding test
+  NSString* urlString = @"http://domain/?%D0%90%D0%B0%D0%91%D0%B1=%D0%90%D0%B0%D0%91%D0%B1";
+  NSString* cyrillicStr = @"\U00000410\U00000430\U00000411\U00000431";
+  NSURLComponents* components = [NSURLComponents componentsWithString:urlString];
+  NSURLQueryItem* item = [[components queryItems] lastObject];
+  PASS_EQUAL(item.name, cyrillicStr,  "Should return decoded query item name from url");
+  PASS_EQUAL(item.value, cyrillicStr, "Should return decoded query item value from url");
+  
+  item = [NSURLQueryItem queryItemWithName:cyrillicStr value:cyrillicStr];
+  [components setQueryItems:[NSArray arrayWithObject:item]];
+  PASS_EQUAL([components string], urlString, "Encoded url string from unencoded item");
+  PASS_EQUAL([components URL], [NSURL URLWithString:urlString], "Encoded url query part from unencoded item");
+    
+  NSString* invalidUrlString = @"\U00000410\U00000430\U00000411\U00000431";
+  PASS_EQUAL([NSURL URLWithString:invalidUrlString], nil, "nil NSURL from invalid string")
+  PASS_EQUAL([NSURLComponents componentsWithString:invalidUrlString], nil, "nil NSComponents from invalid string")
 
   END_SET("components")
 


### PR DESCRIPTION
- Fixed missed autorelease 
- Fixed NSURLComponents when initialized with an NSURL containing percent-encoded query
- Updated NSURLQueryItem initializers to match OSX behavior
- Added test to cover some of the cases (checked with OSX implementation)