### PR TITLE
Fix MSYS2-32

### DIFF
--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -785,6 +785,9 @@
 /* Define to 1 if you have the <windows.h> header file. */
 #undef HAVE_WINDOWS_H
 
+/* Define to 1 if you have the <ws2tcpip.h> header file. */
+#undef HAVE_WS2TCPIP_H
+
 /* Define to 1 if you have the <zlib.h> header file. */
 #undef HAVE_ZLIB_H
 

--- a/Source/GSSocketStream.m
+++ b/Source/GSSocketStream.m
@@ -61,10 +61,10 @@
   #endif // HAVE_WS2TCPIP_H
 
   #if !defined(HAVE_INET_NTOP)
-  extern const char *inet_ntop(int, const void *, char *, size_t);
+  extern const char* WSAAPI inet_ntop(int, const void *, char *, size_t);
   #endif
   #if !defined(HAVE_INET_NTOP)
-  extern int inet_pton(int , const char *, void *);
+  extern int WSAAPI inet_pton(int , const char *, void *);
   #endif
 
   #define	OPTLEN	int

--- a/Source/GSSocketStream.m
+++ b/Source/GSSocketStream.m
@@ -56,12 +56,21 @@
 #endif
 
 #ifdef _WIN32
-extern const char *inet_ntop(int, const void *, char *, size_t);
-extern int inet_pton(int , const char *, void *);
-#define	OPTLEN	int
-#else
-#define	OPTLEN	socklen_t
-#endif
+  #ifdef HAVE_WS2TCPIP_H
+  #include <ws2tcpip.h>
+  #endif // HAVE_WS2TCPIP_H
+
+  #if !defined(HAVE_INET_NTOP)
+  extern const char *inet_ntop(int, const void *, char *, size_t);
+  #endif
+  #if !defined(HAVE_INET_NTOP)
+  extern int inet_pton(int , const char *, void *);
+  #endif
+
+  #define	OPTLEN	int
+#else  // _WIN32
+  #define	OPTLEN	socklen_t
+#endif // _WIN32
 
 unsigned
 GSPrivateSockaddrLength(struct sockaddr *addr)

--- a/Source/NSHost.m
+++ b/Source/NSHost.m
@@ -43,10 +43,10 @@
 #include <ws2tcpip.h>
 #endif // HAVE_WS2TCPIP_H
 #if !defined(HAVE_INET_NTOP)
-extern const char *inet_ntop(int, const void *, char *, size_t);
+extern const char* WSAAPI inet_ntop(int, const void *, char *, size_t);
 #endif
 #if !defined(HAVE_INET_NTOP)
-extern int inet_pton(int , const char *, void *);
+extern int WSAAPI inet_pton(int , const char *, void *);
 #endif
 #else /* !_WIN32 */
 #include <netdb.h>

--- a/Source/NSHost.m
+++ b/Source/NSHost.m
@@ -39,17 +39,22 @@
 #import "Foundation/NSCoder.h"
 
 #if defined(_WIN32)
-#include <winsock2.h>
+#ifdef HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
+#endif // HAVE_WS2TCPIP_H
+#if !defined(HAVE_INET_NTOP)
 extern const char *inet_ntop(int, const void *, char *, size_t);
+#endif
+#if !defined(HAVE_INET_NTOP)
 extern int inet_pton(int , const char *, void *);
-#else
+#endif
+#else /* !_WIN32 */
 #include <netdb.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#endif /* !_WIN32*/
+#endif /* !_WIN32 */
 
 #ifndef	INADDR_NONE
 #define	INADDR_NONE	-1

