### PR TITLE
Export objc_enumerationMutation() in public header

### DIFF
--- a/Headers/Foundation/NSEnumerator.h
+++ b/Headers/Foundation/NSEnumerator.h
@@ -57,6 +57,11 @@ GS_EXPORT_CLASS
 - (GS_GENERIC_TYPE(IterT)) nextObject;
 @end
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+GS_EXPORT void objc_enumerationMutation(id);
+#pragma GCC diagnostic pop
+
 #if	defined(__cplusplus)
 }
 #endif

--- a/Source/GSFastEnumeration.h
+++ b/Source/GSFastEnumeration.h
@@ -1,9 +1,4 @@
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
-GS_EXPORT void objc_enumerationMutation(id);
-#pragma GCC diagnostic pop
-
 #ifdef __clang__
 #define FOR_IN(type, var, collection) \
   for (type var in collection)\

--- a/Source/NSEnumerator.m
+++ b/Source/NSEnumerator.m
@@ -102,6 +102,7 @@
  * objc_enumerationMutation() is called whenever a collection mutates in the
  * middle of fast enumeration.
  */
+GS_DECLARE
 void objc_enumerationMutation(id obj)
 {
   [NSException raise: NSGenericException 


### PR DESCRIPTION
Fixes linker error on Windows, as I didn’t realize that the previous declaration in GSFastEnumeration.h was not public, and therefore didn't expose the dllspec attributes.