### PR TITLE
Fix possible deadlock when becoming multi-threaded.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-07-06  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSThread.m: Fix possible deadlock when becoming multi-
+	threaded.
+
 2020-06-14 Gregory John Casamento <greg.casamento@gmail.com>
 
 	* Headers/Foundation/NSKeyedArchiver.h

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -775,7 +775,6 @@ gnustep_base_thread_callback(void)
       pthread_mutex_lock(&threadLock);
       if (entered_multi_threaded_state == NO)
 	{
-	  ENTER_POOL
 	  /*
 	   * For apple compatibility ... and to make things easier for
 	   * code called indirectly within a will-become-multi-threaded
@@ -783,6 +782,12 @@ gnustep_base_thread_callback(void)
 	   * threaded BEFORE sending the notifications.
 	   */
 	  entered_multi_threaded_state = YES;
+	  /*
+	   * Enter pool after setting flag, because -[NSAutoreleasePool
+	   * allocWithZone:] calls GSCurrentThread(), which may end up
+	   * calling this function, which would cause a deadlock.
+	   */
+	  ENTER_POOL
 	  NS_DURING
 	    {
 	      [GSPerformHolder class];	// Force initialization


### PR DESCRIPTION
Fixes a possible recursion and deadlock from `gnustep_base_thread_callback()` when setting up the autorelease pool inside the thread lock, as `-[NSAutoreleasePool allocWithZone:]` calls `GSCurrentThread()`, which may end up calling `GSRegisterCurrentThread()` and thereby `gnustep_base_thread_callback()` in some circumstances.