### PR TITLE
Fix compilation with ICU 68

### DIFF
--- a/Source/GSICUString.h
+++ b/Source/GSICUString.h
@@ -2,6 +2,17 @@
 #import <Foundation/NSException.h>
 #include <unicode/utext.h>
 
+/*
+ * Define TRUE/FALSE to be used with UBool parameters, as these are no longer
+ * defined in ICU as of ICU 68.
+ */
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
 /**
  * Initialises a UText structure with an NSString.  If txt is NULL, then this
  * allocates a new structure on the heap, otherwise it fills in the existing


### PR DESCRIPTION
ICU 68 no longer defines the `TRUE` and `FALSE` defines, as outlined in their updated [Coding Guidelines](https://github.com/unicode-org/icu/blob/master/docs/userguide/dev/codingguidelines.md#primitive-types). This causes building GNUstep with ICU 68 to fail.