### PR TITLE
Set up CI for Windows using MinGW and GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,73 +1,141 @@
 ---
-os: linux
 language: cpp
 dist: xenial
-compiler:
-    - clang
-    - gcc
-env:
-    - LIBRARY_COMBO=gnu-gnu-gnu
-    - LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9
-    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-1.9
-    - LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
-    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-2.0
 jobs:
-    exclude:
-        - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9
-        - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-1.9
-        - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
-        - compiler: gcc
-          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixedabi RUNTIME_VERSION=gnustep-2.0
-        - compiler: clang
+    include:
+        - name: "Linux GCC"
+          os: linux
+          compiler: gcc
           env: LIBRARY_COMBO=gnu-gnu-gnu
-before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev
-    - >
-        if [ $LIBRARY_COMBO = 'gnu-gnu-gnu' ];
-        then
-          if [ $CC = 'gcc' ];
-          then
-            sudo apt-get install -y gobjc;
-          fi;
-          sudo apt-get install -y libobjc-4.8-dev libblocksruntime-dev;
-        else
-          curl -s -o - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -;
-          sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" && sudo apt-get update -qq;
-          sudo apt-get install -y clang-9 libkqueue-dev libpthread-workqueue-dev;
-          sudo update-alternatives   --install /usr/bin/clang   clang   /usr/bin/clang-9   10 \
-                                     --slave   /usr/bin/clang++ clang++ /usr/bin/clang++-9;
-          export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/clang-7.0.0\/bin//');
-          if [ "$RUNTIME_VERSION" = "gnustep-2.0" ];
-          then
-             sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10;
-          fi;
-        fi;
-    # libdispatch requires a fairly recent version of cmake
-    - >
-        if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ];
-        then
-          curl -LO https://cmake.org/files/v3.15/cmake-3.15.5-Linux-x86_64.tar.gz;
-          tar xf cmake-3.15.5-Linux-x86_64.tar.gz;
-          mv cmake-3.15.5-Linux-x86_64 $HOME/cmake;
-          export PATH=$HOME/cmake/:$HOME/cmake/bin:$PATH
-        fi;
+        - name: "Linux Clang gnustep-1.9"
+          os: linux
+          compiler: clang
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9
+        - name: "Linux Clang gnustep-1.9 disable-mixedabi"
+          os: linux
+          compiler: clang
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-1.9 BASE_ABI=--disable-mixedabi
+        - name: "Linux Clang gnustep-2.0"
+          os: linux
+          compiler: clang
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0
+        - name: "Linux Clang gnustep-2.0 disable-mixedabi"
+          os: linux
+          compiler: clang
+          env: LIBRARY_COMBO=ng-gnu-gnu RUNTIME_VERSION=gnustep-2.0 BASE_ABI=--disable-mixedabi
+        - name: "Windows GCC MinGW-w64 i686"
+          os: windows
+          compiler: gcc
+          env: LIBRARY_COMBO=gnu-gnu-gnu MSYSTEM=mingw32 ARCH=i686
+        - name: "Windows GCC MinGW-w64 x86_64"
+          os: windows
+          compiler: gcc
+          env: LIBRARY_COMBO=gnu-gnu-gnu MSYSTEM=mingw64 ARCH=x86_64
+    # allow Windows builds to fail (remove once all tests are passing on Windows)
+    allow_failures:
+        - os: windows
+before_install: |
+    case $TRAVIS_OS_NAME in
+    linux)
+        sudo apt-get -qq update
+        sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev
+        case $LIBRARY_COMBO in
+        gnu-gnu-gnu)
+            if [ $CC = 'gcc' ]; then
+                sudo apt-get install -y gobjc
+            fi
+            sudo apt-get install -y libobjc-4.8-dev libblocksruntime-dev
+            ;;
+        ng-gnu-gnu)
+            curl -s -o - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+            sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" && sudo apt-get update -qq
+            sudo apt-get install -y clang-9 libkqueue-dev libpthread-workqueue-dev
+            sudo update-alternatives   --install /usr/bin/clang   clang   /usr/bin/clang-9   10 \
+                                       --slave   /usr/bin/clang++ clang++ /usr/bin/clang++-9
+            export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/clang-7.0.0\/bin//')
+            if [ "$RUNTIME_VERSION" = "gnustep-2.0" ]; then
+               sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
+            fi;
+            ## libdispatch requires a fairly recent version of cmake
+            curl -LO https://cmake.org/files/v3.15/cmake-3.15.5-Linux-x86_64.tar.gz
+            tar xf cmake-3.15.5-Linux-x86_64.tar.gz
+            mv cmake-3.15.5-Linux-x86_64 $HOME/cmake
+            export PATH=$HOME/cmake/:$HOME/cmake/bin:$PATH
+            ;;
+        esac
+        ;;
+    windows)
+        ## from https://docs.travis-ci.com/user/reference/windows/#how-do-i-use-msys2
+        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+        choco uninstall -y mingw
+        choco upgrade --no-progress -y msys2
+        export msys2='cmd //C RefreshEnv.cmd '
+        export msys2+='& set MSYS=winsymlinks:nativestrict '
+        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+        export mingw="$msys2 -$MSYSTEM -full-path -here -c "\"\$@"\" --"
+        export msys2+=" -msys2 -c "\"\$@"\" --"
+        ## Install MSYS2 packages required by GNUstep
+        $msys2 pacman --sync --noconfirm --needed \
+            mingw-w64-$ARCH-gcc-objc \
+            make \
+            pkg-config \
+            libxml2-devel \
+            libxslt-devel \
+            libffi-devel \
+            libgnutls-devel \
+            icu-devel \
+            mingw-w64-$ARCH-pkg-config \
+            mingw-w64-$ARCH-libxml2 \
+            mingw-w64-$ARCH-libxslt \
+            mingw-w64-$ARCH-libffi \
+            mingw-w64-$ARCH-gnutls \
+            mingw-w64-$ARCH-icu \
+        ##
+        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+        export PATH=/C/tools/msys64/$MSYSTEM/bin:$PATH
+        ## disable conversion to native-form paths when configuring GNUstep Make in travis-deps.sh
+        ## https://www.msys2.org/wiki/Porting/#filesystem-namespaces
+        export MSYS2_ARG_CONV_EXCL="--prefix="
+        ;;
+    esac
 install: ./travis-deps.sh
