### PR TITLE
NSLocale improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-05-07  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSLocale.h:
+	* Source/NSLocale.m:
+	Use "instancetype" for instance-returning methods. Fix method
+	signature of -displayNameForKey:value:.
+
 2020-05-05  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSXMLParser.h:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2020-04-07  Frederik Seiffert <frederik@algoriddim.com>
+2020-05-05  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSXMLParser.h:
 	* Headers/GNUstepBase/GSXML.h:

--- a/Headers/Foundation/NSLocale.h
+++ b/Headers/Foundation/NSLocale.h
@@ -156,7 +156,7 @@ GS_EXPORT NSString * const NSISO8601Calendar;
 
 /** Returns the current locale information.
  */
-+ (id) currentLocale;
++ (instancetype) currentLocale;
 
 /** Returns an array of NSString representing all known country codes.
  */
@@ -190,7 +190,7 @@ GS_EXPORT NSString * const NSISO8601Calendar;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Returns a locale initialised with the given locale identifier.
  */
-+ (id) localeWithLocaleIdentifier:(NSString *)string;
++ (instancetype) localeWithLocaleIdentifier:(NSString *)string;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
@@ -202,7 +202,7 @@ GS_EXPORT NSString * const NSISO8601Calendar;
 
 /** Returns the the system locale.
  */
-+ (id) systemLocale;
++ (instancetype) systemLocale;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Returns the windows locale code corresponding to the staqndard locale
@@ -216,12 +216,12 @@ GS_EXPORT NSString * const NSISO8601Calendar;
  * on the basis that it represents information whose type is specified by
  * the key.
  */
-- (NSString *) displayNameForKey: (id)key value: (id)value;
+- (NSString *) displayNameForKey: (NSString *)key value: (id)value;
 
 /** Initialises the receiver to be the locale specified by the identifier.
  * This may result in replacement of the receiver by an existing locale.
  */
-- (id) initWithLocaleIdentifier: (NSString *)string;
+- (instancetype) initWithLocaleIdentifier: (NSString *)string;
 
 /** Returns the canonical identifier for the receiver (which
  * may differ from the identifgier used to create the receiver

--- a/Source/NSLocale.m
+++ b/Source/NSLocale.m
@@ -691,7 +691,7 @@ static NSRecursiveLock *classLock = nil;
 #endif
 }
 
-- (NSString *) displayNameForKey: (id) key value: (id) value
+- (NSString *) displayNameForKey: (NSString *) key value: (id) value
 {
 #if	GS_USE_ICU == 1
   int32_t length = 0;


### PR DESCRIPTION
- Use "instancetype" for instance-returning methods.
- Fix method signature of -displayNameForKey:value: to match Apple, and since implementation expects NSString.