### PR TITLE
Disable gdomap for all Android ABIs.

### DIFF
--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -74,8 +74,10 @@ TOOL_NAME = autogsdoc cvtenc plmerge sfparse xmlparse
 else
 TOOL_NAME = autogsdoc cvtenc gdnc gspath defaults pl plmerge plutil \
 		plparse sfparse pldes plget plser pl2link xmlparse HTMLLinker
+# gdomap is currently not supported on Windows MSVC or Android (which
+# can be either "linux-android" or "linux-androideabi")
 ifneq ($(GNUSTEP_TARGET_OS), windows)
-ifneq ($(GNUSTEP_TARGET_OS), linux-android)
+ifneq ($(findstring android, $(GNUSTEP_TARGET_OS)), android)
 CTOOL_NAME = gdomap
 endif
 endif


### PR DESCRIPTION
#169 was not working for all ABIs, as target OS can be either "linux-android" or "linux-androideabi" (when building for armeabi-v7a).