--- a/Source/inet_ntop.m
+++ b/Source/inet_ntop.m
@@ -56,11 +56,8 @@ static  __attribute__((unused)) const char *inet_ntop6(const u_char *src, char *
  *      Paul Vixie, 1996.
  */
 const char *
-inet_ntop(af, src, dst, size)
-        int af;
-        const void *src;
-        char *dst;
-        size_t size;
+WSAAPI
+inet_ntop(int af, const void *src, char *dst, size_t size)
 {
         switch (af) {
         case AF_INET:

--- a/Source/inet_ntop.m
+++ b/Source/inet_ntop.m
@@ -39,6 +39,11 @@
 #define INT16SZ     2    /* for systems without 16-bit ints */
 #endif
 
+#ifndef WSAAPI
+#define WSAAPI
+#endif
+
+
 /*
  * WARNING: Don't even consider trying to compile this on a system where
  * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.

--- a/Source/inet_pton.m
+++ b/Source/inet_pton.m
@@ -41,6 +41,11 @@
 #include <arpa/nameser.h>
 #endif
 
+#ifndef WSAAPI
+#define WSAAPI
+#endif
+
+
 /*
  * WARNING: Don't even consider trying to compile this on a system where
  * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.

--- a/Source/inet_pton.m
+++ b/Source/inet_pton.m
@@ -63,6 +63,7 @@ static int	inet_pton6(const char *src, uint8_t *dst);
  *	Paul Vixie, 1996.
  */
 int
+WSAAPI
 inet_pton(int af, const char *src, void *dst)
 {
 

--- a/Tools/gdomap.c
+++ b/Tools/gdomap.c
@@ -511,8 +511,8 @@ delRInfo(int s)
   if (i == _rInfoCount)
     {
       snprintf(ebuf, sizeof(ebuf),
-	"%s requested unallocated RInfo struct (socket %d)",
-	__FUNCTION__, s);
+	"%s requested unallocated RInfo struct (socket %ld)",
+	__FUNCTION__, (long int)s);
       gdomap_log(LOG_ERR);
       return;
     }
@@ -585,8 +585,8 @@ delWInfo(int s)
   if (i == _wInfoCount)
     {
       snprintf(ebuf, sizeof(ebuf),
-	"%s requested unallocated WInfo struct (socket %d)",
-	__FUNCTION__, s);
+	"%s requested unallocated WInfo struct (socket %ld)",
+	__FUNCTION__, (long int)s);
       gdomap_log(LOG_ERR);
       return;
     }

--- a/configure
+++ b/configure
@@ -9721,6 +9721,18 @@ fi
 # These used by GSFileHandle.m and distributed objects
 # On some systems we need -lnsl ... so check for that case.
 #--------------------------------------------------------------------
+for ac_header in ws2tcpip.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "ws2tcpip.h" "ac_cv_header_ws2tcpip_h" "$ac_includes_default"
+if test "x$ac_cv_header_ws2tcpip_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_WS2TCPIP_H 1
+_ACEOF
+
+fi
+
+done
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing inet_ntop" >&5
 $as_echo_n "checking for library containing inet_ntop... " >&6; }
 if ${ac_cv_search_inet_ntop+:} false; then :
@@ -9745,7 +9757,7 @@ return inet_ntop ();
   return 0;
 }
 _ACEOF
-for ac_lib in '' nsl; do
+for ac_lib in '' nsl Ws2_32; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else

--- a/configure.ac
+++ b/configure.ac
@@ -2497,7 +2497,8 @@ AC_SUBST(DEFINE_UINTPTR_T)
 # These used by GSFileHandle.m and distributed objects
 # On some systems we need -lnsl ... so check for that case.
 #--------------------------------------------------------------------
-AC_SEARCH_LIBS([inet_ntop],[nsl])
+AC_CHECK_HEADERS(ws2tcpip.h)
+AC_SEARCH_LIBS([inet_ntop],[nsl Ws2_32])
 AC_CHECK_FUNCS(gethostbyaddr_r inet_aton inet_pton inet_ntop sigaction)
 
 USE_ZLIB=0


### PR DESCRIPTION
after some discussion with Fred and Frederick and several local test, I come up with this.
Although it is a mystery (the whole cause is that in 32bit MSYS2, inet_ntop is not found in the same library where it is found in 64bit version, so we need a replacement.

Thus I created a replacement which does not clash and works better. If we can in future make the configure check better, then fine.
This pull-request should make #34 obsolete too and concentrate on why URL stuff times out (now coherently in 32bit and 64bit MSYS2).