### PR TITLE
Store NSNumber instead of NSString for NSUserDefaults -setBool:forKey:.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-05-25  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSUserDefaults.m:
+	Store NSNumber instead of NSString for NSUserDefaults -setBool:forKey:.
+
 2020-05-14  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSException.h:

--- a/Source/NSUserDefaults.m
+++ b/Source/NSUserDefaults.m
@@ -1420,14 +1420,9 @@ newLanguages(NSArray *oldNames)
 
 - (void) setBool: (BOOL)value forKey: (NSString*)defaultName
 {
-  if (value == YES)
-    {
-      [self setObject: @"YES" forKey: defaultName];
-    }
-  else
-    {
-      [self setObject: @"NO" forKey: defaultName];
-    }
+  NSNumber	*n = [NSNumberClass numberWithBool: value];
+
+  [self setObject: n forKey: defaultName];
 }
 
 - (void) setDouble: (double)value forKey: (NSString*)defaultName

--- a/Tests/base/NSUserDefaults/general.m
+++ b/Tests/base/NSUserDefaults/general.m
@@ -1,6 +1,8 @@
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSNotification.h>
 #import <Foundation/NSUserDefaults.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
 #import "ObjectTesting.h"
 
 @interface      Observer : NSObject
@@ -40,26 +42,38 @@ int main()
   [defs setBool: YES forKey: @"Test Suite Bool"];
   PASS([defs boolForKey: @"Test Suite Bool"],
        "NSUserDefaults can set/get a BOOL");
+  PASS([[defs objectForKey: @"Test Suite Bool"] isKindOfClass:[NSNumber class]],
+       "NSUserDefaults returns NSNumber for a BOOL");
 
   PASS_EQUAL([obs count], @"1", "setting a boolean causes notification");
 
   [defs setInteger: 34 forKey: @"Test Suite Int"];
   PASS([defs integerForKey: @"Test Suite Int"] == 34,
        "NSUserDefaults can set/get an int");
+  PASS([[defs objectForKey: @"Test Suite Int"] isKindOfClass:[NSNumber class]],
+       "NSUserDefaults returns NSNumber for an int");
 
   PASS_EQUAL([obs count], @"2", "setting an integer causes notification");
 
   [defs setObject: @"SetString" forKey: @"Test Suite Str"];
   PASS([[defs stringForKey: @"Test Suite Str"] isEqual: @"SetString"],
        "NSUserDefaults can set/get a string");
-  
+  PASS([[defs objectForKey: @"Test Suite Str"] isKindOfClass:[NSString class]],
+       "NSUserDefaults returns NSString for a string");
+
+  PASS_EQUAL([obs count], @"3", "setting a string causes notification");
+
   [defs removeObjectForKey: @"Test Suite Bool"];
   PASS(nil == [defs objectForKey: @"Test Suite Bool"],
        "NSUserDefaults can use -removeObjectForKey: to remove a bool");
 
+  PASS_EQUAL([obs count], @"4", "removing a key causes notification");
+
   [defs setObject: nil forKey: @"Test Suite Int"];
   PASS(nil == [defs objectForKey: @"Test Suite Int"],
        "NSUserDefaults can use -setObject:forKey: to remove an int");
+
+  PASS_EQUAL([obs count], @"5", "setting nil object causes notification");
 
   [arp release]; arp = nil;
   return 0;


### PR DESCRIPTION
Changes `-[NSUserDefaults setBool:forKey:]` to store a bool NSNumber instead of a YES/NO string.

I am not sure why a string was used here, but this seems more correct, and it should make no difference when reading the value via `-[NSUserDefaults boolForKey:]` or `[[NSUserDefaults objectForKey:X] boolValue]`.

We had a code path that was observing NSUserDefaults and was expecting the new value to be an NSNumber (which is the case on Apple platforms).