### PR TITLE
Add support for using ICU DLL from Windows 10 when using MSVC toolchain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+2021-07-29 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/GNUstepBase/config.h.in:
+	* Source/Additions/Unicode.m:
+	* Source/GSICUString.h:
+	* Source/NSCalendar.m:
+	* Source/NSDateFormatter.m:
+	* Source/NSLocale.m:
+	* Source/NSNumberFormatter.m:
+	* Source/NSPredicate.m:
+	* Source/NSRegularExpression.m:
+	* Source/NSString.m:
+	* Source/NSTimeZone.m:
+	* configure:
+	* configure.ac:
+	Add support for using ICU DLL from Windows 10.
+
 2021-07-29 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSTimeZone.m:

--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -344,6 +344,9 @@
 /* Define if you have this function */
 #undef HAVE_ICONV
 
+/* Define to 1 if you have the <icu.h> header file. */
+#undef HAVE_ICU_H
+
 /* Define to 1 if you have the `inet_aton' function. */
 #undef HAVE_INET_ATON
 
@@ -771,6 +774,9 @@
 
 /* Define to 1 if you have the <unicode/ustring.h> header file. */
 #undef HAVE_UNICODE_USTRING_H
+
+/* Define to 1 if you have the <unicode/utext.h> header file. */
+#undef HAVE_UNICODE_UTEXT_H
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H

--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -56,6 +56,9 @@
 #if     defined(HAVE_UNICODE_UCNV_H)
 #include <unicode/ucnv.h>
 #endif
+#if     defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 
 typedef struct {unichar from; unsigned char to;} _ucc_;

--- a/Source/GSICUString.h
+++ b/Source/GSICUString.h
@@ -1,6 +1,16 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSException.h>
+
+#if defined(HAVE_UNICODE_UTEXT_H)
 #include <unicode/utext.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+// icu.h in Windows 10 is missing a declaration of UTEXT_MAGIC
+#ifndef UTEXT_MAGIC
+#define UTEXT_MAGIC 0x345ad82c
+#endif
+#endif
 
 /*
  * Define TRUE/FALSE to be used with UBool parameters, as these are no longer

--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -40,6 +40,8 @@
 #include <unicode/ucal.h>
 #include <unicode/uvernum.h>
 #undef id
+#elif defined(HAVE_ICU_H)
+#include <icu.h>
 #endif
 
 

--- a/Source/NSDateFormatter.m
+++ b/Source/NSDateFormatter.m
@@ -54,6 +54,9 @@
 #if defined(HAVE_UNICODE_UDATPG_H)
 #include <unicode/udatpg.h>
 #endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 
 
@@ -1034,7 +1037,7 @@ symbolRange(NSInteger symbol, int *from)
       unichar           *value;
       NSString          *str;
       NSZone            *z = [self zone];
-      UErrorCode        err = U_ERROR_LIMIT;
+      UErrorCode        err = U_ZERO_ERROR;
       
       length
         = udat_getSymbols(internal->_formatter, symbol, idx, NULL, 0, &err);

--- a/Source/NSLocale.m
+++ b/Source/NSLocale.m
@@ -47,6 +47,9 @@
 #if	defined(HAVE_UNICODE_UCURR_H)
 # include <unicode/ucurr.h>
 #endif
+#if defined(HAVE_ICU_H)
+# include <icu.h>
+#endif
 
 
 

--- a/Source/NSNumberFormatter.m
+++ b/Source/NSNumberFormatter.m
@@ -66,6 +66,9 @@
 #if	defined(HAVE_UNICODE_UNUM_H)
 # include <unicode/unum.h>
 #endif
+#if defined(HAVE_ICU_H)
+# include <icu.h>
+#endif
 
 #define BUFFER_SIZE 1024
 

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -55,6 +55,9 @@
 #if     defined(HAVE_UNICODE_UREGEX_H)
 #include <unicode/uregex.h>
 #endif
+#if     defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 /* Object to represent the expression beign evaluated.
  */

--- a/Source/NSRegularExpression.m
+++ b/Source/NSRegularExpression.m
@@ -27,7 +27,12 @@
 #import "common.h"
 
 #if GS_USE_ICU == 1
-#include "unicode/uregex.h"
+#if defined(HAVE_UNICODE_UREGEX_H)
+#include <unicode/uregex.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 /* FIXME It would be nice to use autoconf for checking whether uregex_openUText
  * is defined.  However the naive check using AC_CHECK_FUNCS(uregex_openUText)

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -109,6 +109,9 @@
 #if     defined(HAVE_UNICODE_USEARCH_H)
 # include <unicode/usearch.h>
 #endif
+#if     defined(HAVE_ICU_H)
+# include <icu.h>
+#endif
 
 /* Create local inline versions of key functions for case-insensitive operations
  */

