### PR TITLE
Reword NSDebug*LLog "level" argument to "key"

### DIFF
--- a/Headers/GNUstepBase/NSDebug+GNUstepBase.h
+++ b/Headers/GNUstepBase/NSDebug+GNUstepBase.h
@@ -63,7 +63,7 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
 /**
    <p>NSDebugLLog() is the basic debug logging macro used to display
    log messages using NSLog(), if debug logging was enabled at compile
-   time and the appropriate logging level was set at runtime.
+   time and the appropriate logging key was set at runtime.
    </p>
    <p>Debug logging which can be enabled/disabled by defining GSDIAGNOSE
    when compiling and also setting values in the mutable set which
@@ -71,7 +71,7 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
    unless diagnose=no is specified in the make arguments.
    </p>
    <p>NSProcess initialises a set of strings that are the names of active
-   debug levels using the '--GNU-Debug=...' command line argument.
+   debug keys using the '--GNU-Debug=...' command line argument.
    Each command-line argument of that form is removed from
    <code>NSProcessInfo</code>'s list of arguments and the variable part
    (...) is added to the set.
@@ -83,23 +83,23 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
    You can of course supply multiple '--GNU-Debug=...' arguments to
    output debug information on more than one thing.
    </p>
-   <p>NSUserDefaults also adds debug levels from the array given by the
-   GNU-Debug key ... but these values will not take effect until the
+   <p>NSUserDefaults also adds debug keys from the array given by the
+   GNU-Debug default ... but these values will not take effect until the
    +standardUserDefaults method is called ... so they are useless for
    debugging NSUserDefaults itself or for debugging any code executed
    before the defaults system is used.
    </p>
    <p>To embed debug logging in your code you use the NSDebugLLog() or
    NSDebugLog() macro.  NSDebugLog() is just NSDebugLLog() with the debug
-   level set to 'dflt'.  So, to activate debug statements that use
+   key set to 'dflt'.  So, to activate debug statements that use
    NSDebugLog(), you supply the '--GNU-Debug=dflt' argument to your program.
    </p>
-   <p>You can also change the active debug levels under your programs control -
+   <p>You can also change the active debug keys under your programs control -
    NSProcessInfo has a [-debugSet] method that returns the mutable set that
-   contains the active debug levels - your program can modify this set.
+   contains the active debug keys - your program can modify this set.
    </p>
-   <p>Two debug levels have a special effect - 'dflt' is the level used for
-   debug logs statements where no debug level is specified, and 'NoWarn'
+   <p>Two debug keys have a special effect - 'dflt' is the key used for
+   debug logs statements where no debug key is specified, and 'NoWarn'
    is used to *disable* warning messages.
    </p>
    <p>As a convenience, there are four more logging macros you can use -
@@ -109,13 +109,13 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
    and either function or class/method in which the message was generated.
    </p>
  */
-#define NSDebugLLog(level, format, args...) \
-  do { if (GSDebugSet(level) == YES) \
+#define NSDebugLLog(key, format, args...) \
+  do { if (GSDebugSet(key) == YES) \
     NSLog(format , ## args); } while (0)
 
 /**
- * This macro is a shorthand for NSDebugLLog() using then default debug
- * level ... 'dflt'
+ * This macro is a shorthand for NSDebugLLog() using the default debug
+ * key ... 'dflt'
  */
 #define NSDebugLog(format, args...) \
   do { if (GSDebugSet(@"dflt") == YES) \
@@ -125,16 +125,16 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
  * This macro is like NSDebugLLog() but includes the name and location
  * of the function in which the macro is used as part of the log output.
  */
-#define NSDebugFLLog(level, format, args...) \
-  do { if (GSDebugSet(level) == YES) { \
+#define NSDebugFLLog(key, format, args...) \
+  do { if (GSDebugSet(key) == YES) { \
     NSString *s = GSDebugFunctionMsg( \
       __PRETTY_FUNCTION__, __FILE__, __LINE__, \
       [NSString stringWithFormat: format, ##args]); \
     NSLog(@"%@", s); }} while (0)
 
 /**
- * This macro is a shorthand for NSDebugFLLog() using then default debug
- * level ... 'dflt'
+ * This macro is a shorthand for NSDebugFLLog() using the default debug
+ * key ... 'dflt'
  */
 #define NSDebugFLog(format, args...) \
   do { if (GSDebugSet(@"dflt") == YES) { \
@@ -147,8 +147,8 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
  * This macro is like NSDebugLLog() but includes the name and location
  * of the <em>method</em> in which the macro is used as part of the log output.
  */
-#define NSDebugMLLog(level, format, args...) \
-  do { if (GSDebugSet(level) == YES) { \
+#define NSDebugMLLog(key, format, args...) \
+  do { if (GSDebugSet(key) == YES) { \
     NSString *s = GSDebugMethodMsg( \
       self, _cmd, __FILE__, __LINE__, \
       [NSString stringWithFormat: format, ##args]); \
@@ -156,7 +156,7 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
 
 /**
  * This macro is a shorthand for NSDebugMLLog() using then default debug
- * level ... 'dflt'
+ * key ... 'dflt'
  */
 #define NSDebugMLog(format, args...) \
   do { if (GSDebugSet(@"dflt") == YES) { \
@@ -188,11 +188,11 @@ GS_EXPORT NSString*	GSDebugMethodMsg(id obj, SEL sel, const char *file,
     GSDebugAllocationTagRecordedObject(object, tag); } while (0)
 
 #else
-#define NSDebugLLog(level, format, args...)
+#define NSDebugLLog(key, format, args...)
 #define NSDebugLog(format, args...)
-#define NSDebugFLLog(level, format, args...)
+#define NSDebugFLLog(key, format, args...)
 #define NSDebugFLog(format, args...)
-#define NSDebugMLLog(level, format, args...)
+#define NSDebugMLLog(key, format, args...)
 #define NSDebugMLog(format, args...)
 #define NSDebugFRLog(object, msg)
 #define NSDebugMRLog(object, msg)


### PR DESCRIPTION
The motivation is that these are more like keys to specific logging domain names, not log levels. If you think of log levels, you usually think of the syslog style debug/info/warn/error levels where enabling logs at any one level implies enabling those at all levels above. Our log keys aren't ordered in that way. The texinfo docs were inconsistent in using "level" and "key" as the argument and we already changed that to use "key" throughout" this change makes the header and auto docs consistent.