### PR TITLE
Fix possible heap corruption when converting to NSNonLossyASCIIStringEncoding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-07-02 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/Additions/Unicode.m:
+	Fix possible heap corruption when converting to
+	NSNonLossyASCIIStringEncoding.
+
 2021-06-19 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/Foundation/Port.h:

--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -2242,12 +2242,22 @@ GSFromUnicode(unsigned char **dst, unsigned int *size, const unichar *src,
                         }
                       else
                         {
-                          dpos += sprintf((char*)&ptr[dpos], "\\%03o", u);
+                          char octchars[] = "01234567";
+                          ptr[dpos++] = '\\';
+                          ptr[dpos++] = octchars[(u >> 6) & 7];
+                          ptr[dpos++] = octchars[(u >> 3) & 7];
+                          ptr[dpos++] = octchars[u & 7];
                         }
                     }
                   else
                     {
-                      dpos += sprintf((char*)&ptr[dpos], "\\u%04x", u);
+                      char hexchars[] = "0123456789abcdef";
+                      ptr[dpos++] = '\\';
+                      ptr[dpos++] = 'u';
+                      ptr[dpos++] = hexchars[(u >> 12) & 0xF];
+                      ptr[dpos++] = hexchars[(u >> 8) & 0xF];
+                      ptr[dpos++] = hexchars[(u >> 4) & 0xF];
+                      ptr[dpos++] = hexchars[u & 0xF];
                     }
                 }
             }


### PR DESCRIPTION
Possible heap corruption in `GSFromUnicode()` because `sprintf()` always appends NULL terminator, which is written past the end of the `ptr` buffer for the last character in the string.

Was exposed by existing `NSString/basic` test when checking for "latin1 in lossy encoding", as the last character of that string is running into the affected code. When running tests using the Windows MSVC toolchain this was showing a "HEAP CORRUPTION DETECTED" error.