### PR TITLE
Fix building Win32 classes with nonfragile ABI.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-05-13  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/win32/GSFileHandle.m:
+	* Source/win32/NSMessagePort.m:
+	Fix building Win32 classes with nonfragile ABI.
+
 2010-05-12 Riccardo Mottola <rm@gnu.org>
 
 	* Source/NSFileManager.m:

--- a/Source/win32/GSFileHandle.m
+++ b/Source/win32/GSFileHandle.m
@@ -32,7 +32,8 @@
 #endif
 
 #include "common.h"
-
+#define	EXPOSE_NSFileHandle_IVARS	1
+#define	EXPOSE_GSFileHandle_IVARS	1
 #import "Foundation/NSObject.h"
 #import "Foundation/NSData.h"
 #import "Foundation/NSArray.h"

--- a/Source/win32/NSMessagePort.m
+++ b/Source/win32/NSMessagePort.m
@@ -22,6 +22,8 @@
    */
 
 #include "common.h"
+#define	EXPOSE_NSPort_IVARS	1
+#define	EXPOSE_NSMessagePort_IVARS	1
 #include "GNUstepBase/GSLock.h"
 #include "Foundation/NSArray.h"
 #include "Foundation/NSNotification.h"


### PR DESCRIPTION
Low-hanging fix to ensure `GS_EXPOSE()` doesn’t hide the instance variables when building Windows sources. Copied `EXPOSE_XXX_IVARS` defines from corresponding Unix-classes.