### PR TITLE
Rename first argument to NSDebug[MF]LLog to make it easier to understand

### DIFF
--- a/Documentation/manual/ExceptionHandling.texi
+++ b/Documentation/manual/ExceptionHandling.texi
@@ -385,12 +385,12 @@ behaviors:
 Basic debug log function already discussed.
 @item NSDebugLog(format, args,...)
 Equivalent to @code{NSDebugLLog} with key ``dflt'' (for default).
-@item NSDebugMLLog(level, format, args,...)
+@item NSDebugMLLog(key, format, args,...)
 Equivalent to @code{NSDebugLLog} but includes information on which method the
 logging call was made from in the message.
 @item NSDebugMLog(format, args,...)
 Same, but use 'dflt' log key.
-@item NSDebugFLLog(level, format, args,...)
+@item NSDebugFLLog(key, format, args,...)
 As @code{NSDebugMLLog} but includes information on a function rather than a
 method.
 @item NSDebugFLog(format, args,...)


### PR DESCRIPTION
The argument was named "level" in the docs but it's preferable if it's called "key" because then you can see the parallels with `NSDebugLLog`.