### PR TITLE
Improve NSLog output on Android.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-07-08  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSLog.m,
+	* Source/NSProcessInfo.m: Improve NSLog output on Android.
+	We now always set -GSLogSyslog, as stdout/stderr is not available on
+	Android. Also fixes log output containing extraneous date/time.
+
 2020-07-06  Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSThread.m: Fix possible deadlock when becoming multi-

--- a/Source/NSLog.m
+++ b/Source/NSLog.m
@@ -181,10 +181,8 @@ _NSLog_standard_printf_handler(NSString* message)
 #else
 
 #if	defined(HAVE_SYSLOG)
-#ifndef __ANDROID__ // always use syslog on Android (no stdout/stderr)
   if (GSPrivateDefaultsFlag(GSLogSyslog) == YES
     || write(_NSLogDescriptor, buf, len) != (int)len)
-#endif
     {
       null_terminated_buf = malloc(sizeof (char) * (len + 1));
       strncpy (null_terminated_buf, buf, len);

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -1602,7 +1602,10 @@ GSInitializeProcessAndroid(JNIEnv *env, jobject context)
   // initialize process
   [procLock lock];
   fallbackInitialisation = YES;
-  char *argv[] = { arg0 };
+  char *argv[] = {
+    arg0,
+    "-GSLogSyslog", "YES" // use syslog (available via logcat) instead of stdout/stderr (not available on Android)
+  };
   _gnu_process_args(sizeof(argv)/sizeof(char *), argv, NULL);
   [procLock unlock];
 


### PR DESCRIPTION
Always set GSLogSyslog flag on Android instead of using #ifdefs. This enables other checks for this flag (e.g. not logging date/time to syslog) that were previously inactive on Android.

This is an improvement over #43.