-before_script: >
-    export LIBRARY_PATH=$HOME/staging/lib:$HOME/staging/lib64:$LIBRARY_PATH;
-    export LD_LIBRARY_PATH=$HOME/staging/lib:$HOME/staging/lib64:$LD_LIBRARY_PATH;
-    if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ];
-    then
-      export CPATH=$HOME/staging/include;
-    else
-      export CPATH=/usr/lib/gcc/x86_64-linux-gnu/4.8/include;
-    fi;
-    export PATH=$HOME/staging/bin:$PATH;
-    export GNUSTEP_MAKEFILES=$HOME/staging/share/GNUstep/Makefiles;
-    . $HOME/staging/share/GNUstep/Makefiles/GNUstep.sh;
-script: >
-    ./configure $BASE_ABI || (cat config.log && false);
-    make && make install && make check || (cat Tests/tests.log && false);
+before_script: |
+    case $TRAVIS_OS_NAME in
+    linux)
+        DEP_ROOT=$HOME/staging
+        export PATH=$DEP_ROOT/bin:$PATH
+        ;;
+    windows)
+        DEP_ROOT=/c/staging
+        setx -m PATH "C:\staging;%PATH%"
+        ;;
+    esac
+    export LIBRARY_PATH=$DEP_ROOT/lib:$DEP_ROOT/lib64:$LIBRARY_PATH
+    export LD_LIBRARY_PATH=$DEP_ROOT/lib:$DEP_ROOT/lib64:$LD_LIBRARY_PATH
+    case $LIBRARY_COMBO in
+    gnu-gnu-gnu)
+        export CPATH=/usr/lib/gcc/x86_64-linux-gnu/4.8/include
+        ;;
+    ng-gnu-gnu)
+        export CPATH=$DEP_ROOT/include
+        ;;
+    esac
+    export GNUSTEP_MAKEFILES=$DEP_ROOT/share/GNUstep/Makefiles
+    . $GNUSTEP_MAKEFILES/GNUstep.sh
+script:
+    # configure and make need to be executed via MinGW shell on Windows ($mingw is undefined on Linux)
+    - $mingw ./configure $BASE_ABI || (cat config.log && false)
+    - $mingw make && $mingw make install && $mingw make check || (cat Tests/tests.log && false)
+
+# set up packages cache (currently used on Windows only)
+before_cache: |
+    case $TRAVIS_OS_NAME in
+    windows)
+        # https://unix.stackexchange.com/a/137322/107554
+        $msys2 pacman --sync --clean --noconfirm
+        ;;
+    esac
+cache:
+    directories:
+        - $HOME/AppData/Local/Temp/chocolatey
+        - /C/tools/msys64

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,14 @@
 	* Source/NSUserDefaults.m:
 	Store NSNumber instead of NSString for NSUserDefaults -setBool:forKey:.
 
