### PR TITLE
Fix optional NSFilePresenter methods not being declared as optional.

### DIFF
--- a/Headers/Foundation/NSFilePresenter.h
+++ b/Headers/Foundation/NSFilePresenter.h
@@ -39,11 +39,16 @@ DEFINE_BLOCK_TYPE(GSFilePresentedItemChangesWithCompletionHandler, void, NSError
 
 @protocol NSFilePresenter <NSObject>
 
-// @required
 - (NSURL *) presentedItemURL;
 - (NSOperationQueue *) presentedItemOperationQueue;
 
-// @optional
+#if GS_PROTOCOLS_HAVE_OPTIONAL
+@optional
+#else
+@end
+@interface NSObject (NSFilePresenter)
+#endif
+
 - (NSURL *) primaryPresentedItemURL;
 - (NSString *) observedPresentedItemUbiquityAttributes;
 


### PR DESCRIPTION
Also removed `@required` as I think protocol methods are required by default.