### PR TITLE
Add support for libobjc2 runtime in NSObject on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2021-03-27 Frederik Seiffert <frederik@algoriddim.com>
 
+	* Headers/GNUstepBase/GSVersionMacros.h:
+	Add GS_IMPORT macro resolving to dllimport annonation on Windows.
+	* Source/NSObject.m:
+	Add support for libobjc2 runtime on Windows.
+
+2021-03-27 Frederik Seiffert <frederik@algoriddim.com>
+
 	* Headers/Foundation/NSConnection.h:
 	* Source/Additions/GSMime.m:
 	* Source/Additions/NSDebug+GNUstepBase.m:

--- a/Headers/GNUstepBase/GSVersionMacros.h
+++ b/Headers/GNUstepBase/GSVersionMacros.h
@@ -386,10 +386,12 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
    */
 #  define GS_EXPORT_CLASS
 #  define GS_EXPORT  extern
+#  define GS_IMPORT  __declspec(dllimport)
 #  define GS_DECLARE
 # else
 #  define GS_EXPORT_CLASS  __declspec(dllexport)
 #  define GS_EXPORT  extern __declspec(dllexport)
+#  define GS_IMPORT  __declspec(dllimport)
 #  define GS_DECLARE __declspec(dllexport)
 # endif
 #else
@@ -399,6 +401,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
 # else
 #  define GS_EXPORT_CLASS  __declspec(dllimport)
 # endif
+#  define GS_IMPORT  __declspec(dllimport)
 #  define GS_EXPORT  extern __declspec(dllimport)
 #  define GS_DECLARE __declspec(dllimport)
 #endif
@@ -407,6 +410,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
 
 #  define GS_EXPORT_CLASS
 #  define GS_EXPORT extern
+#  define GS_IMPORT
 #  define GS_DECLARE
 
 #endif

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -87,11 +87,9 @@
 /* platforms which do not support weak */
 #if defined (__WIN32)
 #define WEAK_ATTRIBUTE
-#undef SUPPORT_WEAK
 #else
 /* all platforms which support weak */
 #define WEAK_ATTRIBUTE __attribute__((weak))
-#define SUPPORT_WEAK 1
 #endif
 
 /* When this is `YES', every call to release/autorelease, checks to
@@ -474,16 +472,16 @@ typedef	struct obj_layout *obj;
  * runtime.  When linked against an older version, we will use our internal
  * versions.
  */
-WEAK_ATTRIBUTE
+GS_IMPORT WEAK_ATTRIBUTE
 BOOL objc_release_fast_no_destroy_np(id anObject);
 
-WEAK_ATTRIBUTE
+GS_IMPORT WEAK_ATTRIBUTE
 void objc_release_fast_np(id anObject);
 
-WEAK_ATTRIBUTE
+GS_IMPORT WEAK_ATTRIBUTE
 size_t object_getRetainCount_np(id anObject);
 
-WEAK_ATTRIBUTE
+GS_IMPORT WEAK_ATTRIBUTE
 id objc_retain_fast_np(id anObject);
 
 
@@ -548,7 +546,7 @@ static BOOL objc_release_fast_no_destroy_internal(id anObject)
 
 static BOOL release_fast_no_destroy(id anObject)
 {
-#ifdef SUPPORT_WEAK
+#ifdef __GNUSTEP_RUNTIME__
   if (objc_release_fast_no_destroy_np)
     {
       return objc_release_fast_no_destroy_np(anObject);
@@ -570,7 +568,7 @@ static void objc_release_fast_np_internal(id anObject)
 
 static void release_fast(id anObject)
 {
-#ifdef SUPPORT_WEAK
+#ifdef __GNUSTEP_RUNTIME__
   if (objc_release_fast_np)
     {
       objc_release_fast_np(anObject);
@@ -601,7 +599,7 @@ size_t object_getRetainCount_np_internal(id anObject)
 
 size_t getRetainCount(id anObject)
 {
-#ifdef SUPPORT_WEAK
+#ifdef __GNUSTEP_RUNTIME__
   if (object_getRetainCount_np)
     {
       return object_getRetainCount_np(anObject);
@@ -698,7 +696,7 @@ static id objc_retain_fast_np_internal(id anObject)
 
 static id retain_fast(id anObject)
 {
-#ifdef SUPPORT_WEAK
+#ifdef __GNUSTEP_RUNTIME__
   if (objc_retain_fast_np)
     {
       return objc_retain_fast_np(anObject);


### PR DESCRIPTION
Windows doesn’t support resolving weak symbols, so we need to guard the retain/release libobjc2 support on `__GNUSTEP_RUNTIME__` instead of `SUPPORT_WEAK`. And we also need a `__declspec(dllimport)` annotation on the libobjc2 functions so they are resolved from the DLL.

The new `GS_IMPORT` macro should be added in other places too where we declare externally defined functions.