### PR TITLE
Fix replacing existing value in a weak objects map table

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-06-05  Frederik Seiffert <frederik@algoriddim.com>
+
+        * Tests/base/NSMapTable/weakObjects.m,
+        * Source/NSConcreteMapTable.m:
+        Add test for and fix replacing an existing value in a weak objects map
+        table.
+
 2020-05-25  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSUserDefaults.m:

--- a/Source/NSConcreteMapTable.m
+++ b/Source/NSConcreteMapTable.m
@@ -1392,7 +1392,7 @@ const NSMapTableValueCallBacks NSOwnedPointerMapValueCallBacks =
       if (GSI_MAP_READ_VALUE(self, &node->value).obj != anObject)
 	{
           GSI_MAP_RELEASE_VAL(self, node->value);
-          node->value.obj = anObject;
+          GSI_MAP_WRITE_VAL(self, &node->value, (GSIMapVal)anObject);
           GSI_MAP_RETAIN_VAL(self, node->value);
 	  version++;
 	}

--- a/Tests/base/NSMapTable/weakObjects.m
+++ b/Tests/base/NSMapTable/weakObjects.m
@@ -19,9 +19,14 @@ int main()
 
   NSAutoreleasePool *arp2 = [NSAutoreleasePool new];
 
-  id testObj = [[[NSObject alloc] init] autorelease];
-  [mapTable setObject:testObj forKey:@"test"];
-  PASS([mapTable objectForKey:@"test"] != nil, "Table retains active weak reference");
+  id testObj1 = [[[NSObject alloc] init] autorelease];
+  id testObj2 = [[[NSObject alloc] init] autorelease];
+  
+  [mapTable setObject:testObj1 forKey:@"test"];
+  PASS([mapTable objectForKey:@"test"] == testObj1, "Table retains first active weak reference");
+  
+  [mapTable setObject:testObj2 forKey:@"test"];
+  PASS([mapTable objectForKey:@"test"] == testObj2, "Table retains second active weak reference");
 
   [arp2 release]; arp2 = nil;
 


### PR DESCRIPTION
Replacing an existing value in a hash table was setting the pointer before calling `pointerFunctionsAssign()`. In the case of weak objects, this meant that the pointer was already the new value before `objc_storeWeak()` was called, causing the weak pointer to not be updated correctly.