### PR TITLE
Msys fix

### DIFF
--- a/Headers/GNUstepBase/GSConfig.h.in
+++ b/Headers/GNUstepBase/GSConfig.h.in
@@ -306,8 +306,18 @@ typedef	struct {
 #define WINVER Windows2000
 #endif
 
+// Trick to distinguish between MSYS/MinGW and MSYS2/MinGW32, the latter defines
+// __MINGW32_MAJOR_VERSION and __MINGW32_MINOR_VERSION for compatibility
+// but to a lower version than older MSYS/MinGW, but not the compound version
+//
+#if defined(__MINGW32_VERSION)
+#define __USE_W32_SOCKETS
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <winsock2.h>
 #include <windows.h>
+#endif
 
 #undef __OBJC_BOOL
 #undef  BOOL

--- a/Source/win32/GSFileHandle.m
+++ b/Source/win32/GSFileHandle.m
@@ -22,9 +22,6 @@
    Boston, MA 02111 USA.
    */
 
-#include <winsock2.h>
-#include <windows.h>
-
 #include "common.h"
 #define	EXPOSE_NSFileHandle_IVARS	1
 #define	EXPOSE_GSFileHandle_IVARS	1


### PR DESCRIPTION
Support both old MinGW1 als current MinGW2-32 and MINGW2-64

Clean up another header of "windows hacks" and centralize ifdef's.