### PR TITLE
Implement -[NSXMLParser initWithStream:].

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-04-07  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSXMLParser.h:
+	* Headers/GNUstepBase/GSXML.h:
+	* Source/Additions/GSXML.m:
+	* Source/NSXMLParser.m:
+	* Tests/base/NSXMLParser/parse.m:
+	Implement -[NSXMLParser initWithStream:].
+
 2020-04-26  Fred Kiefer <fredkiefer@gmx.de>
 
 	* Source/NSLocale.m: Respect NSLocaleCalendarIdentifier if

--- a/Headers/Foundation/NSXMLParser.h
+++ b/Headers/Foundation/NSXMLParser.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-@class NSData, NSDictionary, NSError, NSString, NSURL;
+@class NSData, NSDictionary, NSError, NSInputStream, NSString, NSURL;
 
 /**
  * Domain for errors
@@ -100,12 +100,17 @@ GS_EXPORT NSString* const NSXMLParserErrorDomain;
 /**
  * Convenience method fetching data from anURL.<br />
  */
-- (id) initWithContentsOfURL: (NSURL*)anURL;
+- (instancetype) initWithContentsOfURL: (NSURL*)anURL;
 
 /** <init />
  * Initialises the parser with the specified xml data.
  */
-- (id) initWithData: (NSData*)data;
+- (instancetype) initWithData: (NSData*)data;
+
+/**
+ * Initialises the parser with the specified input stream.
+ */
+- (instancetype) initWithStream: (NSInputStream*)stream;
 
 /**
  * Parses the supplied data and returns YES on success, NO otherwise.

--- a/Headers/GNUstepBase/GSXML.h
+++ b/Headers/GNUstepBase/GSXML.h
@@ -42,6 +42,7 @@
 #import <Foundation/NSObject.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSDictionary.h>
+#import <Foundation/NSStream.h>
 #else
 #import <Foundation/Foundation.h>
 #endif
@@ -222,6 +223,8 @@ extern "C" {
 	withContentsOfURL: (NSURL*)url;
 - (id) initWithSAXHandler: (GSSAXHandler*)handler
 		 withData: (NSData*)data;
+- (id) initWithSAXHandler: (GSSAXHandler*)handler
+	 withInputStream: (NSInputStream*)stream;
 
 - (BOOL) keepBlanks: (BOOL)yesno;
 - (NSInteger) lineNumber;

--- a/MISSING
+++ b/MISSING
@@ -910,7 +910,6 @@ NSXMLNodeOptions:
 NSXMLParser:
 	@class NSInputStream
 
-	- initWithStream:
 	- parseError
 -------------------------------------------------------------
 NSZone:

--- a/Source/Additions/GSXML.m
+++ b/Source/Additions/GSXML.m
@@ -172,6 +172,19 @@ setupCache()
     }
 }
 
+static int xmlNSInputStreamReadCallback(void *context, char *buffer, int len)
+{
+  NSInputStream *stream = (NSInputStream *)context;
+  return [stream read: (uint8_t *)buffer maxLength: len];
+}
+
+static int xmlNSInputStreamCloseCallback (void *context)
+{
+  NSInputStream *stream = (NSInputStream *)context;
+  [stream close];
+  return 0;
+}
+
 static xmlParserInputPtr
 loadEntityFunction(const unsigned char *url, const unsigned char *eid,
   void *ctx);
@@ -2103,6 +2116,31 @@ static NSString	*endMarker = @"At end of incremental parse";
 }
 
 /**
+ * <p>
+ *   Initialisation of a new Parser with SAX handler (if not nil)
+ *   by calling -initWithSAXHandler:
+ * </p>
+ * <p>
+ *   Sets the input source for the parser to be the specified input stream,
+ *   so parsing of the entire document will be performed rather than
+ *   incremental parsing.
+ * </p>
+ */
+- (id) initWithSAXHandler: (GSSAXHandler*)handler
+	 withInputStream: (NSInputStream*)stream
+{
+  if (stream == nil || [stream isKindOfClass: [NSInputStream class]] == NO)
+    {
+      NSLog(@"Bad NSInputStream passed to initialize GSXMLParser");
+      DESTROY(self);
+      return nil;
+    }
+  src = RETAIN(stream);
+  self = [self initWithSAXHandler: handler];
+  return self;
+}
+
+/**
  * Set and return the previous value for blank text nodes support.
  * ignorableWhitespace nodes are only generated when running
  * the parser in validating mode and when the current element
@@ -2167,7 +2205,8 @@ static NSString	*endMarker = @"At end of incremental parse";
       return NO;
     }
 
-  if ([src isKindOfClass: [NSData class]])
+  if ([src isKindOfClass: [NSData class]]
+      || [src isKindOfClass: [NSInputStream class]])
     {
     }
   else if ([src isKindOfClass: NSString_class])
@@ -2194,14 +2233,22 @@ static NSString	*endMarker = @"At end of incremental parse";
     }
   else
     {
-       NSLog(@"source for [-parse] must be NSString, NSData or NSURL type");
+       NSLog(@"Source for [-parse] must be NSString, NSData, NSInputStream, or"
+         @" NSURL type");
        return NO;
     }
 
   tmp = RETAIN(src);
   ASSIGN(src, endMarker);
-  [self _parseChunk: tmp];
-  [self _parseChunk: nil];
+  if ([tmp isKindOfClass: [NSInputStream class]])
+    {
+      xmlParseDocument(lib);
+    }
+  else
+    {
+      [self _parseChunk: tmp];
+      [self _parseChunk: nil];
+    }
   RELEASE(tmp);
 
   if (((xmlParserCtxtPtr)lib)->wellFormed != 0
@@ -2382,7 +2429,19 @@ static NSString	*endMarker = @"At end of incremental parse";
     {
       file = ".";
     }
-  lib = (void*)xmlCreatePushParserCtxt([saxHandler lib], NULL, 0, 0, file);
+
+  if ([src isKindOfClass: [NSInputStream class]])
+    {
+      [(NSInputStream*)src open];
+      lib = (void*)xmlCreateIOParserCtxt([saxHandler lib], NULL,
+        xmlNSInputStreamReadCallback, xmlNSInputStreamCloseCallback,
+        (void*)src, XML_CHAR_ENCODING_NONE);
+    }
+  else
+    {
+      lib = (void*)xmlCreatePushParserCtxt([saxHandler lib], NULL, 0, 0, file);
+    }
+
   if (lib == NULL)
     {
       NSLog(@"Failed to create libxml parser context");

--- a/Source/NSXMLParser.m
+++ b/Source/NSXMLParser.m
@@ -480,16 +480,11 @@ static  NSNull  *null = nil;
 
 - (id) initWithContentsOfURL: (NSURL*)anURL
 {
-  NSData	*d = [NSData dataWithContentsOfURL: anURL];
-
-  if (d == nil)
-    {
-      DESTROY(self);
-    }
-  else
-    {
-      self = [self initWithData: d];
-    }
+  _handler = [NSXMLSAXHandler new];
+  [myHandler _setOwner: self];
+  _parser = [[GSXMLParser alloc] initWithSAXHandler: myHandler
+                                  withContentsOfURL: anURL];
+  [(GSXMLParser*)_parser substituteEntities: YES];
   return self;
 }
 
@@ -497,7 +492,18 @@ static  NSNull  *null = nil;
 {
   _handler = [NSXMLSAXHandler new];
   [myHandler _setOwner: self];
-  _parser = [[GSXMLParser alloc] initWithSAXHandler: myHandler withData: data];
+  _parser = [[GSXMLParser alloc] initWithSAXHandler: myHandler
+                                           withData: data];
+  [(GSXMLParser*)_parser substituteEntities: YES];
+  return self;
+}
+
+- (id) initWithStream: (NSInputStream*)stream
+{
+  _handler = [NSXMLSAXHandler new];
+  [myHandler _setOwner: self];
+  _parser = [[GSXMLParser alloc] initWithSAXHandler: myHandler
+                                    withInputStream: stream];
   [(GSXMLParser*)_parser substituteEntities: YES];
   return self;
 }


### PR DESCRIPTION
This uses an I/O parser (streaming the data into the parser) instead of a push parser, which should result in reduced memory requirements when parsing large XML files over `-initWithData:`.

Also [changes](https://github.com/gnustep/libs-base/pull/130/files#diff-049b8082c6e5b42981048909755c7aaeL483-R487) `-[NSXMLParser initWithContentsOfURL:]` to use `-[GSXMLParser initWithSAXHandler:withContentsOfURL:]` for consistency, which internally does the same thing as before, i.e. read the URL into an NSData.