### PR TITLE
Fix possible memory corruption in string handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-07-16 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/GSICUString.h:
+	* Source/GSICUString.m:
+	Fix possible memory corruption in string handling that occured
+	primarily when using NSRegularExpression with strings longer than
+	16 characters.
+
 2021-07-02 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/Additions/Unicode.m:

--- a/Source/GSICUString.h
+++ b/Source/GSICUString.h
@@ -80,13 +80,13 @@ static inline void free_string(unichar **buf)
  *
  * Buffers created in this way are exception safe when using native exceptions.
  */
-#define TEMP_BUFFER(name, size)\
+#define TEMP_BUFFER(name, length)\
   __attribute__((cleanup(free_string))) unichar *name ##_onheap = 0;\
-  unichar name ## _onstack[64 / sizeof(unichar)];\
+  unichar name ## _onstack[64];\
   unichar *name = name ## _onstack;\
-  if (size > 64)\
+  if (length > 64)\
     {\
-      name ## _onheap = malloc(size);\
+      name ## _onheap = malloc(length * sizeof(unichar));\
       name = name ## _onheap;\
     }
 

--- a/Source/GSICUString.m
+++ b/Source/GSICUString.m
@@ -487,13 +487,13 @@ UTextInitWithNSString(UText *txt, NSString *str)
 - (void) replaceCharactersInRange: (NSRange)r
                        withString: (NSString*)aString
 {
-  NSUInteger	size = [aString length];
+  NSUInteger	length = [aString length];
   UErrorCode	status = 0;
 
-  TEMP_BUFFER(buffer, size);
-  [aString getCharacters: buffer range: NSMakeRange(0, size)];
+  TEMP_BUFFER(buffer, length);
+  [aString getCharacters: buffer range: NSMakeRange(0, length)];
 
-  utext_replace(&txt, r.location, r.location + r.length, buffer, size, &status);
+  utext_replace(&txt, r.location, r.location + r.length, buffer, length, &status);
 }
 
 - (void) dealloc


### PR DESCRIPTION
The `TEMP_BUFFER()` macro was making some incorrect calculations. This is used extensively in `NSRegularExpression` and also in `GSUTextMutableString` (which however doesn’t seem to be used).

With `sizeof(unichar) == 2`, the `onstack` variable was initialized for 32 bytes (= 16 characters), while the `onheap` variable (used with more than 64 characters) was only half the size needed.

Note that the macro is always called with the string length and not the buffer size, so I renamed the variable from `size` to `length`.

Note that this increases the `onstack` variable to be 64 bytes, as noted in the macro’s comment. We could also keep this 32 bytes if preferred.