### PR TITLE
Android assets improvements to support directories

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-05-20  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSBundle.m: Extend NSBundle resources support to handle
+	directories in Android assets.
+	* Source/NSFileManager.m: Fix NSFileManager -isReadableFileAtPath:
+	to also support directories in Android assets.
+
 2020-05-14  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSException.h:

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -2228,6 +2228,22 @@ IF_NO_GC(
 	}
     }
 
+#ifdef __ANDROID__
+  /* Android: check for directory resources by passing file path as subpath,
+   * as AAssetDir and thereby NSDirectoryEnumerator doesn't list directories
+   */
+  subPath = subPath ? [subPath stringByAppendingPathComponent: file] : file;
+  pathlist = [[self _bundleResourcePathsWithRootPath: rootPath
+    subPath: subPath localization: nil] objectEnumerator];
+  while ((path = [pathlist nextObject]) != nil)
+    {
+      if (YES == [mgr isReadableFileAtPath: path])
+        {
+          return path;
+        }
+    }
+#endif /* __ANDROID__ */
+
   return nil;
 }
 

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -1806,8 +1806,8 @@ static NSStringEncoding	defaultEncoding;
 	{
 #ifdef __ANDROID__
           /* Android: try using asset manager if path is in
-	   * main bundle resources
-	   */
+           * main bundle resources
+           */
           AAsset *asset = [NSBundle assetForPath: path];
           if (asset)
 	    {
@@ -1877,11 +1877,20 @@ static NSStringEncoding	defaultEncoding;
 	}
 
 #ifdef __ANDROID__
-        // Android: try using asset manager if path is in main bundle resources
+        /* Android: try using asset manager if path is in
+         * main bundle resources
+         */
         AAsset *asset = [NSBundle assetForPath: path];
         if (asset)
 	  {
 	    AAsset_close(asset);
+	    return YES;
+	  }
+
+        AAssetDir *assetDir = [NSBundle assetDirForPath: path];
+        if (assetDir)
+	  {
+	    AAssetDir_close(assetDir);
 	    return YES;
 	  }
 #endif


### PR DESCRIPTION
Fixes:
* `-[NSBundle pathForResource:ofType:]` not finding directories in Android assets.
* `-[NSFileManager isReadableFileAtPath:]` always returning NO for directories in Android assets.