### PR TITLE
Don't log current thread if its identical to private thread ID.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2020-07-08  Frederik Seiffert <frederik@algoriddim.com>
 
+	* Source/NSLog.m:
+	Don't log current thread if its identical to private thread ID.
+	This makes the log more succinct when GSLogThread is enabled and the
+	system doesn't provide an OS-level thread ID (i.e. GSPrivateThreadID()
+	returns GSCurrentThread()), which would previously cause the NSThread
+	pointer to be logged twice.
+
+2020-07-08  Frederik Seiffert <frederik@algoriddim.com>
+
 	* Source/NSLog.m,
 	* Source/NSProcessInfo.m: Improve NSLog output on Android.
 	We now always set -GSLogSyslog, as stdout/stderr is not available on

--- a/Source/NSLog.m
+++ b/Source/NSLog.m
@@ -335,6 +335,7 @@ NSLogv(NSString* format, va_list args)
   NSString              *message;
   NSString              *threadName = nil;
   NSThread              *t = nil;
+  NSUInteger            tid = GSPrivateThreadID();
   static int		pid = 0;
 
   if (_NSLog_printf_handler == NULL)
@@ -365,20 +366,20 @@ NSLogv(NSString* format, va_list args)
 #ifdef	HAVE_SYSLOG
   if (GSPrivateDefaultsFlag(GSLogSyslog) == YES)
     {
-      if (nil == t)
+      if (nil == t || (tid == t && nil == threadName))
         {
           [prefix appendFormat: @"[thread:%"PRIuPTR"] ",
-            GSPrivateThreadID()];
+            tid];
         }
       else if (nil == threadName)
         {
           [prefix appendFormat: @"[thread:%"PRIuPTR",%p] ",
-            GSPrivateThreadID(), t];
+            tid, t];
         }
       else
         {
           [prefix appendFormat: @"[thread:%"PRIuPTR",%@] ",
-            GSPrivateThreadID(), threadName];
+            tid, threadName];
         }
     }
   else
@@ -400,20 +401,20 @@ NSLogv(NSString* format, va_list args)
       [prefix appendString: cal];
       [prefix appendString: @" "];
       [prefix appendString: [[NSProcessInfo processInfo] processName]];
-      if (nil == t)
+      if (nil == t || (tid == t && nil == threadName))
         {
           [prefix appendFormat: @"[%d:%"PRIuPTR"] ",
-            pid, GSPrivateThreadID()];
+            pid, tid];
         }
       else if (nil == threadName)
         {
           [prefix appendFormat: @"[%d:%"PRIuPTR",%p] ",
-            pid, GSPrivateThreadID(), t];
+            pid, tid, t];
         }
       else
         {
           [prefix appendFormat: @"[%d:%"PRIuPTR",%@] ",
-            pid, GSPrivateThreadID(), threadName];
+            pid, tid, threadName];
         }
     }
 


### PR DESCRIPTION
This makes the log more succinct when GSLogThread is enabled and the system doesn't provide an OS-level thread ID (i.e. GSPrivateThreadID() returns GSCurrentThread()), which would previously cause the NSThread pointer to be logged twice.