### PR TITLE
Fix lookup of string encodings with high numeric values in encoding table

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-06-17 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/Additions/Unicode.m:
+	Fix lookup of string encodings with high numeric values in
+	encoding table when they are interpreted as negative numbers
+	for some platforms/compilers (pertains
+	NSUTF16*EndianStringEncoding and NSUTF32*StringEncoding).
+
 2021-06-03 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/GSTLS.h: New session ivar for I/O handle.

--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -364,10 +364,10 @@ EntryForEncoding(NSStringEncoding enc)
 {
   struct _strenc_ *entry = 0;
 
-  if (enc > 0)
+  if (enc != 0)
     {
       GSSetupEncodingTable();
-      if (enc <= encTableSize)
+      if (enc > 0 && enc <= encTableSize)
 	{
 	  entry = encodingTable[enc];
 	}


### PR DESCRIPTION
Using Clang MSVC on 64-bit Windows was interpreting the constants in the `NSStringEncoding` enum as `int` (which is [according to the C standard](https://stackoverflow.com/q/366017/1534401)), which meant that the `NSUTF16*EndianStringEncoding` and `NSUTF32*StringEncoding` were interpreted as negative numbers due to their topmost bit being set, which caused the `EntryForEncoding()` function to always fail for these constants.

I’m not sure in how far this affects other compilers/platforms, although it seems like it might affect all.