+2020-05-23  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/GNUstepBase/GSConfig.h.in,
+	* Source/GSNetwork.h,
+	* Source/win32/GSFileHandle.m,
+	* config/config.reuseaddr.c:
+	Include winsock2.h before windows.h, as required by MSYS2/MinGW-w64.
+
 2020-05-14  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSException.h:

--- a/Headers/Foundation/NSException.h
+++ b/Headers/Foundation/NSException.h
@@ -59,7 +59,9 @@
  * implementation of longjmp in mingw-w64  sometimes crashes in msvcrt.dll
  * but the builtin version provided by gcc seems to work.
  */
+#undef	setjmp
 #define	setjmp(X)	__builtin_setjmp(X)
+#undef	longjmp
 #define	longjmp(X,Y)	__builtin_longjmp(X,Y)
 #endif
 

--- a/Headers/GNUstepBase/GSConfig.h.in
+++ b/Headers/GNUstepBase/GSConfig.h.in
@@ -306,13 +306,8 @@ typedef	struct {
 #define WINVER Windows2000
 #endif
 
-#if defined(__WIN64__)
 #include <winsock2.h>
 #include <windows.h>
-#else
-#include <windows.h>
-#include <winsock2.h>
-#endif
 
 #undef __OBJC_BOOL
 #undef  BOOL

--- a/Source/GSNetwork.h
+++ b/Source/GSNetwork.h
@@ -40,12 +40,8 @@
 
 #if     defined(_WIN32)
 
-#if     defined(__WIN64__)
 #include <winsock2.h>
-#endif
-
 #include <io.h>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 #include <wininet.h>
 #if     !defined(EAFNOSUPPORT)

--- a/Source/win32/GSFileHandle.m
+++ b/Source/win32/GSFileHandle.m
@@ -22,14 +22,8 @@
    Boston, MA 02111 USA.
    */
 
-#if	defined(__WIN64__)
 #include <winsock2.h>
 #include <windows.h>
-#else
-/* mingw32 wants winsock2.h before windows.h */
-#include <windows.h>
-#include <winsock2.h>
-#endif
 
 #include "common.h"
 #define	EXPOSE_NSFileHandle_IVARS	1

--- a/config/config.reuseaddr.c
+++ b/config/config.reuseaddr.c
@@ -6,8 +6,8 @@
   notice and this notice are preserved.
 */
 #if defined(__MINGW32__) || defined(__MINGW64__)
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #else
 #include <time.h>
 #include <sys/time.h>

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -3,7 +3,15 @@
 set -ex
 
 DEP_SRC=$HOME/dependency_source/
-DEP_ROOT=$HOME/staging
+
+case $TRAVIS_OS_NAME in
+linux)
+    DEP_ROOT=$HOME/staging
+    ;;
+windows)
+    DEP_ROOT=/c/staging
+    ;;
+esac
 
 install_gnustep_make() {
     cd $DEP_SRC
@@ -15,9 +23,9 @@ install_gnustep_make() {
     else
         WITH_RUNTIME_ABI=""
     fi
-    ./configure --prefix=$DEP_ROOT --with-library-combo=$LIBRARY_COMBO $WITH_RUNTIME_ABI
-    make install
-    echo Objective-C build flags: `$HOME/staging/bin/gnustep-config --objc-flags`
+    $mingw ./configure --prefix=$DEP_ROOT --with-library-combo=$LIBRARY_COMBO $WITH_RUNTIME_ABI
+    $mingw make install
+    echo Objective-C build flags: `$DEP_ROOT/bin/gnustep-config --objc-flags`
 }
 
 install_ng_runtime() {
@@ -33,7 +41,12 @@ install_ng_runtime() {
     export CC="clang"
     export CXX="clang++"
     export CXXFLAGS="-std=c++11"
-    cmake -DTESTS=off -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGNUSTEP_INSTALL_TYPE=NONE -DCMAKE_INSTALL_PREFIX:PATH=$DEP_ROOT ../
+    cmake \
+      -DTESTS=off \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DGNUSTEP_INSTALL_TYPE=NONE \
+      -DCMAKE_INSTALL_PREFIX:PATH=$DEP_ROOT \
+      ../
     make install
 }
 
@@ -48,7 +61,14 @@ install_libdispatch() {
     export LIBRARY_PATH=$DEP_ROOT/lib;
     export LD_LIBRARY_PATH=$DEP_ROOT/lib:$LD_LIBRARY_PATH;
     export CPATH=$DEP_ROOT/include;
-    cmake -DBUILD_TESTING=off -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging -DINSTALL_PRIVATE_HEADERS=1 -DBlocksRuntime_INCLUDE_DIR=$DEP_ROOT/include -DBlocksRuntime_LIBRARIES=$DEP_ROOT/lib/libobjc.so ../
+    cmake \
+      -DBUILD_TESTING=off \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_INSTALL_PREFIX:PATH=$DEP_ROOT \
+      -DINSTALL_PRIVATE_HEADERS=1 \
+      -DBlocksRuntime_INCLUDE_DIR=$DEP_ROOT/include \
+      -DBlocksRuntime_LIBRARIES=$DEP_ROOT/lib/libobjc.so \
+      ../
     make install
 }
 


### PR DESCRIPTION
This adds Windows as a CI target using MinGW-w64 by following these instructions:
https://docs.travis-ci.com/user/reference/windows/#how-do-i-use-msys2

The required packages are taken from the [MSYS2 instructions](http://wiki.gnustep.org/index.php/Installation_MSYS2), with the addition of packages for ICU.

The current status is:
* 64-bit target:
  * builds [successfully](https://travis-ci.org/github/gnustep/libs-base/jobs/687727959#L6167) (albeit with many more warnings than on Unices)
  * running the tests [fails](https://travis-ci.org/github/gnustep/libs-base/jobs/687727959#L6403), but I’m not sure why
* 32-bit target [fails building](https://travis-ci.org/github/gnustep/libs-base/jobs/687727958#L1196)

I’m not sure about the amount of work required to get tests working and 32-bit builds to compile, but I’d appreciate any feedback.

(As a side note, for some reason chaining commands like `make && make install && make check` does not seem to work with the MSYS wrapper, so I’m running make/install/check as separate steps, which means that subsequent steps are still executed even if previous steps fail.)

I’ve currently marked the Windows targets so that they are allowed to fail without failing the whole CI-run, so this could already be merged as is. This would at least allows to verify progress towards getting Windows to work on both architectures and including tests.

This also reworks CI setup to list build matrix explicitly with names.