### PR TITLE
Disable gdomap on Android

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-02-03 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Tools/GNUmakefile: disable gdomap on Android (unsupported).
+
 2021-02-02 Riccardo Mottola <rm@gnu.org>
 
 	* configure

--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -75,7 +75,9 @@ else
 TOOL_NAME = autogsdoc cvtenc gdnc gspath defaults pl plmerge plutil \
 		plparse sfparse pldes plget plser pl2link xmlparse HTMLLinker
 ifneq ($(GNUSTEP_TARGET_OS), windows)
+ifneq ($(GNUSTEP_TARGET_OS), linux-android)
 CTOOL_NAME = gdomap
+endif
 endif
 
 SUBPROJECTS = make_strings


### PR DESCRIPTION
gdomap doesn’t compile when building for Android.

This patch was previously done manually in tools-android.