### PR TITLE
Fix exponent validation in NSJSONSerialization

### DIFF
--- a/Source/NSJSONSerialization.m
+++ b/Source/NSJSONSerialization.m
@@ -513,6 +513,8 @@ parseNumber(ParserState *state)
               free(number);
               number = numberBuffer;
             }
+            parseError(state);
+            return nil;
         }
       BUFFER(c);
       while (isdigit(c = consumeChar(state)))


### PR DESCRIPTION
## The problem
In NSJSONSerialization
When the number has invalid exponent, parseNumber() does not stop parse.

## Cause

The problem is here.

```
// parse the exponent if there is one
if ('e' == tolower(c))
{
  BUFFER(c);
  c = consumeChar(state);
  // The exponent must be a valid number
  if (!(c == '-' || c == '+' || isdigit(c)))
    {
      if (number != numberBuffer)
        {
          free(number);
          number = numberBuffer;
        }
    }
  BUFFER(c);
  while (isdigit(c = consumeChar(state)))
    {
      BUFFER(c);
    }
}
```

The comment `// The exponent must be a valid number` is right.
I think validation ( `if (!(c == '-' || c == '+' || isdigit(c)))` ) is also correct.

But in the if statement for an invalid number, it doesn't call parseError(), and it doesn't interrupt parse.

As a result, it continues `BUFFER(c);` even if it is an invalid number.

## What I did

In the if statement for an invalid number, call `parseError()` and `return nil` .