--- a/Source/NSTimeZone.m
+++ b/Source/NSTimeZone.m
@@ -121,6 +121,9 @@
 #include <unicode/ucal.h>
 #undef id
 #endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 /* Key for local time zone in user defaults. */
 #define LOCALDBKEY @"Local Time Zone"

--- a/configure
+++ b/configure
@@ -13197,7 +13197,70 @@ else
 fi
 
 
-if test "$enable_icu" = "yes"; then
+if test "x$enable_icu" = "xyes"; then :
+
+  case "$target_os" in
+    mingw*|windows)
+      # check for ICU bundled with Windows 10
+      for ac_header in icu.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "icu.h" "ac_cv_header_icu_h" "$ac_includes_default"
+if test "x$ac_cv_header_icu_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_ICU_H 1
+_ACEOF
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for udat_open in -licu" >&5
+$as_echo_n "checking for udat_open in -licu... " >&6; }
+if ${ac_cv_lib_icu_udat_open+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-licu  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char udat_open ();
+int
+main ()
+{
+return udat_open ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_icu_udat_open=yes
+else
+  ac_cv_lib_icu_udat_open=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_icu_udat_open" >&5
+$as_echo "$ac_cv_lib_icu_udat_open" >&6; }
+if test "x$ac_cv_lib_icu_udat_open" = xyes; then :
+  HAVE_ICU=1
+fi
+
+fi
+
+done
+
+      if test $HAVE_ICU = 1; then
+        ICU_LIBS=-licu
+        { $as_echo "$as_me:${as_lineno-$LINENO}: Using ICU DLL from Windows 10 (requires version 1903 or later)" >&5
+$as_echo "$as_me: Using ICU DLL from Windows 10 (requires version 1903 or later)" >&6;}
+      fi
+    ;;
+  esac
+  if test $HAVE_ICU = 0; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ICU" >&5
@@ -13257,39 +13320,18 @@ fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$ICU_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (icu-i18n > 49.0) were not met:
-
-$ICU_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables ICU_CFLAGS
-and ICU_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
+	HAVE_ICU=0
 elif test $pkg_failed = untried; then
      	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables ICU_CFLAGS
-and ICU_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
+	HAVE_ICU=0
 else
 	ICU_CFLAGS=$pkg_cv_ICU_CFLAGS
 	ICU_LIBS=$pkg_cv_ICU_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-fi
-  for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h
+      for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -13297,13 +13339,18 @@ if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
 #define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
 _ACEOF
-
+ HAVE_ICU=1
 fi
 
 done
 
+fi
+  fi
+  if test $HAVE_ICU = 0; then
+    as_fn_error $? "No useable ICU installation found" "$LINENO" 5
+  fi
   LIBS="$LIBS $ICU_LIBS"
-  HAVE_ICU=1
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3493,12 +3493,28 @@ AC_ARG_ENABLE(icu,
   [  --disable-icu			Disable International Components for Unicode],,
   enable_icu=yes)
 
-if test "$enable_icu" = "yes"; then
-  PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0])
-  AC_CHECK_HEADERS(unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h)
+AS_IF([test "x$enable_icu" = "xyes"], [
+  case "$target_os" in
+    mingw*|windows)
+      # check for ICU bundled with Windows 10
+      AC_CHECK_HEADERS([icu.h],
+        AC_CHECK_LIB(icu, udat_open, HAVE_ICU=1))
+      if test $HAVE_ICU = 1; then
+        ICU_LIBS=-licu
+        AC_MSG_NOTICE([Using ICU DLL from Windows 10 (requires version 1903 or later)])
+      fi
+    ;;
+  esac
+  if test $HAVE_ICU = 0; then
+    PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0], [
+      AC_CHECK_HEADERS([unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h],
+        HAVE_ICU=1)], [HAVE_ICU=0])
+  fi
+  if test $HAVE_ICU = 0; then
+    AC_MSG_ERROR([No useable ICU installation found])
+  fi
   LIBS="$LIBS $ICU_LIBS"
-  HAVE_ICU=1
-fi
+])
 AC_SUBST(HAVE_ICU)
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
As suggested by @davidchisnall in https://github.com/gnustep/tools-windows-msvc/issues/2, this PR adds support for using the [Windows-provided ICU libraries](https://docs.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-) when using the MSVC toolchain (I don’t think they can be used under MinGW). Using this requires Windows 10 version 1903 (May 2019 Update) or later.

The main change is in configure, where we now check for `icu.h` and `icu.dll` as a backup if the main check for ICU headers fails, plus using the merged `icu.h` that Windows provides instead of the individual `unicode/*.h` headers.

Also adds missing configure check for unicode/utext.h.