### PR TITLE
Don't return from _setLocaleIdentifier: if my->cal is NULL

### DIFF
--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -210,7 +210,7 @@ static NSRecursiveLock *classLock = nil;
 
 - (void) _setLocaleIdentifier: (NSString *) identifier
 {
-  if ([identifier isEqualToString: my->localeID])
+  if (my->cal != NULL && [identifier isEqualToString: my->localeID])
     {
       return;
     }


### PR DESCRIPTION
Add a check for my->cal being non-NULL to _setLocaleIdentifier to
prevent faulty initialization of NSCalendar* using ICU.

Due to a quirk of some environments (like my weird system), a locale
isn't necessarily going to be a non-empty value. When this happens, the
locale ID ends up being an empty string, for which isEqualToString:nil
returns true. So, following from this, when _setLocaleIdentifier: is
sent as part of initWithCalendarIdentifier:, isEqualToString:nil returns
true and my->cal remains NULL, because it returns early.

Later on, in NSCalendar/basic.m tests, this causes a segfault because
ucal_equivalentTo is called with two NULL pointers. This happens
because my->cal is not initialized.

So, to ensure my->cal is initialized, check that it's not NULL before
checking if an early return is possible from _setLocaleIdentifier:.