### PR TITLE
Disable libcurl support when headers are not found

### DIFF
--- a/configure
+++ b/configure
@@ -13143,22 +13143,38 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use" >&5
 $as_echo "FAILED (version too old to use" >&6; }
   else
-    CURLCFLAGS=`$CURL_CONFIG --cflags`
-    CURLLIBS=`$CURL_CONFIG --libs`
-    CFLAGS="$CFLAGS $CURLCFLAGS"
-    LIBS="$LIBS $CURLLIBS"
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes ... version $curl_ver" >&5
 $as_echo "yes ... version $curl_ver" >&6; }
-    HAVE_LIBCURL=1
-    curl_all=yes
-    if test \( $curl_maj -eq 7 -a $curl_min -lt 56 \); then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: LOSS OF FUNCTIONALITY (version too old for SSL backend control)" >&5
+    for ac_header in curl/curl.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "curl/curl.h" "ac_cv_header_curl_curl_h" "$ac_includes_default"
+if test "x$ac_cv_header_curl_curl_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CURL_CURL_H 1
+_ACEOF
+ curl_ok=yes
+else
+  curl_ok=no
+fi
+
+done
+
+    if test "$curl_ok" = yes; then
+      HAVE_LIBCURL=1
+      CURLCFLAGS=`$CURL_CONFIG --cflags`
+      CURLLIBS=`$CURL_CONFIG --libs`
+      CFLAGS="$CFLAGS $CURLCFLAGS"
+      LIBS="$LIBS $CURLLIBS"
+      curl_all=yes
+      if test \( $curl_maj -eq 7 -a $curl_min -lt 56 \); then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: LOSS OF FUNCTIONALITY (version too old for SSL backend control)" >&5
 $as_echo "$as_me: WARNING: LOSS OF FUNCTIONALITY (version too old for SSL backend control)" >&2;}
-      curl_all=no
-    elif test \( $curl_maj -eq 7 -a $curl_min -lt 65 \); then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: LOSS OF FUNCTIONALITY (version too old for connection lifetime control)" >&5
+        curl_all=no
+      elif test \( $curl_maj -eq 7 -a $curl_min -lt 65 \); then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: LOSS OF FUNCTIONALITY (version too old for connection lifetime control)" >&5
 $as_echo "$as_me: WARNING: LOSS OF FUNCTIONALITY (version too old for connection lifetime control)" >&2;}
-      curl_all=no
+        curl_all=no
+      fi
     fi
   fi
 else
@@ -13223,22 +13239,6 @@ if test "x$ac_cv_lib_curl_curl_multi_perform" = xyes; then :
 else
   curl_ok=no
 fi
-
-fi
-if test $HAVE_LIBCURL = 1; then
-  for ac_header in curl/curl.h
-do :
-  ac_fn_c_check_header_mongrel "$LINENO" "curl/curl.h" "ac_cv_header_curl_curl_h" "$ac_includes_default"
-if test "x$ac_cv_header_curl_curl_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_CURL_CURL_H 1
-_ACEOF
- curl_ok=yes
-else
-  curl_ok=no
-fi
-
-done
 
 fi
 if test $HAVE_LIBCURL = 1; then

--- a/configure.ac
+++ b/configure.ac
@@ -3469,19 +3469,22 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null; then
   if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 49 \); then
     AC_MSG_RESULT([FAILED (version too old to use])
   else
-    CURLCFLAGS=`$CURL_CONFIG --cflags`
-    CURLLIBS=`$CURL_CONFIG --libs`
-    CFLAGS="$CFLAGS $CURLCFLAGS"
-    LIBS="$LIBS $CURLLIBS"
     AC_MSG_RESULT(yes ... version $curl_ver)
-    HAVE_LIBCURL=1
-    curl_all=yes
-    if test \( $curl_maj -eq 7 -a $curl_min -lt 56 \); then
-      AC_MSG_WARN([LOSS OF FUNCTIONALITY (version too old for SSL backend control)])
-      curl_all=no
-    elif test \( $curl_maj -eq 7 -a $curl_min -lt 65 \); then
-      AC_MSG_WARN([LOSS OF FUNCTIONALITY (version too old for connection lifetime control)])
-      curl_all=no
+    AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
+    if test "$curl_ok" = yes; then
+      HAVE_LIBCURL=1
+      CURLCFLAGS=`$CURL_CONFIG --cflags`
+      CURLLIBS=`$CURL_CONFIG --libs`
+      CFLAGS="$CFLAGS $CURLCFLAGS"
+      LIBS="$LIBS $CURLLIBS"
+      curl_all=yes
+      if test \( $curl_maj -eq 7 -a $curl_min -lt 56 \); then
+        AC_MSG_WARN([LOSS OF FUNCTIONALITY (version too old for SSL backend control)])
+        curl_all=no
+      elif test \( $curl_maj -eq 7 -a $curl_min -lt 65 \); then
+        AC_MSG_WARN([LOSS OF FUNCTIONALITY (version too old for connection lifetime control)])
+        curl_all=no
+      fi
     fi
   fi
 else
@@ -3501,9 +3504,6 @@ fi
 
 if test $HAVE_LIBCURL = 1; then
   AC_CHECK_LIB(curl, curl_multi_perform, curl_ok=yes, curl_ok=no)
-fi
-if test $HAVE_LIBCURL = 1; then
-  AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
 fi
 if test $HAVE_LIBCURL = 1; then
   AC_CHECK_DECL(CURLOPT_CONNECT_TO, curl_ok=yes, curl_ok=no,


### PR DESCRIPTION
This moves the check for `curl/curl.h` further up so that `HAVE_LIBCURL` is only enabled if both the library and the headers were found.

Fixes cross-compiling in an environment where the host has curl-config, but the target doesn’t have libcurl, e.g. when building for Android on a macOS host.

I’m no expert at Autoconf, so please let me know if there there’s better way to do this and I’m happy do change the patch.