### PR TITLE
New NSURL initializers (macOS 10.11 initFileURLWithPath:relativeToURL:) and cleanup

### DIFF
--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -1,21 +1,21 @@
 /* NSURL.h - Class NSURL
    Copyright (C) 1999 Free Software Foundation, Inc.
-
+   
    Written by: 	Manuel Guesdon <mguesdon@sbuilders.com>
    Date:	Jan 1999
-
+   
    This file is part of the GNUstep Library.
-
+   
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
    License as published by the Free Software Foundation; either
    version 2 of the License, or (at your option) any later version.
-
+   
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Lesser General Public License for more details.
-
+   
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -24,16 +24,16 @@
 
 #ifndef __NSURL_h_GNUSTEP_BASE_INCLUDE
 #define __NSURL_h_GNUSTEP_BASE_INCLUDE
-#import <GNUstepBase/GSVersionMacros.h>
+#import	<GNUstepBase/GSVersionMacros.h>
 
-#import <Foundation/NSURLHandle.h>
+#import	<Foundation/NSURLHandle.h>
 #import <Foundation/NSRange.h>
 
-#if defined(__cplusplus)
+#if	defined(__cplusplus)
 extern "C" {
 #endif
 
-#if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
+#if	OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 
 @class NSError;
 @class NSNumber;
@@ -44,7 +44,7 @@ extern "C" {
 /**
  *  URL scheme constant for use with [NSURL-initWithScheme:host:path:].
  */
-GS_EXPORT NSString *const NSURLFileScheme;
+GS_EXPORT NSString* const NSURLFileScheme;
 
 /** URL Bookmark Resolution Options **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -69,46 +69,45 @@ enum
  * objects, but NSURL provides a simplified API wrapping these objects.
  */
 GS_EXPORT_CLASS
-@interface NSURL : NSObject <NSCoding, NSCopying, NSURLHandleClient>
+@interface NSURL: NSObject <NSCoding, NSCopying, NSURLHandleClient>
 {
-#if GS_EXPOSE(NSURL)
+#if	GS_EXPOSE(NSURL)
 @private
-  NSString *_urlString;
-  NSURL *   _baseURL;
-  void *    _clients;
-  void *    _data;
+  NSString	*_urlString;
+  NSURL		*_baseURL;
+  void		*_clients;
+  void		*_data;
 #endif
 }
-
+ 
 /**
  * Create and return a file URL with the supplied path.<br />
  * The value of aPath must be a valid filesystem path.<br />
  * Calls -initFileURLWithPath: which escapes characters in the
  * path where necessary.
  */
-+ (instancetype)fileURLWithPath:(NSString *)aPath;
++ (instancetype) fileURLWithPath: (NSString*)aPath;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
+/** Creates a file URL using a path built from components.
+ */
++ (instancetype) fileURLWithPathComponents: (NSArray*)components;
+#endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
-
-+ (instancetype)fileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir;
++ (instancetype) fileURLWithPath: (NSString*)aPath isDirectory: (BOOL)isDir;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
-+ (instancetype)fileURLWithPath:(NSString *)aPath
-	       isDirectory:(BOOL)isDir
-	     relativeToURL:(NSURL *)baseURL;
++ (instancetype) fileURLWithPath: (NSString *)aPath
+	                 isDirectory: (BOOL)isDir
+	               relativeToURL: (NSURL *)baseURL;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
 /** Create and return a file URL with the supplied path, relative to a base URL.
  */
-+ (instancetype)fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL;
-#endif
-
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-/** Creates a file URL using a path built from components.
- */
-+ (instancetype)fileURLWithPathComponents:(NSArray *)components;
++ (instancetype) fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL;
 #endif
 
 /**
@@ -117,13 +116,12 @@ GS_EXPORT_CLASS
  * conforming to the description (in RFC2396) of an absolute URL.<br />
  * Calls -initWithString:
  */
-+ (instancetype)URLWithString:(NSString *)aUrlString;
++ (instancetype) URLWithString: (NSString*)aUrlString;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-+ (instancetype)URLByResolvingAliasFileAtURL:(NSURL *)url
-				     options:
-				       (NSURLBookmarkResolutionOptions)options
-				       error:(NSError **)error;
++ (instancetype) URLByResolvingAliasFileAtURL: (NSURL*)url
+                                      options: (NSURLBookmarkResolutionOptions)options
+                                        error: (NSError**)error;
 #endif
 
 /**
@@ -132,8 +130,8 @@ GS_EXPORT_CLASS
  * conforming to the description (in RFC2396) of a relative URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-+ (instancetype)URLWithString:(NSString *)aUrlString
-		relativeToURL:(NSURL *)aBaseUrl;
++ (instancetype) URLWithString: (NSString*)aUrlString
+                 relativeToURL: (NSURL*)aBaseUrl;
 
 /**
  * Initialise as a file URL with the specified path (which must
@@ -144,9 +142,9 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype)initFileURLWithPath:(NSString *)aPath;
+- (instancetype) initFileURLWithPath: (NSString*)aPath;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5,GS_API_LATEST) 
 /**
  * Initialise as a file URL with the specified path (which must
  * be a valid path on the local filesystem).<br />
@@ -156,7 +154,8 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype)initFileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir;
+- (instancetype) initFileURLWithPath: (NSString*)aPath
+                         isDirectory: (BOOL)isDir;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
@@ -169,8 +168,8 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype)initFileURLWithPath:(NSString *)aPath
-		      relativeToURL:(NSURL *)baseURL;
+- (instancetype) initFileURLWithPath: (NSString *)aPath
+		               relativeToURL: (NSURL *)baseURL;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
@@ -183,9 +182,9 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype)initFileURLWithPath:(NSString *)aPath
-			isDirectory:(BOOL)isDir
-		      relativeToURL:(NSURL *)baseURL;
+- (instancetype) initFileURLWithPath: (NSString *)aPath
+			             isDirectory: (BOOL)isDir
+		               relativeToURL: (NSURL *)baseURL;
 #endif
 
 /**
@@ -199,15 +198,15 @@ GS_EXPORT_CLASS
  * Permits the 'aHost' part to contain 'username:password@host:port' or
  * 'host:port' in addition to a simple host name or address.
  */
-- (instancetype)initWithScheme:(NSString *)aScheme
-			  host:(NSString *)aHost
-			  path:(NSString *)aPath;
+- (instancetype) initWithScheme: (NSString*)aScheme
+                           host: (NSString*)aHost
+                           path: (NSString*)aPath;
 
 /**
  * Initialise as an absolute URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-- (instancetype)initWithString:(NSString *)aUrlString;
+- (instancetype) initWithString: (NSString*)aUrlString;
 
 /** <init />
  * Initialised using aUrlString and aBaseUrl.  The value of aBaseUrl
@@ -217,38 +216,38 @@ GS_EXPORT_CLASS
  * Parses an empty string as an empty path.<br />
  * If the string cannot be parsed the method returns nil.
  */
-- (instancetype)initWithString:(NSString *)aUrlString
-		 relativeToURL:(NSURL *)aBaseUrl;
+- (instancetype) initWithString: (NSString*)aUrlString
+                  relativeToURL: (NSURL*)aBaseUrl;
 
 #if GS_HAS_DECLARED_PROPERTIES
 @property (readonly, getter=isFileURL) BOOL fileURL;
 #else
-- (BOOL)isFileURL;
+- (BOOL) isFileURL;
 #endif
 
 /**
  * Returns the full string describing the receiver resolved against its base.
  */
-- (NSString *)absoluteString;
+- (NSString*) absoluteString;
 
 /**
  * If the receiver is an absolute URL, returns self.  Otherwise returns an
  * absolute URL referring to the same resource as the receiver.
  */
-- (NSURL *)absoluteURL;
+- (NSURL*) absoluteURL;
 
 /**
  * If the receiver is a relative URL, returns its base URL.<br />
  * Otherwise, returns nil.
  */
-- (NSURL *)baseURL;
+- (NSURL*) baseURL;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Attempts to load from the specified URL and provides an error
  * response if the data is unrachable.<br />
  * Returns YES on success, NO on failure.
  */
-- (BOOL)checkResourceIsReachableAndReturnError:(NSError **)error;
+- (BOOL) checkResourceIsReachableAndReturnError: (NSError **)error;
 #endif
 
 /**
@@ -257,7 +256,7 @@ GS_EXPORT_CLASS
  * The fragment is everything in the original URL string after a '#'<br />
  * File URLs do not have fragments.
  */
-- (NSString *)fragment;
+- (NSString*) fragment;
 
 /**
  * Returns the host portion of the receiver or nil if there is no
@@ -267,12 +266,12 @@ GS_EXPORT_CLASS
  * Returns IPv6 addresses <em>without</em> the enclosing square brackets
  * required (by RFC2732) in URL strings.
  */
-- (NSString *)host;
+- (NSString*) host;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Returns the last (rightmost) path component of the receiver.
  */
-- (NSString *)lastPathComponent;
+- (NSString*) lastPathComponent;
 #endif
 
 /**
@@ -297,8 +296,8 @@ GS_EXPORT_CLASS
  *   background load operation to operate!
  * </p>
  */
-- (void)loadResourceDataNotifyingClient:(id)client
-			     usingCache:(BOOL)shouldUseCache;
+- (void) loadResourceDataNotifyingClient: (id)client
+			      usingCache: (BOOL)shouldUseCache;
 
 /**
  * Returns the parameter portion of the receiver or nil if there is no
@@ -307,7 +306,7 @@ GS_EXPORT_CLASS
  * but before the query.<br />
  * File URLs do not have parameters.
  */
-- (NSString *)parameterString;
+- (NSString*) parameterString;
 
 /**
  * Returns the password portion of the receiver or nil if there is no
@@ -317,7 +316,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString *)password;
+- (NSString*) password;
 
 /**
  * Returns the path portion of the receiver.<br />
@@ -330,19 +329,19 @@ GS_EXPORT_CLASS
  * Also, this breaks strict conformance in that a URL of file scheme is
  * treated as having a path (contrary to RFCs)
  */
-- (NSString *)path;
+- (NSString*) path;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Returns thepath components of the receiver.<br />
  * See [NSString-pathComponents].
  */
-- (NSArray *)pathComponents;
+- (NSArray*) pathComponents;
 
 /** Returns the file extension (text after the rightmost dot in the path)
  * of the receiver.<br />
  * see [NSString-pathExtension].
  */
-- (NSString *)pathExtension;
+- (NSString*) pathExtension;
 #endif
 
 /**
@@ -351,13 +350,13 @@ GS_EXPORT_CLASS
  * Percent escape sequences in the user string are translated in GNUstep
  * but this appears to be broken in MacOS-X.
  */
-- (NSNumber *)port;
+- (NSNumber*) port;
 
 /**
  * Asks a URL handle to return the property for the specified key and
  * returns the result.
  */
-- (id)propertyForKey:(NSString *)propertyKey;
+- (id) propertyForKey: (NSString*)propertyKey;
 
 /**
  * Returns the query portion of the receiver or nil if there is no
@@ -366,20 +365,20 @@ GS_EXPORT_CLASS
  * but before the fragment.<br />
  * File URLs do not have queries.
  */
-- (NSString *)query;
+- (NSString*) query;
 
 /**
  * Returns the path of the receiver, without taking any base URL into account.
  * If the receiver is an absolute URL, -relativePath is the same as -path.<br />
  * Returns nil if there is no path specified for the URL.
  */
-- (NSString *)relativePath;
+- (NSString*) relativePath;
 
 /**
  * Returns the relative portion of the URL string.  If the receiver is not
  * a relative URL, this returns the same as absoluteString.
  */
-- (NSString *)relativeString;
+- (NSString*) relativeString;
 
 /**
  * Loads the resource data for the represented URL and returns the result.
@@ -387,93 +386,94 @@ GS_EXPORT_CLASS
  * an existing NSURLHandle can be used to provide the data, or if it should
  * be refetched.
  */
-- (NSData *)resourceDataUsingCache:(BOOL)shouldUseCache;
+- (NSData*) resourceDataUsingCache: (BOOL)shouldUseCache;
 
 /**
  * Returns the resource specifier of the URL ... the part which lies
  * after the scheme.
  */
-- (NSString *)resourceSpecifier;
+- (NSString*) resourceSpecifier;
 
 /**
  * Returns the scheme of the receiver.
  */
-- (NSString *)scheme;
+- (NSString*) scheme;
 
 /**
  * Calls [NSURLHandle-writeProperty:forKey:] to set the named property.
  */
-- (BOOL)setProperty:(id)property forKey:(NSString *)propertyKey;
+- (BOOL) setProperty: (id)property
+	      forKey: (NSString*)propertyKey;
 
 /**
  * Calls [NSURLHandle-writeData:] to write the specified data object
  * to the resource identified by the receiver URL.<br />
  * Returns the result.
  */
-- (BOOL)setResourceData:(NSData *)data;
+- (BOOL) setResourceData: (NSData*)data;
 
 /**
  * Returns a URL with '/./' and '/../' sequences resolved etc.
  */
-- (NSURL *)standardizedURL;
+- (NSURL*) standardizedURL;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Returns a URL formed by adding a path component to the path of the
  * receiver.<br />
  * See [NSString-stringByAppendingPathComponent:].
  */
-- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent;
+- (NSURL*) URLByAppendingPathComponent: (NSString*)pathComponent;
 
 /** Returns a URL formed by adding a path extension to the path of the
  * receiver.<br />
  * See [NSString-stringByAppendingPathExtension:].
  */
-- (NSURL *)URLByAppendingPathExtension:(NSString *)pathExtension;
+- (NSURL*) URLByAppendingPathExtension: (NSString*)pathExtension;
 
 /** Returns a URL formed by removing a path component from the path of the
  * receiver.<br />
  * See [NSString-stringByDeletingLastPathComponent].
  */
-- (NSURL *)URLByDeletingLastPathComponent;
+- (NSURL*) URLByDeletingLastPathComponent;
 
 /** Returns a URL formed by removing an extension from the path of the
  * receiver.<br />
  * See [NSString-stringByDeletingPathExtension].
  */
-- (NSURL *)URLByDeletingPathExtension;
+- (NSURL*) URLByDeletingPathExtension;
 
 /** Returns self unless the receiver is a file URL, in which case it returns
  * a URL formed by calling [NSString-stringByResolvingSymlinksInPath].
  */
-- (NSURL *)URLByResolvingSymlinksInPath;
+- (NSURL*) URLByResolvingSymlinksInPath;
 
 /** Returns self unless the receiver is a file URL, in which case it returns
  * a URL formed by calling [NSString-stringByStandardizingPath].
  */
-- (NSURL *)URLByStandardizingPath;
+- (NSURL*) URLByStandardizingPath;
 
 #endif
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST) 
 /** Returns a URL formed by adding a path component to the path of the
  * receiver, along with a trailing slash if the component is designated a
  * directory.<br />
  * See [NSString-stringByAppendingPathComponent:].
  */
-- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
-			   isDirectory:(BOOL)isDirectory;
+- (NSURL *) URLByAppendingPathComponent:(NSString *)pathComponent
+                            isDirectory:(BOOL)isDirectory;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-- (BOOL)isFileReferenceURL;
+- (BOOL) isFileReferenceURL;
 
-- (NSURL *)fileReferenceURL;
+- (NSURL *) fileReferenceURL;
 
-- (NSURL *)filePathURL;
+- (NSURL *) filePathURL;
 
-- (BOOL)getResourceValue:(id *)value
-		  forKey:(NSString *)key
-		   error:(NSError **)error;
+- (BOOL) getResourceValue: (id*)value 
+                   forKey: (NSString *)key 
+                    error: (NSError**)error;
 #endif
 /**
  * Returns an NSURLHandle instance which may be used to write data to the
@@ -481,7 +481,7 @@ GS_EXPORT_CLASS
  * The shouldUseCache flag indicates whether a cached handle may be returned
  * or a new one should be created.
  */
-- (NSURLHandle *)URLHandleUsingCache:(BOOL)shouldUseCache;
+- (NSURLHandle*)URLHandleUsingCache: (BOOL)shouldUseCache;
 
 /**
  * Returns the user portion of the receiver or nil if there is no
@@ -491,7 +491,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString *)user;
+- (NSString*) user;
 
 @end
 
@@ -501,151 +501,153 @@ GS_EXPORT_CLASS
  * Some data has become available.  Note that this does not mean that all data
  * has become available, only that a chunk of data has arrived.
  */
-- (void)URL:(NSURL *)sender resourceDataDidBecomeAvailable:(NSData *)newBytes;
+- (void) URL: (NSURL*)sender
+  resourceDataDidBecomeAvailable: (NSData*)newBytes;
 
 /** <override-dummy />
  * Loading of resource data is complete.
  */
-- (void)URLResourceDidFinishLoading:(NSURL *)sender;
+- (void) URLResourceDidFinishLoading: (NSURL*)sender;
 
 /** <override-dummy />
  * Loading of resource data was cancelled by programmatic request
  * (not an error).
  */
-- (void)URLResourceDidCancelLoading:(NSURL *)sender;
+- (void) URLResourceDidCancelLoading: (NSURL*)sender;
 
 /** <override-dummy />
  * Loading of resource data has failed, for given human-readable reason.
  */
-- (void)URL:(NSURL *)sender resourceDidFailLoadingWithReason:(NSString *)reason;
+- (void) URL: (NSURL*)sender
+  resourceDidFailLoadingWithReason: (NSString*)reason;
 @end
 
 /** URL Resource Value Constants **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLNameKey;
-GS_EXPORT NSString *const NSURLLocalizedNameKey;
-GS_EXPORT NSString *const NSURLIsRegularFileKey;
-GS_EXPORT NSString *const NSURLIsDirectoryKey;
-GS_EXPORT NSString *const NSURLIsSymbolicLinkKey;
-GS_EXPORT NSString *const NSURLIsVolumeKey;
-GS_EXPORT NSString *const NSURLIsPackageKey;
-GS_EXPORT NSString *const NSURLIsSystemImmutableKey;
-GS_EXPORT NSString *const NSURLIsUserImmutableKey;
-GS_EXPORT NSString *const NSURLIsHiddenKey;
-GS_EXPORT NSString *const NSURLHasHiddenExtensionKey;
-GS_EXPORT NSString *const NSURLCreationDateKey;
-GS_EXPORT NSString *const NSURLContentAccessDateKey;
-GS_EXPORT NSString *const NSURLContentModificationDateKey;
-GS_EXPORT NSString *const NSURLAttributeModificationDateKey;
-GS_EXPORT NSString *const NSURLLinkCountKey;
-GS_EXPORT NSString *const NSURLParentDirectoryURLKey;
-GS_EXPORT NSString *const NSURLVolumeURLKey;
-GS_EXPORT NSString *const NSURLTypeIdentifierKey;
-GS_EXPORT NSString *const NSURLLocalizedTypeDescriptionKey;
-GS_EXPORT NSString *const NSURLLabelNumberKey;
-GS_EXPORT NSString *const NSURLLabelColorKey;
-GS_EXPORT NSString *const NSURLLocalizedLabelKey;
-GS_EXPORT NSString *const NSURLEffectiveIconKey;
-GS_EXPORT NSString *const NSURLCustomIconKey;
-GS_EXPORT NSString *const NSURLFileSizeKey;
-GS_EXPORT NSString *const NSURLFileAllocatedSizeKey;
-GS_EXPORT NSString *const NSURLIsAliasFileKey;
-GS_EXPORT NSString *const NSURLVolumeLocalizedFormatDescriptionKey;
-GS_EXPORT NSString *const NSURLVolumeTotalCapacityKey;
-GS_EXPORT NSString *const NSURLVolumeAvailableCapacityKey;
-GS_EXPORT NSString *const NSURLVolumeResourceCountKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsPersistentIDsKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsSymbolicLinksKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsHardLinksKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsJournalingKey;
-GS_EXPORT NSString *const NSURLVolumeIsJournalingKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsSparseFilesKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsZeroRunsKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsCaseSensitiveNamesKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsCasePreservedNamesKey;
+GS_EXPORT NSString* const NSURLNameKey;
+GS_EXPORT NSString* const NSURLLocalizedNameKey;
+GS_EXPORT NSString* const NSURLIsRegularFileKey;
+GS_EXPORT NSString* const NSURLIsDirectoryKey;
+GS_EXPORT NSString* const NSURLIsSymbolicLinkKey;
+GS_EXPORT NSString* const NSURLIsVolumeKey;
+GS_EXPORT NSString* const NSURLIsPackageKey;
+GS_EXPORT NSString* const NSURLIsSystemImmutableKey;
+GS_EXPORT NSString* const NSURLIsUserImmutableKey;
+GS_EXPORT NSString* const NSURLIsHiddenKey;
+GS_EXPORT NSString* const NSURLHasHiddenExtensionKey;
+GS_EXPORT NSString* const NSURLCreationDateKey;
+GS_EXPORT NSString* const NSURLContentAccessDateKey;
+GS_EXPORT NSString* const NSURLContentModificationDateKey;
+GS_EXPORT NSString* const NSURLAttributeModificationDateKey;
+GS_EXPORT NSString* const NSURLLinkCountKey;
+GS_EXPORT NSString* const NSURLParentDirectoryURLKey;
+GS_EXPORT NSString* const NSURLVolumeURLKey;
+GS_EXPORT NSString* const NSURLTypeIdentifierKey;
+GS_EXPORT NSString* const NSURLLocalizedTypeDescriptionKey;
+GS_EXPORT NSString* const NSURLLabelNumberKey;
+GS_EXPORT NSString* const NSURLLabelColorKey;
+GS_EXPORT NSString* const NSURLLocalizedLabelKey;
+GS_EXPORT NSString* const NSURLEffectiveIconKey;
+GS_EXPORT NSString* const NSURLCustomIconKey;
+GS_EXPORT NSString* const NSURLFileSizeKey;
+GS_EXPORT NSString* const NSURLFileAllocatedSizeKey;
+GS_EXPORT NSString* const NSURLIsAliasFileKey;
+GS_EXPORT NSString* const NSURLVolumeLocalizedFormatDescriptionKey;
+GS_EXPORT NSString* const NSURLVolumeTotalCapacityKey;
+GS_EXPORT NSString* const NSURLVolumeAvailableCapacityKey;
+GS_EXPORT NSString* const NSURLVolumeResourceCountKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsPersistentIDsKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsSymbolicLinksKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsHardLinksKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsJournalingKey;
+GS_EXPORT NSString* const NSURLVolumeIsJournalingKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsSparseFilesKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsZeroRunsKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsCaseSensitiveNamesKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsCasePreservedNamesKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLFileResourceIdentifierKey;
-GS_EXPORT NSString *const NSURLVolumeIdentifierKey;
-GS_EXPORT NSString *const NSURLPreferredIOBlockSizeKey;
-GS_EXPORT NSString *const NSURLIsReadableKey;
-GS_EXPORT NSString *const NSURLIsWritableKey;
-GS_EXPORT NSString *const NSURLIsExecutableKey;
-GS_EXPORT NSString *const NSURLFileSecurityKey;
-GS_EXPORT NSString *const NSURLIsMountTriggerKey;
-GS_EXPORT NSString *const NSURLFileResourceTypeKey;
-GS_EXPORT NSString *const NSURLTotalFileSizeKey;
-GS_EXPORT NSString *const NSURLTotalFileAllocatedSizeKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsRootDirectoryDatesKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsVolumeSizesKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsRenamingKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsAdvisoryFileLockingKey;
-GS_EXPORT NSString *const NSURLVolumeSupportsExtendedSecurityKey;
-GS_EXPORT NSString *const NSURLVolumeIsBrowsableKey;
-GS_EXPORT NSString *const NSURLVolumeMaximumFileSizeKey;
-GS_EXPORT NSString *const NSURLVolumeIsEjectableKey;
-GS_EXPORT NSString *const NSURLVolumeIsRemovableKey;
-GS_EXPORT NSString *const NSURLVolumeIsInternalKey;
-GS_EXPORT NSString *const NSURLVolumeIsAutomountedKey;
-GS_EXPORT NSString *const NSURLVolumeIsLocalKey;
-GS_EXPORT NSString *const NSURLVolumeIsReadOnlyKey;
-GS_EXPORT NSString *const NSURLVolumeCreationDateKey;
-GS_EXPORT NSString *const NSURLVolumeURLForRemountingKey;
-GS_EXPORT NSString *const NSURLVolumeUUIDStringKey;
-GS_EXPORT NSString *const NSURLVolumeNameKey;
-GS_EXPORT NSString *const NSURLVolumeLocalizedNameKey;
-GS_EXPORT NSString *const NSURLIsUbiquitousItemKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemHasUnresolvedConflictsKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemIsDownloadingKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemIsUploadedKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemIsUploadingKey;
+GS_EXPORT NSString* const NSURLFileResourceIdentifierKey;
+GS_EXPORT NSString* const NSURLVolumeIdentifierKey;
+GS_EXPORT NSString* const NSURLPreferredIOBlockSizeKey;
+GS_EXPORT NSString* const NSURLIsReadableKey;
+GS_EXPORT NSString* const NSURLIsWritableKey;
+GS_EXPORT NSString* const NSURLIsExecutableKey;
+GS_EXPORT NSString* const NSURLFileSecurityKey;
+GS_EXPORT NSString* const NSURLIsMountTriggerKey;
+GS_EXPORT NSString* const NSURLFileResourceTypeKey;
+GS_EXPORT NSString* const NSURLTotalFileSizeKey;
+GS_EXPORT NSString* const NSURLTotalFileAllocatedSizeKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsRootDirectoryDatesKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsVolumeSizesKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsRenamingKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsAdvisoryFileLockingKey;
+GS_EXPORT NSString* const NSURLVolumeSupportsExtendedSecurityKey;
+GS_EXPORT NSString* const NSURLVolumeIsBrowsableKey;
+GS_EXPORT NSString* const NSURLVolumeMaximumFileSizeKey;
+GS_EXPORT NSString* const NSURLVolumeIsEjectableKey;
+GS_EXPORT NSString* const NSURLVolumeIsRemovableKey;
+GS_EXPORT NSString* const NSURLVolumeIsInternalKey;
+GS_EXPORT NSString* const NSURLVolumeIsAutomountedKey;
+GS_EXPORT NSString* const NSURLVolumeIsLocalKey;
+GS_EXPORT NSString* const NSURLVolumeIsReadOnlyKey;
+GS_EXPORT NSString* const NSURLVolumeCreationDateKey;
+GS_EXPORT NSString* const NSURLVolumeURLForRemountingKey;
+GS_EXPORT NSString* const NSURLVolumeUUIDStringKey;
+GS_EXPORT NSString* const NSURLVolumeNameKey;
+GS_EXPORT NSString* const NSURLVolumeLocalizedNameKey;
+GS_EXPORT NSString* const NSURLIsUbiquitousItemKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemHasUnresolvedConflictsKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemIsDownloadingKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemIsUploadedKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemIsUploadingKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLIsExcludedFromBackupKey;
-GS_EXPORT NSString *const NSURLPathKey;
+GS_EXPORT NSString* const NSURLIsExcludedFromBackupKey;
+GS_EXPORT NSString* const NSURLPathKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLTagNamesKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingErrorKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemUploadingErrorKey;
+GS_EXPORT NSString* const NSURLTagNamesKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingErrorKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemUploadingErrorKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLGenerationIdentifierKey;
-GS_EXPORT NSString *const NSURLDocumentIdentifierKey;
-GS_EXPORT NSString *const NSURLAddedToDirectoryDateKey;
-GS_EXPORT NSString *const NSURLQuarantinePropertiesKey;
-GS_EXPORT NSString *const NSThumbnail1024x1024SizeKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadRequestedKey;
-GS_EXPORT NSString *const NSURLUbiquitousItemContainerDisplayNameKey;
+GS_EXPORT NSString* const NSURLGenerationIdentifierKey;
+GS_EXPORT NSString* const NSURLDocumentIdentifierKey;
+GS_EXPORT NSString* const NSURLAddedToDirectoryDateKey;
+GS_EXPORT NSString* const NSURLQuarantinePropertiesKey;
+GS_EXPORT NSString* const NSThumbnail1024x1024SizeKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadRequestedKey;
+GS_EXPORT NSString* const NSURLUbiquitousItemContainerDisplayNameKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLIsApplicationKey;
-GS_EXPORT NSString *const NSURLApplicationIsScriptableKey;
+GS_EXPORT NSString* const NSURLIsApplicationKey;
+GS_EXPORT NSString* const NSURLApplicationIsScriptableKey;
 #endif
 
 /** Possible values for File Resource Type Key **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLFileResourceTypeNamedPipe;
-GS_EXPORT NSString *const NSURLFileResourceTypeCharacterSpecial;
-GS_EXPORT NSString *const NSURLFileResourceTypeDirectory;
-GS_EXPORT NSString *const NSURLFileResourceTypeBlockSpecial;
-GS_EXPORT NSString *const NSURLFileResourceTypeRegular;
-GS_EXPORT NSString *const NSURLFileResourceTypeSymbolicLink;
-GS_EXPORT NSString *const NSURLFileResourceTypeSocket;
-GS_EXPORT NSString *const NSURLFileResourceTypeUnknown;
+GS_EXPORT NSString* const NSURLFileResourceTypeNamedPipe;
+GS_EXPORT NSString* const NSURLFileResourceTypeCharacterSpecial;
+GS_EXPORT NSString* const NSURLFileResourceTypeDirectory;
+GS_EXPORT NSString* const NSURLFileResourceTypeBlockSpecial;
+GS_EXPORT NSString* const NSURLFileResourceTypeRegular;
+GS_EXPORT NSString* const NSURLFileResourceTypeSymbolicLink;
+GS_EXPORT NSString* const NSURLFileResourceTypeSocket;
+GS_EXPORT NSString* const NSURLFileResourceTypeUnknown;
 #endif
 
 /** Possible values for Ubiquitous Item Downloading Key **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9, GS_API_LATEST)
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusNotDownloaded;
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusDownloaded;
-GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusCurrent;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusNotDownloaded;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusDownloaded;
+GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusCurrent;
 #endif
 
-#endif /* GS_API_MACOSX */
+#endif	/* GS_API_MACOSX */
 
-#if !NO_GNUSTEP && !defined(GNUSTEP_BASE_INTERNAL)
+#if     !NO_GNUSTEP && !defined(GNUSTEP_BASE_INTERNAL)
 #import <GNUstepBase/NSURL+GNUstepBase.h>
 #endif
 
@@ -654,31 +656,32 @@ GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusCurrent;
 GS_EXPORT_CLASS
 @interface NSURLQueryItem : NSObject <NSCopying, NSCoding>
 {
-#if GS_EXPOSE(NSURLQueryItem)
+#if	GS_EXPOSE(NSURLQueryItem)
 #endif
-#if GS_NONFRAGILE
-#if defined(GS_NSURLQueryItem_IVARS)
+#if     GS_NONFRAGILE
+#  if	defined(GS_NSURLQueryItem_IVARS)
 @public
-  GS_NSURLQueryItem_IVARS;
-#endif
+GS_NSURLQueryItem_IVARS;
+#  endif
 #else
   /* Pointer to private additional data used to avoid breaking ABI
    * when we don't have the non-fragile ABI available.
    * Use this mechanism rather than changing the instance variable
    * layout (see Source/GSInternal.h for details).
    */
-@private
-  id _internal GS_UNUSED_IVAR;
+  @private id _internal GS_UNUSED_IVAR;
 #endif
 }
 
 // Creating query items.
-+ (instancetype)queryItemWithName:(NSString *)name value:(NSString *)value;
-- (instancetype)initWithName:(NSString *)name value:(NSString *)value;
++ (instancetype)queryItemWithName:(NSString *)name 
+                            value:(NSString *)value;
+- (instancetype)initWithName:(NSString *)name 
+                       value:(NSString *)value;
 
 // Reading a name and value from a query
-- (NSString *)name;
-- (NSString *)value;
+- (NSString *) name;  
+- (NSString *) value;
 @end
 
 #endif // OS_API_VERSION
@@ -688,96 +691,99 @@ GS_EXPORT_CLASS
 GS_EXPORT_CLASS
 @interface NSURLComponents : NSObject <NSCopying>
 {
-#if GS_EXPOSE(NSURLComponents)
+#if	GS_EXPOSE(NSURLComponents)
 #endif
-#if GS_NONFRAGILE
-#if defined(GS_NSURLComponents_IVARS)
+#if     GS_NONFRAGILE
+#  if	defined(GS_NSURLComponents_IVARS)
 @public
-  GS_NSURLComponents_IVARS;
-#endif
+GS_NSURLComponents_IVARS;
+#  endif
 #else
   /* Pointer to private additional data used to avoid breaking ABI
    * when we don't have the non-fragile ABI available.
    * Use this mechanism rather than changing the instance variable
    * layout (see Source/GSInternal.h for details).
    */
-@private
-  id _internal GS_UNUSED_IVAR;
+  @private id _internal GS_UNUSED_IVAR;
 #endif
 }
-// Creating URL components...
-+ (instancetype)componentsWithString:(NSString *)URLString;
-+ (instancetype)componentsWithURL:(NSURL *)url
-	  resolvingAgainstBaseURL:(BOOL)resolve;
-- (instancetype)init;
+  // Creating URL components...
++ (instancetype) componentsWithString:(NSString *)URLString;
++ (instancetype) componentsWithURL:(NSURL *)url 
+           resolvingAgainstBaseURL:(BOOL)resolve;
+- (instancetype) init;
 - (instancetype)initWithString:(NSString *)URLString;
 
-- (instancetype)initWithURL:(NSURL *)url resolvingAgainstBaseURL:(BOOL)resolve;
+- (instancetype)initWithURL:(NSURL *)url 
+    resolvingAgainstBaseURL:(BOOL)resolve;
 
 // Getting the URL
-- (NSString *)string;
-- (void)setString:(NSString *)urlString;
-- (NSURL *)URL;
-- (void)setURL:(NSURL *)url;
-- (NSURL *)URLRelativeToURL:(NSURL *)baseURL;
+- (NSString *) string;
+- (void) setString: (NSString *)urlString;
+- (NSURL *) URL;
+- (void) setURL: (NSURL *)url;
+- (NSURL *)URLRelativeToURL: (NSURL *)baseURL;
 
 // Accessing Components in Native Format
-- (NSString *)fragment;
-- (void)setFragment:(NSString *)fragment;
-- (NSString *)host;
-- (void)setHost:(NSString *)host;
-- (NSString *)password;
-- (void)setPassword:(NSString *)password;
-- (NSString *)path;
-- (void)setPath:(NSString *)path;
-- (NSNumber *)port;
-- (void)setPort:(NSNumber *)port;
-- (NSString *)query;
-- (void)setQuery:(NSString *)query;
+- (NSString *) fragment;
+- (void) setFragment: (NSString *)fragment;
+- (NSString *) host;
+- (void) setHost: (NSString *)host;
+- (NSString *) password;
+- (void) setPassword: (NSString *)password;
+- (NSString *) path;
+- (void) setPath: (NSString *)path;
+- (NSNumber *) port;
+- (void) setPort: (NSNumber *)port;
+- (NSString *) query;
+- (void) setQuery: (NSString *)query;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-- (NSArray *)queryItems;
-- (void)setQueryItems:(NSArray *)queryItems;
+- (NSArray *) queryItems;
+- (void) setQueryItems: (NSArray *)queryItems;
 #endif
-- (NSString *)scheme;
-- (void)setScheme:(NSString *)scheme;
-- (NSString *)user;
-- (void)setUser:(NSString *)user;
+- (NSString *) scheme;
+- (void) setScheme: (NSString *)scheme;
+- (NSString *) user;
+- (void) setUser: (NSString *)user;
 
 // Accessing Components in PercentEncoded Format
-- (NSString *)percentEncodedFragment;
-- (void)setPercentEncodedFragment:(NSString *)fragment;
-- (NSString *)percentEncodedHost;
-- (void)setPercentEncodedHost:(NSString *)host;
-- (NSString *)percentEncodedPassword;
-- (void)setPercentEncodedPassword:(NSString *)password;
-- (NSString *)percentEncodedPath;
-- (void)setPercentEncodedPath:(NSString *)path;
-- (NSString *)percentEncodedQuery;
-- (void)setPercentEncodedQuery:(NSString *)query;
+- (NSString *) percentEncodedFragment; 
+- (void) setPercentEncodedFragment: (NSString *)fragment;
+- (NSString *) percentEncodedHost;
+- (void) setPercentEncodedHost: (NSString *)host;
+- (NSString *) percentEncodedPassword;
+- (void) setPercentEncodedPassword: (NSString *)password;
+- (NSString *) percentEncodedPath;
+- (void) setPercentEncodedPath: (NSString *)path;
+- (NSString *) percentEncodedQuery;
+- (void) setPercentEncodedQuery: (NSString *)query;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-- (NSArray *)percentEncodedQueryItems;
-- (void)setPercentEncodedQueryItems:(NSArray *)queryItems;
+- (NSArray *) percentEncodedQueryItems;
+- (void) setPercentEncodedQueryItems: (NSArray *)queryItems;
 #endif
-- (NSString *)percentEncodedUser;
-- (void)setPercentEncodedUser:(NSString *)user;
+- (NSString *) percentEncodedUser;
+- (void) setPercentEncodedUser: (NSString *)user;
 
 // Locating components of the URL string representation
-- (NSRange)rangeOfFragment;
-- (NSRange)rangeOfHost;
-- (NSRange)rangeOfPassword;
-- (NSRange)rangeOfPath;
-- (NSRange)rangeOfPort;
-- (NSRange)rangeOfQuery;
-- (NSRange)rangeOfScheme;
-- (NSRange)rangeOfUser;
-
+- (NSRange) rangeOfFragment;
+- (NSRange) rangeOfHost;
+- (NSRange) rangeOfPassword;
+- (NSRange) rangeOfPath;
+- (NSRange) rangeOfPort;
+- (NSRange) rangeOfQuery;
+- (NSRange) rangeOfScheme;
+- (NSRange) rangeOfUser;
+  
 @end
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif /* GS_API_MACOSX */
+#endif	/* GS_API_MACOSX */
 
-#endif /* __NSURL_h_GNUSTEP_BASE_INCLUDE */
+#endif	/* __NSURL_h_GNUSTEP_BASE_INCLUDE */
+
+
+
 

--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -1,21 +1,21 @@
 /* NSURL.h - Class NSURL
    Copyright (C) 1999 Free Software Foundation, Inc.
-   
+
    Written by: 	Manuel Guesdon <mguesdon@sbuilders.com>
    Date:	Jan 1999
-   
+
    This file is part of the GNUstep Library.
-   
+
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
    License as published by the Free Software Foundation; either
    version 2 of the License, or (at your option) any later version.
-   
+
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Lesser General Public License for more details.
-   
+
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -24,16 +24,16 @@
 
 #ifndef __NSURL_h_GNUSTEP_BASE_INCLUDE
 #define __NSURL_h_GNUSTEP_BASE_INCLUDE
-#import	<GNUstepBase/GSVersionMacros.h>
+#import <GNUstepBase/GSVersionMacros.h>
 
-#import	<Foundation/NSURLHandle.h>
+#import <Foundation/NSURLHandle.h>
 #import <Foundation/NSRange.h>
 
-#if	defined(__cplusplus)
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
-#if	OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
+#if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 
 @class NSError;
 @class NSNumber;
@@ -44,7 +44,7 @@ extern "C" {
 /**
  *  URL scheme constant for use with [NSURL-initWithScheme:host:path:].
  */
-GS_EXPORT NSString* const NSURLFileScheme;
+GS_EXPORT NSString *const NSURLFileScheme;
 
 /** URL Bookmark Resolution Options **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -69,46 +69,61 @@ enum
  * objects, but NSURL provides a simplified API wrapping these objects.
  */
 GS_EXPORT_CLASS
-@interface NSURL: NSObject <NSCoding, NSCopying, NSURLHandleClient>
+@interface NSURL : NSObject <NSCoding, NSCopying, NSURLHandleClient>
 {
-#if	GS_EXPOSE(NSURL)
+#if GS_EXPOSE(NSURL)
 @private
-  NSString	*_urlString;
-  NSURL		*_baseURL;
-  void		*_clients;
-  void		*_data;
+  NSString *_urlString;
+  NSURL *   _baseURL;
+  void *    _clients;
+  void *    _data;
 #endif
 }
- 
+
 /**
  * Create and return a file URL with the supplied path.<br />
  * The value of aPath must be a valid filesystem path.<br />
  * Calls -initFileURLWithPath: which escapes characters in the
  * path where necessary.
  */
-+ (instancetype) fileURLWithPath: (NSString*)aPath;
-
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
-/** Creates a file URL using a path built from components.
- */
-+ (instancetype) fileURLWithPathComponents: (NSArray*)components;
-#endif
++ (instancetype)fileURLWithPath:(NSString *)aPath;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
-+ (instancetype) fileURLWithPath: (NSString*)aPath isDirectory: (BOOL)isDir;
+
++ (instancetype)fileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir;
 #endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
++ (instancetype)fileURLWithPath:(NSString *)aPath
+	       isDirectory:(BOOL)isDir
+	     relativeToURL:(NSURL *)baseURL;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
+/** Create and return a file URL with the supplied path, relative to a base URL.
+ */
++ (instancetype)fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+/** Creates a file URL using a path built from components.
+ */
++ (instancetype)fileURLWithPathComponents:(NSArray *)components;
+#endif
+
 /**
  * Create and return a URL with the supplied string, which should
  * be a string (containing percent escape codes where necessary)
  * conforming to the description (in RFC2396) of an absolute URL.<br />
  * Calls -initWithString:
  */
-+ (instancetype) URLWithString: (NSString*)aUrlString;
++ (instancetype)URLWithString:(NSString *)aUrlString;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-+ (instancetype) URLByResolvingAliasFileAtURL: (NSURL*)url
-                                      options: (NSURLBookmarkResolutionOptions)options
-                                        error: (NSError**)error;
++ (instancetype)URLByResolvingAliasFileAtURL:(NSURL *)url
+				     options:
+				       (NSURLBookmarkResolutionOptions)options
+				       error:(NSError **)error;
 #endif
 
 /**
@@ -117,8 +132,8 @@ GS_EXPORT_CLASS
  * conforming to the description (in RFC2396) of a relative URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-+ (instancetype) URLWithString: (NSString*)aUrlString
-                 relativeToURL: (NSURL*)aBaseUrl;
++ (instancetype)URLWithString:(NSString *)aUrlString
+		relativeToURL:(NSURL *)aBaseUrl;
 
 /**
  * Initialise as a file URL with the specified path (which must
@@ -129,9 +144,9 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype) initFileURLWithPath: (NSString*)aPath;
+- (instancetype)initFileURLWithPath:(NSString *)aPath;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_5,GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
 /**
  * Initialise as a file URL with the specified path (which must
  * be a valid path on the local filesystem).<br />
@@ -141,8 +156,36 @@ GS_EXPORT_CLASS
  * specifies a directory.<br />
  * Calls -initWithScheme:host:path:
  */
-- (instancetype) initFileURLWithPath: (NSString*)aPath
-                         isDirectory: (BOOL)isDir;
+- (instancetype)initFileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
+/**
+ * Initialise as a file URL with the specified path (which must
+ * be a valid path on the local filesystem) relative to the base URL.<br />
+ * Raises NSInvalidArgumentException if aPath is nil.<br />
+ * Converts relative paths to absolute ones.<br />
+ * Appends a trailing slash to the path when necessary if it
+ * specifies a directory.<br />
+ * Calls -initWithScheme:host:path:
+ */
+- (instancetype)initFileURLWithPath:(NSString *)aPath
+		      relativeToURL:(NSURL *)baseURL;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
+/**
+ * Initialise as a file URL with the specified path (which must
+ * be a valid path on the local filesystem) relative to the base URL.<br />
+ * Raises NSInvalidArgumentException if aPath is nil.<br />
+ * Converts relative paths to absolute ones.<br />
+ * Appends a trailing slash to the path when necessary if it
+ * specifies a directory.<br />
+ * Calls -initWithScheme:host:path:
+ */
+- (instancetype)initFileURLWithPath:(NSString *)aPath
+			isDirectory:(BOOL)isDir
+		      relativeToURL:(NSURL *)baseURL;
 #endif
 
 /**
@@ -156,15 +199,15 @@ GS_EXPORT_CLASS
  * Permits the 'aHost' part to contain 'username:password@host:port' or
  * 'host:port' in addition to a simple host name or address.
  */
-- (instancetype) initWithScheme: (NSString*)aScheme
-                           host: (NSString*)aHost
-                           path: (NSString*)aPath;
+- (instancetype)initWithScheme:(NSString *)aScheme
+			  host:(NSString *)aHost
+			  path:(NSString *)aPath;
 
 /**
  * Initialise as an absolute URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-- (instancetype) initWithString: (NSString*)aUrlString;
+- (instancetype)initWithString:(NSString *)aUrlString;
 
 /** <init />
  * Initialised using aUrlString and aBaseUrl.  The value of aBaseUrl
@@ -174,38 +217,38 @@ GS_EXPORT_CLASS
  * Parses an empty string as an empty path.<br />
  * If the string cannot be parsed the method returns nil.
  */
-- (instancetype) initWithString: (NSString*)aUrlString
-                  relativeToURL: (NSURL*)aBaseUrl;
+- (instancetype)initWithString:(NSString *)aUrlString
+		 relativeToURL:(NSURL *)aBaseUrl;
 
 #if GS_HAS_DECLARED_PROPERTIES
 @property (readonly, getter=isFileURL) BOOL fileURL;
 #else
-- (BOOL) isFileURL;
+- (BOOL)isFileURL;
 #endif
 
 /**
  * Returns the full string describing the receiver resolved against its base.
  */
-- (NSString*) absoluteString;
+- (NSString *)absoluteString;
 
 /**
  * If the receiver is an absolute URL, returns self.  Otherwise returns an
  * absolute URL referring to the same resource as the receiver.
  */
-- (NSURL*) absoluteURL;
+- (NSURL *)absoluteURL;
 
 /**
  * If the receiver is a relative URL, returns its base URL.<br />
  * Otherwise, returns nil.
  */
-- (NSURL*) baseURL;
+- (NSURL *)baseURL;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Attempts to load from the specified URL and provides an error
  * response if the data is unrachable.<br />
  * Returns YES on success, NO on failure.
  */
-- (BOOL) checkResourceIsReachableAndReturnError: (NSError **)error;
+- (BOOL)checkResourceIsReachableAndReturnError:(NSError **)error;
 #endif
 
 /**
@@ -214,7 +257,7 @@ GS_EXPORT_CLASS
  * The fragment is everything in the original URL string after a '#'<br />
  * File URLs do not have fragments.
  */
-- (NSString*) fragment;
+- (NSString *)fragment;
 
 /**
  * Returns the host portion of the receiver or nil if there is no
@@ -224,12 +267,12 @@ GS_EXPORT_CLASS
  * Returns IPv6 addresses <em>without</em> the enclosing square brackets
  * required (by RFC2732) in URL strings.
  */
-- (NSString*) host;
+- (NSString *)host;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Returns the last (rightmost) path component of the receiver.
  */
-- (NSString*) lastPathComponent;
+- (NSString *)lastPathComponent;
 #endif
 
 /**
@@ -254,8 +297,8 @@ GS_EXPORT_CLASS
  *   background load operation to operate!
  * </p>
  */
-- (void) loadResourceDataNotifyingClient: (id)client
-			      usingCache: (BOOL)shouldUseCache;
+- (void)loadResourceDataNotifyingClient:(id)client
+			     usingCache:(BOOL)shouldUseCache;
 
 /**
  * Returns the parameter portion of the receiver or nil if there is no
@@ -264,7 +307,7 @@ GS_EXPORT_CLASS
  * but before the query.<br />
  * File URLs do not have parameters.
  */
-- (NSString*) parameterString;
+- (NSString *)parameterString;
 
 /**
  * Returns the password portion of the receiver or nil if there is no
@@ -274,7 +317,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString*) password;
+- (NSString *)password;
 
 /**
  * Returns the path portion of the receiver.<br />
@@ -287,19 +330,19 @@ GS_EXPORT_CLASS
  * Also, this breaks strict conformance in that a URL of file scheme is
  * treated as having a path (contrary to RFCs)
  */
-- (NSString*) path;
+- (NSString *)path;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Returns thepath components of the receiver.<br />
  * See [NSString-pathComponents].
  */
-- (NSArray*) pathComponents;
+- (NSArray *)pathComponents;
 
 /** Returns the file extension (text after the rightmost dot in the path)
  * of the receiver.<br />
  * see [NSString-pathExtension].
  */
-- (NSString*) pathExtension;
+- (NSString *)pathExtension;
 #endif
 
 /**
@@ -308,13 +351,13 @@ GS_EXPORT_CLASS
  * Percent escape sequences in the user string are translated in GNUstep
  * but this appears to be broken in MacOS-X.
  */
-- (NSNumber*) port;
+- (NSNumber *)port;
 
 /**
  * Asks a URL handle to return the property for the specified key and
  * returns the result.
  */
-- (id) propertyForKey: (NSString*)propertyKey;
+- (id)propertyForKey:(NSString *)propertyKey;
 
 /**
  * Returns the query portion of the receiver or nil if there is no
@@ -323,20 +366,20 @@ GS_EXPORT_CLASS
  * but before the fragment.<br />
  * File URLs do not have queries.
  */
-- (NSString*) query;
+- (NSString *)query;
 
 /**
  * Returns the path of the receiver, without taking any base URL into account.
  * If the receiver is an absolute URL, -relativePath is the same as -path.<br />
  * Returns nil if there is no path specified for the URL.
  */
-- (NSString*) relativePath;
+- (NSString *)relativePath;
 
 /**
  * Returns the relative portion of the URL string.  If the receiver is not
  * a relative URL, this returns the same as absoluteString.
  */
-- (NSString*) relativeString;
+- (NSString *)relativeString;
 
 /**
  * Loads the resource data for the represented URL and returns the result.
@@ -344,94 +387,93 @@ GS_EXPORT_CLASS
  * an existing NSURLHandle can be used to provide the data, or if it should
  * be refetched.
  */
-- (NSData*) resourceDataUsingCache: (BOOL)shouldUseCache;
+- (NSData *)resourceDataUsingCache:(BOOL)shouldUseCache;
 
 /**
  * Returns the resource specifier of the URL ... the part which lies
  * after the scheme.
  */
-- (NSString*) resourceSpecifier;
+- (NSString *)resourceSpecifier;
 
 /**
  * Returns the scheme of the receiver.
  */
-- (NSString*) scheme;
+- (NSString *)scheme;
 
 /**
  * Calls [NSURLHandle-writeProperty:forKey:] to set the named property.
  */
-- (BOOL) setProperty: (id)property
-	      forKey: (NSString*)propertyKey;
+- (BOOL)setProperty:(id)property forKey:(NSString *)propertyKey;
 
 /**
  * Calls [NSURLHandle-writeData:] to write the specified data object
  * to the resource identified by the receiver URL.<br />
  * Returns the result.
  */
-- (BOOL) setResourceData: (NSData*)data;
+- (BOOL)setResourceData:(NSData *)data;
 
 /**
  * Returns a URL with '/./' and '/../' sequences resolved etc.
  */
-- (NSURL*) standardizedURL;
+- (NSURL *)standardizedURL;
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 /** Returns a URL formed by adding a path component to the path of the
  * receiver.<br />
  * See [NSString-stringByAppendingPathComponent:].
  */
-- (NSURL*) URLByAppendingPathComponent: (NSString*)pathComponent;
+- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent;
 
 /** Returns a URL formed by adding a path extension to the path of the
  * receiver.<br />
  * See [NSString-stringByAppendingPathExtension:].
  */
-- (NSURL*) URLByAppendingPathExtension: (NSString*)pathExtension;
+- (NSURL *)URLByAppendingPathExtension:(NSString *)pathExtension;
 
 /** Returns a URL formed by removing a path component from the path of the
  * receiver.<br />
  * See [NSString-stringByDeletingLastPathComponent].
  */
-- (NSURL*) URLByDeletingLastPathComponent;
+- (NSURL *)URLByDeletingLastPathComponent;
 
 /** Returns a URL formed by removing an extension from the path of the
  * receiver.<br />
  * See [NSString-stringByDeletingPathExtension].
  */
-- (NSURL*) URLByDeletingPathExtension;
+- (NSURL *)URLByDeletingPathExtension;
 
 /** Returns self unless the receiver is a file URL, in which case it returns
  * a URL formed by calling [NSString-stringByResolvingSymlinksInPath].
  */
-- (NSURL*) URLByResolvingSymlinksInPath;
+- (NSURL *)URLByResolvingSymlinksInPath;
 
 /** Returns self unless the receiver is a file URL, in which case it returns
  * a URL formed by calling [NSString-stringByStandardizingPath].
  */
-- (NSURL*) URLByStandardizingPath;
+- (NSURL *)URLByStandardizingPath;
 
 #endif
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST) 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
 /** Returns a URL formed by adding a path component to the path of the
  * receiver, along with a trailing slash if the component is designated a
  * directory.<br />
  * See [NSString-stringByAppendingPathComponent:].
  */
-- (NSURL *) URLByAppendingPathComponent:(NSString *)pathComponent
-                            isDirectory:(BOOL)isDirectory;
+- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
+			   isDirectory:(BOOL)isDirectory;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-- (BOOL) isFileReferenceURL;
+- (BOOL)isFileReferenceURL;
 
-- (NSURL *) fileReferenceURL;
+- (NSURL *)fileReferenceURL;
 
-- (NSURL *) filePathURL;
+- (NSURL *)filePathURL;
 
-- (BOOL) getResourceValue: (id*)value 
-                   forKey: (NSString *)key 
-                    error: (NSError**)error;
+- (BOOL)getResourceValue:(id *)value
+		  forKey:(NSString *)key
+		   error:(NSError **)error;
 #endif
 /**
  * Returns an NSURLHandle instance which may be used to write data to the
@@ -439,7 +481,7 @@ GS_EXPORT_CLASS
  * The shouldUseCache flag indicates whether a cached handle may be returned
  * or a new one should be created.
  */
-- (NSURLHandle*)URLHandleUsingCache: (BOOL)shouldUseCache;
+- (NSURLHandle *)URLHandleUsingCache:(BOOL)shouldUseCache;
 
 /**
  * Returns the user portion of the receiver or nil if there is no
@@ -449,7 +491,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString*) user;
+- (NSString *)user;
 
 @end
 
@@ -459,153 +501,151 @@ GS_EXPORT_CLASS
  * Some data has become available.  Note that this does not mean that all data
  * has become available, only that a chunk of data has arrived.
  */
-- (void) URL: (NSURL*)sender
-  resourceDataDidBecomeAvailable: (NSData*)newBytes;
+- (void)URL:(NSURL *)sender resourceDataDidBecomeAvailable:(NSData *)newBytes;
 
 /** <override-dummy />
  * Loading of resource data is complete.
  */
-- (void) URLResourceDidFinishLoading: (NSURL*)sender;
+- (void)URLResourceDidFinishLoading:(NSURL *)sender;
 
 /** <override-dummy />
  * Loading of resource data was cancelled by programmatic request
  * (not an error).
  */
-- (void) URLResourceDidCancelLoading: (NSURL*)sender;
+- (void)URLResourceDidCancelLoading:(NSURL *)sender;
 
 /** <override-dummy />
  * Loading of resource data has failed, for given human-readable reason.
  */
-- (void) URL: (NSURL*)sender
-  resourceDidFailLoadingWithReason: (NSString*)reason;
+- (void)URL:(NSURL *)sender resourceDidFailLoadingWithReason:(NSString *)reason;
 @end
 
 /** URL Resource Value Constants **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLNameKey;
-GS_EXPORT NSString* const NSURLLocalizedNameKey;
-GS_EXPORT NSString* const NSURLIsRegularFileKey;
-GS_EXPORT NSString* const NSURLIsDirectoryKey;
-GS_EXPORT NSString* const NSURLIsSymbolicLinkKey;
-GS_EXPORT NSString* const NSURLIsVolumeKey;
-GS_EXPORT NSString* const NSURLIsPackageKey;
-GS_EXPORT NSString* const NSURLIsSystemImmutableKey;
-GS_EXPORT NSString* const NSURLIsUserImmutableKey;
-GS_EXPORT NSString* const NSURLIsHiddenKey;
-GS_EXPORT NSString* const NSURLHasHiddenExtensionKey;
-GS_EXPORT NSString* const NSURLCreationDateKey;
-GS_EXPORT NSString* const NSURLContentAccessDateKey;
-GS_EXPORT NSString* const NSURLContentModificationDateKey;
-GS_EXPORT NSString* const NSURLAttributeModificationDateKey;
-GS_EXPORT NSString* const NSURLLinkCountKey;
-GS_EXPORT NSString* const NSURLParentDirectoryURLKey;
-GS_EXPORT NSString* const NSURLVolumeURLKey;
-GS_EXPORT NSString* const NSURLTypeIdentifierKey;
-GS_EXPORT NSString* const NSURLLocalizedTypeDescriptionKey;
-GS_EXPORT NSString* const NSURLLabelNumberKey;
-GS_EXPORT NSString* const NSURLLabelColorKey;
-GS_EXPORT NSString* const NSURLLocalizedLabelKey;
-GS_EXPORT NSString* const NSURLEffectiveIconKey;
-GS_EXPORT NSString* const NSURLCustomIconKey;
-GS_EXPORT NSString* const NSURLFileSizeKey;
-GS_EXPORT NSString* const NSURLFileAllocatedSizeKey;
-GS_EXPORT NSString* const NSURLIsAliasFileKey;
-GS_EXPORT NSString* const NSURLVolumeLocalizedFormatDescriptionKey;
-GS_EXPORT NSString* const NSURLVolumeTotalCapacityKey;
-GS_EXPORT NSString* const NSURLVolumeAvailableCapacityKey;
-GS_EXPORT NSString* const NSURLVolumeResourceCountKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsPersistentIDsKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsSymbolicLinksKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsHardLinksKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsJournalingKey;
-GS_EXPORT NSString* const NSURLVolumeIsJournalingKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsSparseFilesKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsZeroRunsKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsCaseSensitiveNamesKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsCasePreservedNamesKey;
+GS_EXPORT NSString *const NSURLNameKey;
+GS_EXPORT NSString *const NSURLLocalizedNameKey;
+GS_EXPORT NSString *const NSURLIsRegularFileKey;
+GS_EXPORT NSString *const NSURLIsDirectoryKey;
+GS_EXPORT NSString *const NSURLIsSymbolicLinkKey;
+GS_EXPORT NSString *const NSURLIsVolumeKey;
+GS_EXPORT NSString *const NSURLIsPackageKey;
+GS_EXPORT NSString *const NSURLIsSystemImmutableKey;
+GS_EXPORT NSString *const NSURLIsUserImmutableKey;
+GS_EXPORT NSString *const NSURLIsHiddenKey;
+GS_EXPORT NSString *const NSURLHasHiddenExtensionKey;
+GS_EXPORT NSString *const NSURLCreationDateKey;
+GS_EXPORT NSString *const NSURLContentAccessDateKey;
+GS_EXPORT NSString *const NSURLContentModificationDateKey;
+GS_EXPORT NSString *const NSURLAttributeModificationDateKey;
+GS_EXPORT NSString *const NSURLLinkCountKey;
+GS_EXPORT NSString *const NSURLParentDirectoryURLKey;
+GS_EXPORT NSString *const NSURLVolumeURLKey;
+GS_EXPORT NSString *const NSURLTypeIdentifierKey;
+GS_EXPORT NSString *const NSURLLocalizedTypeDescriptionKey;
+GS_EXPORT NSString *const NSURLLabelNumberKey;
+GS_EXPORT NSString *const NSURLLabelColorKey;
+GS_EXPORT NSString *const NSURLLocalizedLabelKey;
+GS_EXPORT NSString *const NSURLEffectiveIconKey;
+GS_EXPORT NSString *const NSURLCustomIconKey;
+GS_EXPORT NSString *const NSURLFileSizeKey;
+GS_EXPORT NSString *const NSURLFileAllocatedSizeKey;
+GS_EXPORT NSString *const NSURLIsAliasFileKey;
+GS_EXPORT NSString *const NSURLVolumeLocalizedFormatDescriptionKey;
+GS_EXPORT NSString *const NSURLVolumeTotalCapacityKey;
+GS_EXPORT NSString *const NSURLVolumeAvailableCapacityKey;
+GS_EXPORT NSString *const NSURLVolumeResourceCountKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsPersistentIDsKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsSymbolicLinksKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsHardLinksKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsJournalingKey;
+GS_EXPORT NSString *const NSURLVolumeIsJournalingKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsSparseFilesKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsZeroRunsKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsCaseSensitiveNamesKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsCasePreservedNamesKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLFileResourceIdentifierKey;
-GS_EXPORT NSString* const NSURLVolumeIdentifierKey;
-GS_EXPORT NSString* const NSURLPreferredIOBlockSizeKey;
-GS_EXPORT NSString* const NSURLIsReadableKey;
-GS_EXPORT NSString* const NSURLIsWritableKey;
-GS_EXPORT NSString* const NSURLIsExecutableKey;
-GS_EXPORT NSString* const NSURLFileSecurityKey;
-GS_EXPORT NSString* const NSURLIsMountTriggerKey;
-GS_EXPORT NSString* const NSURLFileResourceTypeKey;
-GS_EXPORT NSString* const NSURLTotalFileSizeKey;
-GS_EXPORT NSString* const NSURLTotalFileAllocatedSizeKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsRootDirectoryDatesKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsVolumeSizesKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsRenamingKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsAdvisoryFileLockingKey;
-GS_EXPORT NSString* const NSURLVolumeSupportsExtendedSecurityKey;
-GS_EXPORT NSString* const NSURLVolumeIsBrowsableKey;
-GS_EXPORT NSString* const NSURLVolumeMaximumFileSizeKey;
-GS_EXPORT NSString* const NSURLVolumeIsEjectableKey;
-GS_EXPORT NSString* const NSURLVolumeIsRemovableKey;
-GS_EXPORT NSString* const NSURLVolumeIsInternalKey;
-GS_EXPORT NSString* const NSURLVolumeIsAutomountedKey;
-GS_EXPORT NSString* const NSURLVolumeIsLocalKey;
-GS_EXPORT NSString* const NSURLVolumeIsReadOnlyKey;
-GS_EXPORT NSString* const NSURLVolumeCreationDateKey;
-GS_EXPORT NSString* const NSURLVolumeURLForRemountingKey;
-GS_EXPORT NSString* const NSURLVolumeUUIDStringKey;
-GS_EXPORT NSString* const NSURLVolumeNameKey;
-GS_EXPORT NSString* const NSURLVolumeLocalizedNameKey;
-GS_EXPORT NSString* const NSURLIsUbiquitousItemKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemHasUnresolvedConflictsKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemIsDownloadingKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemIsUploadedKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemIsUploadingKey;
+GS_EXPORT NSString *const NSURLFileResourceIdentifierKey;
+GS_EXPORT NSString *const NSURLVolumeIdentifierKey;
+GS_EXPORT NSString *const NSURLPreferredIOBlockSizeKey;
+GS_EXPORT NSString *const NSURLIsReadableKey;
+GS_EXPORT NSString *const NSURLIsWritableKey;
+GS_EXPORT NSString *const NSURLIsExecutableKey;
+GS_EXPORT NSString *const NSURLFileSecurityKey;
+GS_EXPORT NSString *const NSURLIsMountTriggerKey;
+GS_EXPORT NSString *const NSURLFileResourceTypeKey;
+GS_EXPORT NSString *const NSURLTotalFileSizeKey;
+GS_EXPORT NSString *const NSURLTotalFileAllocatedSizeKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsRootDirectoryDatesKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsVolumeSizesKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsRenamingKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsAdvisoryFileLockingKey;
+GS_EXPORT NSString *const NSURLVolumeSupportsExtendedSecurityKey;
+GS_EXPORT NSString *const NSURLVolumeIsBrowsableKey;
+GS_EXPORT NSString *const NSURLVolumeMaximumFileSizeKey;
+GS_EXPORT NSString *const NSURLVolumeIsEjectableKey;
+GS_EXPORT NSString *const NSURLVolumeIsRemovableKey;
+GS_EXPORT NSString *const NSURLVolumeIsInternalKey;
+GS_EXPORT NSString *const NSURLVolumeIsAutomountedKey;
+GS_EXPORT NSString *const NSURLVolumeIsLocalKey;
+GS_EXPORT NSString *const NSURLVolumeIsReadOnlyKey;
+GS_EXPORT NSString *const NSURLVolumeCreationDateKey;
+GS_EXPORT NSString *const NSURLVolumeURLForRemountingKey;
+GS_EXPORT NSString *const NSURLVolumeUUIDStringKey;
+GS_EXPORT NSString *const NSURLVolumeNameKey;
+GS_EXPORT NSString *const NSURLVolumeLocalizedNameKey;
+GS_EXPORT NSString *const NSURLIsUbiquitousItemKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemHasUnresolvedConflictsKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemIsDownloadingKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemIsUploadedKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemIsUploadingKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLIsExcludedFromBackupKey;
-GS_EXPORT NSString* const NSURLPathKey;
+GS_EXPORT NSString *const NSURLIsExcludedFromBackupKey;
+GS_EXPORT NSString *const NSURLPathKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLTagNamesKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingErrorKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemUploadingErrorKey;
+GS_EXPORT NSString *const NSURLTagNamesKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingErrorKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemUploadingErrorKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLGenerationIdentifierKey;
-GS_EXPORT NSString* const NSURLDocumentIdentifierKey;
-GS_EXPORT NSString* const NSURLAddedToDirectoryDateKey;
-GS_EXPORT NSString* const NSURLQuarantinePropertiesKey;
-GS_EXPORT NSString* const NSThumbnail1024x1024SizeKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadRequestedKey;
-GS_EXPORT NSString* const NSURLUbiquitousItemContainerDisplayNameKey;
+GS_EXPORT NSString *const NSURLGenerationIdentifierKey;
+GS_EXPORT NSString *const NSURLDocumentIdentifierKey;
+GS_EXPORT NSString *const NSURLAddedToDirectoryDateKey;
+GS_EXPORT NSString *const NSURLQuarantinePropertiesKey;
+GS_EXPORT NSString *const NSThumbnail1024x1024SizeKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadRequestedKey;
+GS_EXPORT NSString *const NSURLUbiquitousItemContainerDisplayNameKey;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLIsApplicationKey;
-GS_EXPORT NSString* const NSURLApplicationIsScriptableKey;
+GS_EXPORT NSString *const NSURLIsApplicationKey;
+GS_EXPORT NSString *const NSURLApplicationIsScriptableKey;
 #endif
 
 /** Possible values for File Resource Type Key **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLFileResourceTypeNamedPipe;
-GS_EXPORT NSString* const NSURLFileResourceTypeCharacterSpecial;
-GS_EXPORT NSString* const NSURLFileResourceTypeDirectory;
-GS_EXPORT NSString* const NSURLFileResourceTypeBlockSpecial;
-GS_EXPORT NSString* const NSURLFileResourceTypeRegular;
-GS_EXPORT NSString* const NSURLFileResourceTypeSymbolicLink;
-GS_EXPORT NSString* const NSURLFileResourceTypeSocket;
-GS_EXPORT NSString* const NSURLFileResourceTypeUnknown;
+GS_EXPORT NSString *const NSURLFileResourceTypeNamedPipe;
+GS_EXPORT NSString *const NSURLFileResourceTypeCharacterSpecial;
+GS_EXPORT NSString *const NSURLFileResourceTypeDirectory;
+GS_EXPORT NSString *const NSURLFileResourceTypeBlockSpecial;
+GS_EXPORT NSString *const NSURLFileResourceTypeRegular;
+GS_EXPORT NSString *const NSURLFileResourceTypeSymbolicLink;
+GS_EXPORT NSString *const NSURLFileResourceTypeSocket;
+GS_EXPORT NSString *const NSURLFileResourceTypeUnknown;
 #endif
 
 /** Possible values for Ubiquitous Item Downloading Key **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9, GS_API_LATEST)
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusNotDownloaded;
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusDownloaded;
-GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusCurrent;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusNotDownloaded;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusDownloaded;
+GS_EXPORT NSString *const NSURLUbiquitousItemDownloadingStatusCurrent;
 #endif
 
-#endif	/* GS_API_MACOSX */
+#endif /* GS_API_MACOSX */
 
-#if     !NO_GNUSTEP && !defined(GNUSTEP_BASE_INTERNAL)
+#if !NO_GNUSTEP && !defined(GNUSTEP_BASE_INTERNAL)
 #import <GNUstepBase/NSURL+GNUstepBase.h>
 #endif
 
@@ -614,32 +654,31 @@ GS_EXPORT NSString* const NSURLUbiquitousItemDownloadingStatusCurrent;
 GS_EXPORT_CLASS
 @interface NSURLQueryItem : NSObject <NSCopying, NSCoding>
 {
-#if	GS_EXPOSE(NSURLQueryItem)
+#if GS_EXPOSE(NSURLQueryItem)
 #endif
-#if     GS_NONFRAGILE
-#  if	defined(GS_NSURLQueryItem_IVARS)
+#if GS_NONFRAGILE
+#if defined(GS_NSURLQueryItem_IVARS)
 @public
-GS_NSURLQueryItem_IVARS;
-#  endif
+  GS_NSURLQueryItem_IVARS;
+#endif
 #else
   /* Pointer to private additional data used to avoid breaking ABI
    * when we don't have the non-fragile ABI available.
    * Use this mechanism rather than changing the instance variable
    * layout (see Source/GSInternal.h for details).
    */
-  @private id _internal GS_UNUSED_IVAR;
+@private
+  id _internal GS_UNUSED_IVAR;
 #endif
 }
 
 // Creating query items.
-+ (instancetype)queryItemWithName:(NSString *)name 
-                            value:(NSString *)value;
-- (instancetype)initWithName:(NSString *)name 
-                       value:(NSString *)value;
++ (instancetype)queryItemWithName:(NSString *)name value:(NSString *)value;
+- (instancetype)initWithName:(NSString *)name value:(NSString *)value;
 
 // Reading a name and value from a query
-- (NSString *) name;  
-- (NSString *) value;
+- (NSString *)name;
+- (NSString *)value;
 @end
 
 #endif // OS_API_VERSION
@@ -649,99 +688,96 @@ GS_NSURLQueryItem_IVARS;
 GS_EXPORT_CLASS
 @interface NSURLComponents : NSObject <NSCopying>
 {
-#if	GS_EXPOSE(NSURLComponents)
+#if GS_EXPOSE(NSURLComponents)
 #endif
-#if     GS_NONFRAGILE
-#  if	defined(GS_NSURLComponents_IVARS)
+#if GS_NONFRAGILE
+#if defined(GS_NSURLComponents_IVARS)
 @public
-GS_NSURLComponents_IVARS;
-#  endif
+  GS_NSURLComponents_IVARS;
+#endif
 #else
   /* Pointer to private additional data used to avoid breaking ABI
    * when we don't have the non-fragile ABI available.
    * Use this mechanism rather than changing the instance variable
    * layout (see Source/GSInternal.h for details).
    */
-  @private id _internal GS_UNUSED_IVAR;
+@private
+  id _internal GS_UNUSED_IVAR;
 #endif
 }
-  // Creating URL components...
-+ (instancetype) componentsWithString:(NSString *)URLString;
-+ (instancetype) componentsWithURL:(NSURL *)url 
-           resolvingAgainstBaseURL:(BOOL)resolve;
-- (instancetype) init;
+// Creating URL components...
++ (instancetype)componentsWithString:(NSString *)URLString;
++ (instancetype)componentsWithURL:(NSURL *)url
+	  resolvingAgainstBaseURL:(BOOL)resolve;
+- (instancetype)init;
 - (instancetype)initWithString:(NSString *)URLString;
 
-- (instancetype)initWithURL:(NSURL *)url 
-    resolvingAgainstBaseURL:(BOOL)resolve;
+- (instancetype)initWithURL:(NSURL *)url resolvingAgainstBaseURL:(BOOL)resolve;
 
 // Getting the URL
-- (NSString *) string;
-- (void) setString: (NSString *)urlString;
-- (NSURL *) URL;
-- (void) setURL: (NSURL *)url;
-- (NSURL *)URLRelativeToURL: (NSURL *)baseURL;
+- (NSString *)string;
+- (void)setString:(NSString *)urlString;
+- (NSURL *)URL;
+- (void)setURL:(NSURL *)url;
+- (NSURL *)URLRelativeToURL:(NSURL *)baseURL;
 
 // Accessing Components in Native Format
-- (NSString *) fragment;
-- (void) setFragment: (NSString *)fragment;
-- (NSString *) host;
-- (void) setHost: (NSString *)host;
-- (NSString *) password;
-- (void) setPassword: (NSString *)password;
-- (NSString *) path;
-- (void) setPath: (NSString *)path;
-- (NSNumber *) port;
-- (void) setPort: (NSNumber *)port;
-- (NSString *) query;
-- (void) setQuery: (NSString *)query;
+- (NSString *)fragment;
+- (void)setFragment:(NSString *)fragment;
+- (NSString *)host;
+- (void)setHost:(NSString *)host;
+- (NSString *)password;
+- (void)setPassword:(NSString *)password;
+- (NSString *)path;
+- (void)setPath:(NSString *)path;
+- (NSNumber *)port;
+- (void)setPort:(NSNumber *)port;
+- (NSString *)query;
+- (void)setQuery:(NSString *)query;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-- (NSArray *) queryItems;
-- (void) setQueryItems: (NSArray *)queryItems;
+- (NSArray *)queryItems;
+- (void)setQueryItems:(NSArray *)queryItems;
 #endif
-- (NSString *) scheme;
-- (void) setScheme: (NSString *)scheme;
-- (NSString *) user;
-- (void) setUser: (NSString *)user;
+- (NSString *)scheme;
+- (void)setScheme:(NSString *)scheme;
+- (NSString *)user;
+- (void)setUser:(NSString *)user;
 
 // Accessing Components in PercentEncoded Format
-- (NSString *) percentEncodedFragment; 
-- (void) setPercentEncodedFragment: (NSString *)fragment;
-- (NSString *) percentEncodedHost;
-- (void) setPercentEncodedHost: (NSString *)host;
-- (NSString *) percentEncodedPassword;
-- (void) setPercentEncodedPassword: (NSString *)password;
-- (NSString *) percentEncodedPath;
-- (void) setPercentEncodedPath: (NSString *)path;
-- (NSString *) percentEncodedQuery;
-- (void) setPercentEncodedQuery: (NSString *)query;
+- (NSString *)percentEncodedFragment;
+- (void)setPercentEncodedFragment:(NSString *)fragment;
+- (NSString *)percentEncodedHost;
+- (void)setPercentEncodedHost:(NSString *)host;
+- (NSString *)percentEncodedPassword;
+- (void)setPercentEncodedPassword:(NSString *)password;
+- (NSString *)percentEncodedPath;
+- (void)setPercentEncodedPath:(NSString *)path;
+- (NSString *)percentEncodedQuery;
+- (void)setPercentEncodedQuery:(NSString *)query;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-- (NSArray *) percentEncodedQueryItems;
-- (void) setPercentEncodedQueryItems: (NSArray *)queryItems;
+- (NSArray *)percentEncodedQueryItems;
+- (void)setPercentEncodedQueryItems:(NSArray *)queryItems;
 #endif
-- (NSString *) percentEncodedUser;
-- (void) setPercentEncodedUser: (NSString *)user;
+- (NSString *)percentEncodedUser;
+- (void)setPercentEncodedUser:(NSString *)user;
 
 // Locating components of the URL string representation
-- (NSRange) rangeOfFragment;
-- (NSRange) rangeOfHost;
-- (NSRange) rangeOfPassword;
-- (NSRange) rangeOfPath;
-- (NSRange) rangeOfPort;
-- (NSRange) rangeOfQuery;
-- (NSRange) rangeOfScheme;
-- (NSRange) rangeOfUser;
-  
+- (NSRange)rangeOfFragment;
+- (NSRange)rangeOfHost;
+- (NSRange)rangeOfPassword;
+- (NSRange)rangeOfPath;
+- (NSRange)rangeOfPort;
+- (NSRange)rangeOfQuery;
+- (NSRange)rangeOfScheme;
+- (NSRange)rangeOfUser;
+
 @end
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif	/* GS_API_MACOSX */
+#endif /* GS_API_MACOSX */
 
-#endif	/* __NSURL_h_GNUSTEP_BASE_INCLUDE */
-
-
-
+#endif /* __NSURL_h_GNUSTEP_BASE_INCLUDE */
 

--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -102,9 +102,7 @@ GS_EXPORT_CLASS
 + (instancetype) fileURLWithPath: (NSString *)aPath
 	                 isDirectory: (BOOL)isDir
 	               relativeToURL: (NSURL *)baseURL;
-#endif
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
 /** Create and return a file URL with the supplied path, relative to a base URL.
  */
 + (instancetype) fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL;
@@ -170,9 +168,7 @@ GS_EXPORT_CLASS
  */
 - (instancetype) initFileURLWithPath: (NSString *)aPath
 		               relativeToURL: (NSURL *)baseURL;
-#endif
 
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
 /**
  * Initialise as a file URL with the specified path (which must
  * be a valid path on the local filesystem) relative to the base URL.<br />

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -591,15 +591,15 @@ static NSUInteger	urlAlign;
 	      isDirectory: (BOOL)isDir
 	    relativeToURL: (NSURL *)baseURL
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
-					    isDirectory:isDir
-					  relativeToURL:baseURL]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath
+					    isDirectory: isDir
+					  relativeToURL: baseURL]);
 }
 
-+ (id)fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL
++ (id)fileURLWithPath: (NSString *)aPath relativeToURL: (NSURL *)baseURL
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
-					  relativeToURL:baseURL]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath
+					  relativeToURL: baseURL]);
 }
 
 + (id) fileURLWithPathComponents: (NSArray*)components
@@ -642,21 +642,18 @@ static NSUInteger	urlAlign;
 - (id) initFileURLWithPath: (NSString *)aPath
 {
   /* isDirectory flag will be overwritten if a directory exists. */
-  self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:nil];
-  return self;
+  return [self initFileURLWithPath: aPath isDirectory: NO relativeToURL: nil];
 }
 
 - (id) initFileURLWithPath: (NSString *)aPath isDirectory: (BOOL)isDir
 {
-  self = [self initFileURLWithPath:aPath isDirectory:isDir relativeToURL:nil];
-  return self;
+  return [self initFileURLWithPath: aPath isDirectory: isDir relativeToURL: nil];
 }
 
 - (id) initFileURLWithPath: (NSString *)aPath relativeToURL: (NSURL *)baseURL
 {
   /* isDirectory flag will be overwritten if a directory exists. */
-  self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:baseURL];
-  return self;
+  return [self initFileURLWithPath: aPath isDirectory: NO relativeToURL: baseURL];
 }
 
 - (id) initFileURLWithPath: (NSString *)aPath
@@ -676,30 +673,29 @@ static NSUInteger	urlAlign;
   if ([aPath isAbsolutePath] == NO)
     {
       if (baseURL)
-	{
-	  /* Append aPath to baseURL */
-	  aPath = [[baseURL relativePath] stringByAppendingPathComponent:aPath];
-	}
+        {
+          /* Append aPath to baseURL */
+          aPath = [[baseURL relativePath] stringByAppendingPathComponent:aPath];
+        }
       else
-	{
-	  aPath =
-	    [[mgr currentDirectoryPath] stringByAppendingPathComponent:aPath];
-	}
+        {
+          aPath =
+            [[mgr currentDirectoryPath] stringByAppendingPathComponent:aPath];
+        }
     }
   if ([mgr fileExistsAtPath:aPath isDirectory:&flag] == YES)
     {
       if ([aPath isAbsolutePath] == NO)
-	{
-	  aPath = [aPath stringByStandardizingPath];
-	}
+        {
+          aPath = [aPath stringByStandardizingPath];
+        }
       isDir = flag;
     }
   if (isDir == YES && [aPath hasSuffix:@"/"] == NO)
     {
       aPath = [aPath stringByAppendingString:@"/"];
     }
-  self = [self initWithScheme:NSURLFileScheme host:@"" path:aPath];
-  return self;
+  return [self initWithScheme: NSURLFileScheme host: @"" path: aPath];
 }
 
 - (id) initWithScheme: (NSString*)aScheme

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -7,7 +7,7 @@
    Rewrite by: 	Richard Frith-Macdonald <rfm@gnu.org>
    Date: 	Jun 2002
 
-   Add'l by:    Gregory John Casamento <greg.casamento@gmail.com>  
+   Add'l by:    Gregory John Casamento <greg.casamento@gmail.com>
    Date: 	Jan 2020
 
    This file is part of the GNUstep Library.
@@ -40,33 +40,33 @@ function may be incorrect
 * Some functions are not implemented
 */
 
-#define	GS_NSURLQueryItem_IVARS \
-  NSString *_name; \
-  NSString *_value; 
+#define GS_NSURLQueryItem_IVARS                                                \
+  NSString *_name;                                                             \
+  NSString *_value;
 
-#define	GS_NSURLComponents_IVARS \
-  NSString *_string; \
-  NSString *_fragment; \
-  NSString *_host; \
-  NSString *_password; \
-  NSString *_path; \
-  NSNumber *_port; \
-  NSArray  *_queryItems; \
-  NSString *_scheme; \
-  NSString *_user; \
-  NSRange   _rangeOfFragment; \
-  NSRange   _rangeOfHost; \
-  NSRange   _rangeOfPassword; \
-  NSRange   _rangeOfPath; \
-  NSRange   _rangeOfPort; \
-  NSRange   _rangeOfQuery; \
-  NSRange   _rangeOfQueryItems; \
-  NSRange   _rangeOfScheme; \
-  NSRange   _rangeOfUser; \
-  BOOL      _dirty;
+#define GS_NSURLComponents_IVARS                                               \
+  NSString *_string;                                                           \
+  NSString *_fragment;                                                         \
+  NSString *_host;                                                             \
+  NSString *_password;                                                         \
+  NSString *_path;                                                             \
+  NSNumber *_port;                                                             \
+  NSArray * _queryItems;                                                       \
+  NSString *_scheme;                                                           \
+  NSString *_user;                                                             \
+  NSRange   _rangeOfFragment;                                                  \
+  NSRange   _rangeOfHost;                                                      \
+  NSRange   _rangeOfPassword;                                                  \
+  NSRange   _rangeOfPath;                                                      \
+  NSRange   _rangeOfPort;                                                      \
+  NSRange   _rangeOfQuery;                                                     \
+  NSRange   _rangeOfQueryItems;                                                \
+  NSRange   _rangeOfScheme;                                                    \
+  NSRange   _rangeOfUser;                                                      \
+  BOOL	    _dirty;
 
 #import "common.h"
-#define	EXPOSE_NSURL_IVARS	1
+#define EXPOSE_NSURL_IVARS 1
 #import "Foundation/NSArray.h"
 #import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSCoder.h"
@@ -87,31 +87,31 @@ function may be incorrect
 
 #import "GNUstepBase/NSURL+GNUstepBase.h"
 
-@interface	NSURL (GSPrivate)
-- (NSURL*) _URLBySettingPath: (NSString*)newPath; 
+@interface NSURL (GSPrivate)
+- (NSURL *)_URLBySettingPath:(NSString *)newPath;
 @end
 
-@implementation	NSURL (GSPrivate)
+@implementation NSURL (GSPrivate)
 
-- (NSURL*) _URLBySettingPath: (NSString*)newPath 
+- (NSURL *)_URLBySettingPath:(NSString *)newPath
 {
-  if ([self isFileURL]) 
+  if ([self isFileURL])
     {
-      return [NSURL fileURLWithPath: newPath];
+      return [NSURL fileURLWithPath:newPath];
     }
   else
     {
-      NSURL	*u;
+      NSURL *u;
 
-      u = [[NSURL alloc] initWithScheme: [self scheme]
-				   user: [self user]
-			       password: [self password]
-				   host: [self host]
-				   port: [self port]
-			       fullPath: newPath
-			parameterString: [self parameterString]
-				  query: [self query]
-			       fragment: [self fragment]];
+      u = [[NSURL alloc] initWithScheme:[self scheme]
+				   user:[self user]
+			       password:[self password]
+				   host:[self host]
+				   port:[self port]
+			       fullPath:newPath
+			parameterString:[self parameterString]
+				  query:[self query]
+			       fragment:[self fragment]];
       return [u autorelease];
     }
 }
@@ -123,17 +123,18 @@ function may be incorrect
  * All the char* fields may be NULL pointers, except path, which
  * is *always* non-null (though it may be an empty string).
  */
-typedef struct {
-  id	absolute;		// Cache absolute string or nil
-  char	*scheme;
-  char	*user;
-  char	*password;
-  char	*host;
-  char	*port;
-  char	*path;			// May never be NULL
-  char	*parameters;
-  char	*query;
-  char	*fragment;
+typedef struct
+{
+  id	absolute; // Cache absolute string or nil
+  char *scheme;
+  char *user;
+  char *password;
+  char *host;
+  char *port;
+  char *path; // May never be NULL
+  char *parameters;
+  char *query;
+  char *fragment;
   BOOL	pathIsAbsolute;
   BOOL	emptyPath;
   BOOL	hasNoPath;
@@ -141,58 +142,64 @@ typedef struct {
   BOOL	isFile;
 } parsedURL;
 
-#define	myData ((parsedURL*)(self->_data))
-#define	baseData ((self->_baseURL == 0)?0:((parsedURL*)(self->_baseURL->_data)))
+#define myData ((parsedURL *) (self->_data))
+#define baseData                                                               \
+  ((self->_baseURL == 0) ? 0 : ((parsedURL *) (self->_baseURL->_data)))
 
-static NSLock	*clientsLock = nil;
+static NSLock *clientsLock = nil;
 
 /*
  * Local utility functions.
  */
-static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize);
-static id clientForHandle(void *data, NSURLHandle *hdl);
-static char *findUp(char *str);
-static char *unescape(const char *from, char * to);
+static char *
+buildURL(parsedURL *base, parsedURL *rel, BOOL standardize);
+static id
+clientForHandle(void *data, NSURLHandle *hdl);
+static char *
+findUp(char *str);
+static char *
+unescape(const char *from, char *to);
 
 /**
  * Build an absolute URL as a C string
  */
-static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
+static char *
+buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
 {
-  const char	*rpath;
-  char		*buf;
-  char		*ptr;
-  char		*tmp;
-  int		l;
-  unsigned int	len = 1;
+  const char * rpath;
+  char *       buf;
+  char *       ptr;
+  char *       tmp;
+  int	       l;
+  unsigned int len = 1;
 
   if (NO == rel->hasNoPath)
     {
-      len += 1;                         // trailing '/' to be added
+      len += 1; // trailing '/' to be added
     }
   if (rel->scheme != 0)
     {
-      len += strlen(rel->scheme) + 3;	// scheme://
+      len += strlen(rel->scheme) + 3; // scheme://
     }
   else if (YES == rel->isGeneric)
     {
-      len += 2;                         // need '//' even if no scheme
+      len += 2; // need '//' even if no scheme
     }
   if (rel->user != 0)
     {
-      len += strlen(rel->user) + 1;	// user...@
+      len += strlen(rel->user) + 1; // user...@
     }
   if (rel->password != 0)
     {
-      len += strlen(rel->password) + 1;	// :password
+      len += strlen(rel->password) + 1; // :password
     }
   if (rel->host != 0)
     {
-      len += strlen(rel->host) + 1;	// host.../
+      len += strlen(rel->host) + 1; // host.../
     }
   if (rel->port != 0)
     {
-      len += strlen(rel->port) + 1;	// :port
+      len += strlen(rel->port) + 1; // :port
     }
   if (rel->path != 0)
     {
@@ -202,25 +209,25 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
     {
       rpath = "";
     }
-  len += strlen(rpath) + 1;	// path
+  len += strlen(rpath) + 1; // path
   if (base != 0 && base->path != 0)
     {
-      len += strlen(base->path) + 1;	// path
+      len += strlen(base->path) + 1; // path
     }
   if (rel->parameters != 0)
     {
-      len += strlen(rel->parameters) + 1;	// ;parameters
+      len += strlen(rel->parameters) + 1; // ;parameters
     }
   if (rel->query != 0)
     {
-      len += strlen(rel->query) + 1;		// ?query
+      len += strlen(rel->query) + 1; // ?query
     }
   if (rel->fragment != 0)
     {
-      len += strlen(rel->fragment) + 1;		// #fragment
+      len += strlen(rel->fragment) + 1; // #fragment
     }
 
-  ptr = buf = (char*)NSZoneMalloc(NSDefaultMallocZone(), len);
+  ptr = buf = (char *) NSZoneMalloc(NSDefaultMallocZone(), len);
 
   if (rel->scheme != 0)
     {
@@ -229,8 +236,8 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       ptr += l;
       *ptr++ = ':';
     }
-  if (rel->isGeneric == YES
-    || rel->user != 0 || rel->password != 0 || rel->host != 0 || rel->port != 0)
+  if (rel->isGeneric == YES || rel->user != 0 || rel->password != 0
+      || rel->host != 0 || rel->port != 0)
     {
       *ptr++ = '/';
       *ptr++ = '/';
@@ -305,19 +312,19 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
     }
   else
     {
-      char	*start = base->path;
+      char *start = base->path;
 
       if (start != 0)
-        {
-          char	*end = strrchr(start, '/');
+	{
+	  char *end = strrchr(start, '/');
 
-          if (end != 0)
-            {
-              *tmp++ = '/';
-              memcpy(tmp, start, end - start);
-              tmp += (end - start);
-            }
-        }
+	  if (end != 0)
+	    {
+	      *tmp++ = '/';
+	      memcpy(tmp, start, end - start);
+	      tmp += (end - start);
+	    }
+	}
       *tmp++ = '/';
       l = strlen(rpath);
       memcpy(tmp, rpath, l);
@@ -334,7 +341,7 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       while (*tmp != '\0')
 	{
 	  if (tmp[0] == '/' && tmp[1] == '.'
-	    && (tmp[2] == '/' || tmp[2] == '\0'))
+	      && (tmp[2] == '/' || tmp[2] == '\0'))
 	    {
 	      /*
 	       * Ensure we don't remove the leading '/'
@@ -377,7 +384,7 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       tmp = ptr;
       while ((tmp = findUp(tmp)) != 0)
 	{
-	  char	*next = &tmp[3];
+	  char *next = &tmp[3];
 
 	  while (tmp > ptr)
 	    {
@@ -435,14 +442,15 @@ static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
   return buf;
 }
 
-static id clientForHandle(void *data, NSURLHandle *hdl)
+static id
+clientForHandle(void *data, NSURLHandle *hdl)
 {
-  id	client = nil;
+  id client = nil;
 
   if (data != 0)
     {
       [clientsLock lock];
-      client = (id)NSMapGet((NSMapTable*)data, hdl);
+      client = (id) NSMapGet((NSMapTable *) data, hdl);
       [clientsLock unlock];
     }
   return client;
@@ -451,12 +459,13 @@ static id clientForHandle(void *data, NSURLHandle *hdl)
 /**
  * Locate a '/../ or trailing '/..'
  */
-static char *findUp(char *str)
+static char *
+findUp(char *str)
 {
   while (*str != '\0')
     {
       if (str[0] == '/' && str[1] == '.' && str[2] == '.'
-	&& (str[3] == '/' || str[3] == '\0'))
+	  && (str[3] == '/' || str[3] == '\0'))
 	{
 	  return str;
 	}
@@ -469,9 +478,10 @@ static char *findUp(char *str)
  * Check a string to see if it contains only legal data characters
  * or percent escape sequences.
  */
-static BOOL legal(const char *str, const char *extras)
+static BOOL
+legal(const char *str, const char *extras)
 {
-  const char	*mark = "-_.!~*'()";
+  const char *mark = "-_.!~*'()";
 
   if (str != 0)
     {
@@ -505,13 +515,14 @@ static BOOL legal(const char *str, const char *extras)
 /*
  * Convert percent escape sequences to individual characters.
  */
-static char *unescape(const char *from, char * to)
+static char *
+unescape(const char *from, char *to)
 {
   while (*from != '\0')
     {
       if (*from == '%')
 	{
-	  unsigned char	c;
+	  unsigned char c;
 
 	  from++;
 	  if (isxdigit(*from))
@@ -532,9 +543,9 @@ static char *unescape(const char *from, char * to)
 	    }
 	  else
 	    {
-	      c = 0;	// Avoid compiler warning
-	      [NSException raise: NSGenericException
-			  format: @"Bad percent escape sequence in URL string"];
+	      c = 0; // Avoid compiler warning
+	      [NSException raise:NSGenericException
+			  format:@"Bad percent escape sequence in URL string"];
 	    }
 	  c <<= 4;
 	  if (isxdigit(*from))
@@ -556,8 +567,8 @@ static char *unescape(const char *from, char * to)
 	    }
 	  else
 	    {
-	      [NSException raise: NSGenericException
-			  format: @"Bad percent escape sequence in URL string"];
+	      [NSException raise:NSGenericException
+			  format:@"Bad percent escape sequence in URL string"];
 	    }
 	}
       else
@@ -569,111 +580,124 @@ static char *unescape(const char *from, char * to)
   return to;
 }
 
-
-
 @implementation NSURL
 
-static NSCharacterSet	*fileCharSet = nil;
-static NSUInteger	urlAlign;
+static NSCharacterSet *fileCharSet = nil;
+static NSUInteger      urlAlign;
 
-+ (id) fileURLWithPath: (NSString*)aPath
++ (id)fileURLWithPath:(NSString *)aPath
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath]);
 }
 
-+ (id) fileURLWithPath: (NSString*)aPath isDirectory: (BOOL)isDir
++ (id)fileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath
-					    isDirectory: isDir]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
+					    isDirectory:isDir]);
 }
 
-+ (id) fileURLWithPathComponents: (NSArray*)components
++ (id)fileURLWithPath:(NSString *)aPath
+	  isDirectory:(BOOL)isDir
+	relativeToURL:(NSURL *)baseURL
 {
-  return [self fileURLWithPath: [NSString pathWithComponents: components]];
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
+					    isDirectory:isDir
+					  relativeToURL:baseURL]);
 }
 
-+ (void) initialize
++ (id)fileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL
+{
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
+					  relativeToURL:baseURL]);
+}
+
++ (id)fileURLWithPathComponents:(NSArray *)components
+{
+  return [self fileURLWithPath:[NSString pathWithComponents:components]];
+}
+
++ (void)initialize
 {
   if (clientsLock == nil)
     {
       NSGetSizeAndAlignment(@encode(parsedURL), &urlAlign, 0);
       clientsLock = [NSLock new];
-      [[NSObject leakAt: &clientsLock] release];
-      ASSIGN(fileCharSet, [NSCharacterSet characterSetWithCharactersInString:
-        @"!$&'()*+,-./0123456789:=@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]);
+      [[NSObject leakAt:&clientsLock] release];
+      ASSIGN(fileCharSet,
+	     [NSCharacterSet characterSetWithCharactersInString:
+			       @"!$&'()*+,-./"
+			       @"0123456789:=@ABCDEFGHIJKLMNOPQRSTUVWXYZ_"
+			       @"abcdefghijklmnopqrstuvwxyz~"]);
     }
 }
 
-+ (id) URLWithString: (NSString*)aUrlString
++ (id)URLWithString:(NSString *)aUrlString
 {
-  return AUTORELEASE([[NSURL alloc] initWithString: aUrlString]);
+  return AUTORELEASE([[NSURL alloc] initWithString:aUrlString]);
 }
 
-+ (id) URLWithString: (NSString*)aUrlString
-       relativeToURL: (NSURL*)aBaseUrl
++ (id)URLWithString:(NSString *)aUrlString relativeToURL:(NSURL *)aBaseUrl
 {
-  return AUTORELEASE([[NSURL alloc] initWithString: aUrlString
-				     relativeToURL: aBaseUrl]);
+  return AUTORELEASE([[NSURL alloc] initWithString:aUrlString
+				     relativeToURL:aBaseUrl]);
 }
 
-+ (id) URLByResolvingAliasFileAtURL: (NSURL*)url 
-                            options: (NSURLBookmarkResolutionOptions)options 
-                              error: (NSError**)error
++ (id)URLByResolvingAliasFileAtURL:(NSURL *)url
+			   options:(NSURLBookmarkResolutionOptions)options
+			     error:(NSError **)error
 {
   // TODO: unimplemented
   return nil;
 }
 
-- (id) initFileURLWithPath: (NSString*)aPath
+- (id)initFileURLWithPath:(NSString *)aPath
 {
-  NSFileManager	*mgr = [NSFileManager defaultManager];
-  BOOL		flag = NO;
-
-  if (nil == aPath)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"[%@ %@] nil string parameter",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-    }
-  if ([aPath isAbsolutePath] == NO)
-    {
-      aPath = [[mgr currentDirectoryPath]
-	stringByAppendingPathComponent: aPath];
-    }
-  if ([mgr fileExistsAtPath: aPath isDirectory: &flag] == YES)
-    {
-      if ([aPath isAbsolutePath] == NO)
-	{
-	  aPath = [aPath stringByStandardizingPath];
-	}
-      if (flag == YES && [aPath hasSuffix: @"/"] == NO)
-	{
-	  aPath = [aPath stringByAppendingString: @"/"];
-	}
-    }
-  self = [self initWithScheme: NSURLFileScheme
-			 host: @""
-			 path: aPath];
+  /* isDirectory flag will be overwritten if a directory exists. */
+  self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:nil];
   return self;
 }
 
-- (id) initFileURLWithPath: (NSString*)aPath isDirectory: (BOOL)isDir
+- (id)initFileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir
 {
-  NSFileManager	*mgr = [NSFileManager defaultManager];
-  BOOL		flag = NO;
+  self = [self initFileURLWithPath:aPath isDirectory:isDir relativeToURL:nil];
+  return self;
+}
+
+- (id)initFileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL
+{
+  /* isDirectory flag will be overwritten if a directory exists. */
+  self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:baseURL];
+  return self;
+}
+
+- (id)initFileURLWithPath:(NSString *)aPath
+	      isDirectory:(BOOL)isDir
+	    relativeToURL:(NSURL *)baseURL
+{
+  NSFileManager *mgr = [NSFileManager defaultManager];
+  BOOL		 flag = NO;
 
   if (nil == aPath)
     {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"[%@ %@] nil string parameter",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+      [NSException
+	 raise:NSInvalidArgumentException
+	format:@"[%@ %@] nil string parameter", NSStringFromClass([self class]),
+	       NSStringFromSelector(_cmd)];
     }
   if ([aPath isAbsolutePath] == NO)
     {
-      aPath = [[mgr currentDirectoryPath]
-	stringByAppendingPathComponent: aPath];
+      if (baseURL)
+	{
+	  /* Append aPath to baseURL */
+	  aPath = [[baseURL relativePath] stringByAppendingPathComponent:aPath];
+	}
+      else
+	{
+	  aPath =
+	    [[mgr currentDirectoryPath] stringByAppendingPathComponent:aPath];
+	}
     }
-  if ([mgr fileExistsAtPath: aPath isDirectory: &flag] == YES)
+  if ([mgr fileExistsAtPath:aPath isDirectory:&flag] == YES)
     {
       if ([aPath isAbsolutePath] == NO)
 	{
@@ -681,56 +705,54 @@ static NSUInteger	urlAlign;
 	}
       isDir = flag;
     }
-  if (isDir == YES && [aPath hasSuffix: @"/"] == NO)
+  if (isDir == YES && [aPath hasSuffix:@"/"] == NO)
     {
-      aPath = [aPath stringByAppendingString: @"/"];
+      aPath = [aPath stringByAppendingString:@"/"];
     }
-  self = [self initWithScheme: NSURLFileScheme
-			 host: @""
-			 path: aPath];
+  self = [self initWithScheme:NSURLFileScheme host:@"" path:aPath];
   return self;
 }
 
-- (id) initWithScheme: (NSString*)aScheme
-		 host: (NSString*)aHost
-		 path: (NSString*)aPath
+- (id)initWithScheme:(NSString *)aScheme
+		host:(NSString *)aHost
+		path:(NSString *)aPath
 {
-  NSRange	r = NSMakeRange(NSNotFound, 0);
-  NSString	*auth = nil;
-  NSString	*aUrlString = [NSString alloc];
+  NSRange   r = NSMakeRange(NSNotFound, 0);
+  NSString *auth = nil;
+  NSString *aUrlString = [NSString alloc];
 
-  if ([aScheme isEqualToString: @"file"])
+  if ([aScheme isEqualToString:@"file"])
     {
-      aPath = [aPath stringByAddingPercentEncodingWithAllowedCharacters:
-	fileCharSet];
+      aPath =
+	[aPath stringByAddingPercentEncodingWithAllowedCharacters:fileCharSet];
     }
   else
     {
-      aPath = [aPath
-	stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+      aPath =
+	[aPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     }
 
-  r = [aHost rangeOfString: @"@"];
+  r = [aHost rangeOfString:@"@"];
 
   /* Allow for authentication (username:password) before actual host.
    */
   if (r.length > 0)
     {
-      auth = [aHost substringToIndex: r.location];
-      aHost = [aHost substringFromIndex: NSMaxRange(r)];
+      auth = [aHost substringToIndex:r.location];
+      aHost = [aHost substringFromIndex:NSMaxRange(r)];
     }
 
   /* Add square brackets around ipv6 address if necessary
    */
-  if ([[aHost componentsSeparatedByString: @":"] count] > 2
-    && [aHost hasPrefix: @"["] == NO)
+  if ([[aHost componentsSeparatedByString:@":"] count] > 2 &&
+      [aHost hasPrefix:@"["] == NO)
     {
-      aHost = [NSString stringWithFormat: @"[%@]", aHost];
+      aHost = [NSString stringWithFormat:@"[%@]", aHost];
     }
 
   if (auth != nil)
     {
-      aHost = [NSString stringWithFormat: @"%@@%@", auth, aHost];
+      aHost = [NSString stringWithFormat:@"%@@%@", auth, aHost];
     }
 
   if ([aPath length] > 0)
@@ -740,35 +762,33 @@ static NSUInteger	urlAlign;
        * a leading slash is intended to have that slash separating
        * the host from the path as specified in the RFC1738
        */
-      if ([aPath hasPrefix: @"/"] == YES)
-        {
-          aUrlString = [aUrlString initWithFormat: @"%@://%@%@",
-            aScheme, aHost, aPath];
-        }
+      if ([aPath hasPrefix:@"/"] == YES)
+	{
+	  aUrlString =
+	    [aUrlString initWithFormat:@"%@://%@%@", aScheme, aHost, aPath];
+	}
       else
-        {
-          aUrlString = [aUrlString initWithFormat: @"%@://%@/%@",
-            aScheme, aHost, aPath];
-        }
+	{
+	  aUrlString =
+	    [aUrlString initWithFormat:@"%@://%@/%@", aScheme, aHost, aPath];
+	}
     }
   else
     {
-      aUrlString = [aUrlString initWithFormat: @"%@://%@/",
-        aScheme, aHost];
+      aUrlString = [aUrlString initWithFormat:@"%@://%@/", aScheme, aHost];
     }
-  self = [self initWithString: aUrlString relativeToURL: nil];
+  self = [self initWithString:aUrlString relativeToURL:nil];
   RELEASE(aUrlString);
   return self;
 }
 
-- (id) initWithString: (NSString*)aUrlString
+- (id)initWithString:(NSString *)aUrlString
 {
-  self = [self initWithString: aUrlString relativeToURL: nil];
+  self = [self initWithString:aUrlString relativeToURL:nil];
   return self;
 }
 
-- (id) initWithString: (NSString*)aUrlString
-	relativeToURL: (NSURL*)aBaseUrl
+- (id)initWithString:(NSString *)aUrlString relativeToURL:(NSURL *)aBaseUrl
 {
   /* RFC 2396 'reserved' characters ...
    * as modified by RFC2732
@@ -781,463 +801,461 @@ static NSUInteger	urlAlign;
   if (nil == aUrlString)
     {
       RELEASE(self);
-      return nil;       // OSX behavior is to give up.
+      return nil; // OSX behavior is to give up.
     }
-  if ([aUrlString isKindOfClass: [NSString class]] == NO)
+  if ([aUrlString isKindOfClass:[NSString class]] == NO)
     {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"[%@ %@] bad string parameter",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+      [NSException
+	 raise:NSInvalidArgumentException
+	format:@"[%@ %@] bad string parameter", NSStringFromClass([self class]),
+	       NSStringFromSelector(_cmd)];
     }
-  if (aBaseUrl != nil
-    && [aBaseUrl isKindOfClass: [NSURL class]] == NO)
+  if (aBaseUrl != nil && [aBaseUrl isKindOfClass:[NSURL class]] == NO)
     {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"[%@ %@] bad base URL parameter",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+      [NSException
+	 raise:NSInvalidArgumentException
+	format:@"[%@ %@] bad base URL parameter",
+	       NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
   ASSIGNCOPY(_urlString, aUrlString);
   ASSIGN(_baseURL, [aBaseUrl absoluteURL]);
   NS_DURING
+  {
+    parsedURL *buf;
+    parsedURL *base = baseData;
+    unsigned   size = [_urlString length];
+    char *     end;
+    char *     start;
+    char *     ptr;
+    BOOL       usesFragments = YES;
+    BOOL       usesParameters = YES;
+    BOOL       usesQueries = YES;
+    BOOL       canBeGeneric = YES;
+
+    size += sizeof(parsedURL) + urlAlign + 1;
+    buf = _data = (parsedURL *) NSZoneMalloc(NSDefaultMallocZone(), size);
+    memset(buf, '\0', size);
+    start = end = ptr = (char *) &buf[1];
+    NS_DURING
     {
-      parsedURL	*buf;
-      parsedURL	*base = baseData;
-      unsigned	size = [_urlString length];
-      char	*end;
-      char	*start;
-      char	*ptr;
-      BOOL	usesFragments = YES;
-      BOOL	usesParameters = YES;
-      BOOL	usesQueries = YES;
-      BOOL	canBeGeneric = YES;
-
-      size += sizeof(parsedURL) + urlAlign + 1;
-      buf = _data = (parsedURL*)NSZoneMalloc(NSDefaultMallocZone(), size);
-      memset(buf, '\0', size);
-      start = end = ptr = (char*)&buf[1];
-      NS_DURING
-        {
-          [_urlString getCString: start
-                       maxLength: size
-                        encoding: NSASCIIStringEncoding];
-        }
-      NS_HANDLER
-        {
-          /* OSX behavior when given non-ascii text is to return nil.
-           */
-          RELEASE(self);
-          return nil;
-        }
-      NS_ENDHANDLER
-
-      /*
-       * Parse the scheme if possible.
-       */
-      ptr = start;
-      if (isalpha(*ptr))
-	{
-	  ptr++;
-	  while (isalnum(*ptr) || *ptr == '+' || *ptr == '-' || *ptr == '.')
-	    {
-	      ptr++;
-	    }
-	  if (*ptr == ':')
-	    {
-	      buf->scheme = start;		// Got scheme.
-	      *ptr = '\0';			// Terminate it.
-	      end = &ptr[1];
-	      /*
-	       * Standardise uppercase to lower.
-	       */
-	      while (--ptr > start)
-		{
-		  if (isupper(*ptr))
-		    {
-		      *ptr = tolower(*ptr);
-		    }
-		}
-	    }
-	}
-      start = end;
-
-      if (buf->scheme != 0 && base != 0
-        && 0 != strcmp(buf->scheme, base->scheme))
-        {
-          /* The relative URL is of a different scheme to the base ...
-           * so it's actually an absolute URL without a base.
-           */
-          DESTROY(_baseURL);
-          base = 0;
-        }
-
-      if (buf->scheme == 0 && base != 0)
-	{
-	  buf->scheme = base->scheme;
-	}
-
-      /*
-       * Set up scheme specific parsing options.
-       */
-      if (buf->scheme != 0)
-        {
-          if (strcmp(buf->scheme, "file") == 0)
-	    {
-	      buf->isFile = YES;
-	    }
-	  else if (strcmp(buf->scheme, "data") == 0)
-            {
-	      canBeGeneric = NO;
-              DESTROY(_baseURL);
-              base = 0;
-            }
-          else if (strcmp(buf->scheme, "mailto") == 0)
-	    {
-	      usesFragments = NO;
-	      usesParameters = NO;
-	      usesQueries = NO;
-	    }
-          else if (strcmp(buf->scheme, "http") == 0
-            || strcmp(buf->scheme, "https") == 0)
-	    {
-	      buf->emptyPath = YES;
-	    }
-        }
-
-      if (canBeGeneric == YES)
-	{
-	  /*
-	   * Parse the 'authority'
-	   * //user:password@host:port
-	   */
-	  if (start[0] == '/' && start[1] == '/')
-	    {
-	      buf->isGeneric = YES;
-	      start = end = &end[2];
-
-	      /*
-	       * Set 'end' to point to the start of the path, or just past
-	       * the 'authority' if there is no path.
-	       */
-	      end = strchr(start, '/');
-	      if (end == 0)
-		{
-		  buf->hasNoPath = YES;
-		  end = &start[strlen(start)];
-		}
-	      else
-		{
-		  *end++ = '\0';
-		}
-
-	      /*
-	       * Parser username:password part
-	       */
-	      ptr = strchr(start, '@');
-	      if (ptr != 0)
-		{
-		  buf->user = start;
-		  *ptr++ = '\0';
-		  start = ptr;
-		  if (legal(buf->user, ";:&=+$,") == NO)
-		    {
-		      [NSException raise: NSInvalidArgumentException
-                        format: @"[%@ %@](%@, %@) "
-			@"illegal character in user/password part",
-                        NSStringFromClass([self class]),
-                        NSStringFromSelector(_cmd),
-                        aUrlString, aBaseUrl];
-		    }
-		  ptr = strchr(buf->user, ':');
-		  if (ptr != 0)
-		    {
-		      *ptr++ = '\0';
-		      buf->password = ptr;
-		    }
-		}
-
-	      /*
-	       * Parse host:port part
-	       */
-	      buf->host = start;
-	      if (*start == '[')
-		{
-	          ptr = strchr(buf->host, ']');
-		  if (ptr == 0)
-		    {
-		      [NSException raise: NSInvalidArgumentException
-			format: @"[%@ %@](%@, %@) "
-			@"illegal ipv6 host address",
-			NSStringFromClass([self class]),
-			NSStringFromSelector(_cmd),
-			aUrlString, aBaseUrl];
-		    }
-		  else
-		    {
-		      ptr = start + 1;
-		      while (*ptr != ']')
-			{
-			  if (*ptr != ':' && *ptr != '.' && !isxdigit(*ptr))
-			    {
-			      [NSException raise: NSInvalidArgumentException
-				format: @"[%@ %@](%@, %@) "
-				@"illegal ipv6 host address",
-				NSStringFromClass([self class]),
-				NSStringFromSelector(_cmd),
-				aUrlString, aBaseUrl];
-			    }
-			  ptr++;
-			}
-		    }
-	          ptr = strchr(ptr, ':');
-		}
-	      else
-		{
-	          ptr = strchr(buf->host, ':');
-		}
-	      if (ptr != 0)
-		{
-		  const char	*str;
-
-		  *ptr++ = '\0';
-		  buf->port = ptr;
-		  str = buf->port;
-		  while (*str != 0)
-		    {
-		      if (*str == '%' && isxdigit(str[1]) && isxdigit(str[2]))
-			{
-			  unsigned char	c;
-
-			  str++;
-			  if (*str <= '9')
-			    {
-			      c = *str - '0';
-			    }
-			  else if (*str <= 'F')
-			    {
-			      c = *str - 'A' + 10;
-			    }
-			  else
-			    {
-			      c = *str - 'a' + 10;
-			    }
-			  c <<= 4;
-			  str++;
-			  if (*str <= '9')
-			    {
-			      c |= *str - '0';
-			    }
-			  else if (*str <= 'F')
-			    {
-			      c |= *str - 'A' + 10;
-			    }
-			  else
-			    {
-			      c |= *str - 'a' + 10;
-			    }
-
-			  if (isdigit(c))
-			    {
-			      str++;
-			    }
-			  else
-			    {
-			      [NSException raise: NSInvalidArgumentException
-                                format: @"[%@ %@](%@, %@) "
-				@"illegal port part",
-                                NSStringFromClass([self class]),
-                                NSStringFromSelector(_cmd),
-                                aUrlString, aBaseUrl];
-			    }
-			}
-		      else if (isdigit(*str))
-			{
-			  str++;
-			}
-		      else
-			{
-			  [NSException raise: NSInvalidArgumentException
-                            format: @"[%@ %@](%@, %@) "
-			    @"illegal character in port part",
-                            NSStringFromClass([self class]),
-                            NSStringFromSelector(_cmd),
-                            aUrlString, aBaseUrl];
-			}
-		    }
-		}
-	      start = end;
-	      /* Check for a legal host, unless it's an ipv6 address
-	       * (which would have been checked earlier).
-	       */
-	      if (*buf->host != '[' && legal(buf->host, "-") == NO)
-		{
-		  [NSException raise: NSInvalidArgumentException
-                    format: @"[%@ %@](%@, %@) "
-		    @"illegal character in host part",
-                    NSStringFromClass([self class]),
-                    NSStringFromSelector(_cmd),
-                    aUrlString, aBaseUrl];
-		}
-
-	      /*
-	       * If we have an authority component,
-	       * this must be an absolute URL
-	       */
-	      buf->pathIsAbsolute = YES;
-	      base = 0;
-	    }
-	  else
-	    {
-	      if (base != 0)
-		{
-		  buf->isGeneric = base->isGeneric;
-		}
-	      if (*start == '/')
-		{
-		  buf->pathIsAbsolute = YES;
-		  start++;
-		}
-	    }
-
-	  if (usesFragments == YES)
-	    {
-	      /*
-	       * Strip fragment string from end of url.
-	       */
-	      ptr = strchr(start, '#');
-	      if (ptr != 0)
-		{
-		  *ptr++ = '\0';
-		  if (*ptr != 0)
-		    {
-		      buf->fragment = ptr;
-		    }
-		}
-	      if (buf->fragment == 0 && base != 0)
-		{
-		  buf->fragment = base->fragment;
-		}
-	      if (legal(buf->fragment, filepath) == NO)
-		{
-		  [NSException raise: NSInvalidArgumentException
-		    format: @"[%@ %@](%@, %@) "
-		    @"illegal character in fragment part",
-		    NSStringFromClass([self class]),
-		    NSStringFromSelector(_cmd),
-		    aUrlString, aBaseUrl];
-		}
-	    }
-
-	  if (usesQueries == YES)
-	    {
-	      /*
-	       * Strip query string from end of url.
-	       */
-	      ptr = strchr(start, '?');
-	      if (ptr != 0)
-		{
-		  *ptr++ = '\0';
-		  if (*ptr != 0)
-		    {
-		      buf->query = ptr;
-		    }
-		}
-	      if (buf->query == 0 && base != 0)
-		{
-		  buf->query = base->query;
-		}
-	      if (legal(buf->query, filepath) == NO)
-		{
-		  [NSException raise: NSInvalidArgumentException
-		    format: @"[%@ %@](%@, %@) "
-		    @"illegal character in query part",
-		    NSStringFromClass([self class]),
-		    NSStringFromSelector(_cmd),
-		    aUrlString, aBaseUrl];
-		}
-	    }
-
-	  if (usesParameters == YES)
-	    {
-	      /*
-	       * Strip parameters string from end of url.
-	       */
-	      ptr = strchr(start, ';');
-	      if (ptr != 0)
-		{
-		  *ptr++ = '\0';
-		  if (*ptr != 0)
-		    {
-		      buf->parameters = ptr;
-		    }
-		}
-	      if (buf->parameters == 0 && base != 0)
-		{
-		  buf->parameters = base->parameters;
-		}
-	      if (legal(buf->parameters, filepath) == NO)
-		{
-		  [NSException raise: NSInvalidArgumentException
-		    format: @"[%@ %@](%@, %@) "
-		    @"illegal character in parameters part",
-		    NSStringFromClass([self class]),
-		    NSStringFromSelector(_cmd),
-		    aUrlString, aBaseUrl];
-		}
-	    }
-
-	  if (buf->isFile == YES)
-	    {
-	      buf->user = 0;
-	      buf->password = 0;
-	      if (base != 0 && base->host != 0)
-		{
-		  buf->host = base->host;
-		}
-	      else if (buf->host != 0 && *buf->host == 0)
-		{
-		  buf->host = 0;
-		}
-	      buf->port = 0;
-	      buf->isGeneric = YES;
-	    }
-	  else if (base != 0
-	    && buf->user == 0 && buf->password == 0
-	    && buf->host == 0 && buf->port == 0)
-	    {
-	      buf->user = base->user;
-	      buf->password = base->password;
-	      buf->host = base->host;
-	      buf->port = base->port;
-	    }
-	}
-      /*
-       * Store the path.
-       */
-      buf->path = start;
-      if (0 == base && '\0' == *buf->path && NO == buf->pathIsAbsolute)
-	{
-	  buf->hasNoPath = YES;
-	}
-      if (legal(buf->path, filepath) == NO)
-	{
-	  [NSException raise: NSInvalidArgumentException
-            format: @"[%@ %@](%@, %@) "
-	    @"illegal character in path part",
-            NSStringFromClass([self class]),
-            NSStringFromSelector(_cmd),
-            aUrlString, aBaseUrl];
-	}
+      [_urlString getCString:start
+		   maxLength:size
+		    encoding:NSASCIIStringEncoding];
     }
+    NS_HANDLER
+    {
+      /* OSX behavior when given non-ascii text is to return nil.
+       */
+      RELEASE(self);
+      return nil;
+    }
+    NS_ENDHANDLER
+
+    /*
+     * Parse the scheme if possible.
+     */
+    ptr = start;
+    if (isalpha(*ptr))
+      {
+	ptr++;
+	while (isalnum(*ptr) || *ptr == '+' || *ptr == '-' || *ptr == '.')
+	  {
+	    ptr++;
+	  }
+	if (*ptr == ':')
+	  {
+	    buf->scheme = start; // Got scheme.
+	    *ptr = '\0';	 // Terminate it.
+	    end = &ptr[1];
+	    /*
+	     * Standardise uppercase to lower.
+	     */
+	    while (--ptr > start)
+	      {
+		if (isupper(*ptr))
+		  {
+		    *ptr = tolower(*ptr);
+		  }
+	      }
+	  }
+      }
+    start = end;
+
+    if (buf->scheme != 0 && base != 0 && 0 != strcmp(buf->scheme, base->scheme))
+      {
+	/* The relative URL is of a different scheme to the base ...
+	 * so it's actually an absolute URL without a base.
+	 */
+	DESTROY(_baseURL);
+	base = 0;
+      }
+
+    if (buf->scheme == 0 && base != 0)
+      {
+	buf->scheme = base->scheme;
+      }
+
+    /*
+     * Set up scheme specific parsing options.
+     */
+    if (buf->scheme != 0)
+      {
+	if (strcmp(buf->scheme, "file") == 0)
+	  {
+	    buf->isFile = YES;
+	  }
+	else if (strcmp(buf->scheme, "data") == 0)
+	  {
+	    canBeGeneric = NO;
+	    DESTROY(_baseURL);
+	    base = 0;
+	  }
+	else if (strcmp(buf->scheme, "mailto") == 0)
+	  {
+	    usesFragments = NO;
+	    usesParameters = NO;
+	    usesQueries = NO;
+	  }
+	else if (strcmp(buf->scheme, "http") == 0
+		 || strcmp(buf->scheme, "https") == 0)
+	  {
+	    buf->emptyPath = YES;
+	  }
+      }
+
+    if (canBeGeneric == YES)
+      {
+	/*
+	 * Parse the 'authority'
+	 * //user:password@host:port
+	 */
+	if (start[0] == '/' && start[1] == '/')
+	  {
+	    buf->isGeneric = YES;
+	    start = end = &end[2];
+
+	    /*
+	     * Set 'end' to point to the start of the path, or just past
+	     * the 'authority' if there is no path.
+	     */
+	    end = strchr(start, '/');
+	    if (end == 0)
+	      {
+		buf->hasNoPath = YES;
+		end = &start[strlen(start)];
+	      }
+	    else
+	      {
+		*end++ = '\0';
+	      }
+
+	    /*
+	     * Parser username:password part
+	     */
+	    ptr = strchr(start, '@');
+	    if (ptr != 0)
+	      {
+		buf->user = start;
+		*ptr++ = '\0';
+		start = ptr;
+		if (legal(buf->user, ";:&=+$,") == NO)
+		  {
+		    [NSException
+		       raise:NSInvalidArgumentException
+		      format:@"[%@ %@](%@, %@) "
+			     @"illegal character in user/password part",
+			     NSStringFromClass([self class]),
+			     NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+		  }
+		ptr = strchr(buf->user, ':');
+		if (ptr != 0)
+		  {
+		    *ptr++ = '\0';
+		    buf->password = ptr;
+		  }
+	      }
+
+	    /*
+	     * Parse host:port part
+	     */
+	    buf->host = start;
+	    if (*start == '[')
+	      {
+		ptr = strchr(buf->host, ']');
+		if (ptr == 0)
+		  {
+		    [NSException
+		       raise:NSInvalidArgumentException
+		      format:@"[%@ %@](%@, %@) "
+			     @"illegal ipv6 host address",
+			     NSStringFromClass([self class]),
+			     NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+		  }
+		else
+		  {
+		    ptr = start + 1;
+		    while (*ptr != ']')
+		      {
+			if (*ptr != ':' && *ptr != '.' && !isxdigit(*ptr))
+			  {
+			    [NSException raise:NSInvalidArgumentException
+					format:@"[%@ %@](%@, %@) "
+					       @"illegal ipv6 host address",
+					       NSStringFromClass([self class]),
+					       NSStringFromSelector(_cmd),
+					       aUrlString, aBaseUrl];
+			  }
+			ptr++;
+		      }
+		  }
+		ptr = strchr(ptr, ':');
+	      }
+	    else
+	      {
+		ptr = strchr(buf->host, ':');
+	      }
+	    if (ptr != 0)
+	      {
+		const char *str;
+
+		*ptr++ = '\0';
+		buf->port = ptr;
+		str = buf->port;
+		while (*str != 0)
+		  {
+		    if (*str == '%' && isxdigit(str[1]) && isxdigit(str[2]))
+		      {
+			unsigned char c;
+
+			str++;
+			if (*str <= '9')
+			  {
+			    c = *str - '0';
+			  }
+			else if (*str <= 'F')
+			  {
+			    c = *str - 'A' + 10;
+			  }
+			else
+			  {
+			    c = *str - 'a' + 10;
+			  }
+			c <<= 4;
+			str++;
+			if (*str <= '9')
+			  {
+			    c |= *str - '0';
+			  }
+			else if (*str <= 'F')
+			  {
+			    c |= *str - 'A' + 10;
+			  }
+			else
+			  {
+			    c |= *str - 'a' + 10;
+			  }
+
+			if (isdigit(c))
+			  {
+			    str++;
+			  }
+			else
+			  {
+			    [NSException raise:NSInvalidArgumentException
+					format:@"[%@ %@](%@, %@) "
+					       @"illegal port part",
+					       NSStringFromClass([self class]),
+					       NSStringFromSelector(_cmd),
+					       aUrlString, aBaseUrl];
+			  }
+		      }
+		    else if (isdigit(*str))
+		      {
+			str++;
+		      }
+		    else
+		      {
+			[NSException raise:NSInvalidArgumentException
+				    format:@"[%@ %@](%@, %@) "
+					   @"illegal character in port part",
+					   NSStringFromClass([self class]),
+					   NSStringFromSelector(_cmd),
+					   aUrlString, aBaseUrl];
+		      }
+		  }
+	      }
+	    start = end;
+	    /* Check for a legal host, unless it's an ipv6 address
+	     * (which would have been checked earlier).
+	     */
+	    if (*buf->host != '[' && legal(buf->host, "-") == NO)
+	      {
+		[NSException
+		   raise:NSInvalidArgumentException
+		  format:@"[%@ %@](%@, %@) "
+			 @"illegal character in host part",
+			 NSStringFromClass([self class]),
+			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+	      }
+
+	    /*
+	     * If we have an authority component,
+	     * this must be an absolute URL
+	     */
+	    buf->pathIsAbsolute = YES;
+	    base = 0;
+	  }
+	else
+	  {
+	    if (base != 0)
+	      {
+		buf->isGeneric = base->isGeneric;
+	      }
+	    if (*start == '/')
+	      {
+		buf->pathIsAbsolute = YES;
+		start++;
+	      }
+	  }
+
+	if (usesFragments == YES)
+	  {
+	    /*
+	     * Strip fragment string from end of url.
+	     */
+	    ptr = strchr(start, '#');
+	    if (ptr != 0)
+	      {
+		*ptr++ = '\0';
+		if (*ptr != 0)
+		  {
+		    buf->fragment = ptr;
+		  }
+	      }
+	    if (buf->fragment == 0 && base != 0)
+	      {
+		buf->fragment = base->fragment;
+	      }
+	    if (legal(buf->fragment, filepath) == NO)
+	      {
+		[NSException
+		   raise:NSInvalidArgumentException
+		  format:@"[%@ %@](%@, %@) "
+			 @"illegal character in fragment part",
+			 NSStringFromClass([self class]),
+			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+	      }
+	  }
+
+	if (usesQueries == YES)
+	  {
+	    /*
+	     * Strip query string from end of url.
+	     */
+	    ptr = strchr(start, '?');
+	    if (ptr != 0)
+	      {
+		*ptr++ = '\0';
+		if (*ptr != 0)
+		  {
+		    buf->query = ptr;
+		  }
+	      }
+	    if (buf->query == 0 && base != 0)
+	      {
+		buf->query = base->query;
+	      }
+	    if (legal(buf->query, filepath) == NO)
+	      {
+		[NSException
+		   raise:NSInvalidArgumentException
+		  format:@"[%@ %@](%@, %@) "
+			 @"illegal character in query part",
+			 NSStringFromClass([self class]),
+			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+	      }
+	  }
+
+	if (usesParameters == YES)
+	  {
+	    /*
+	     * Strip parameters string from end of url.
+	     */
+	    ptr = strchr(start, ';');
+	    if (ptr != 0)
+	      {
+		*ptr++ = '\0';
+		if (*ptr != 0)
+		  {
+		    buf->parameters = ptr;
+		  }
+	      }
+	    if (buf->parameters == 0 && base != 0)
+	      {
+		buf->parameters = base->parameters;
+	      }
+	    if (legal(buf->parameters, filepath) == NO)
+	      {
+		[NSException
+		   raise:NSInvalidArgumentException
+		  format:@"[%@ %@](%@, %@) "
+			 @"illegal character in parameters part",
+			 NSStringFromClass([self class]),
+			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+	      }
+	  }
+
+	if (buf->isFile == YES)
+	  {
+	    buf->user = 0;
+	    buf->password = 0;
+	    if (base != 0 && base->host != 0)
+	      {
+		buf->host = base->host;
+	      }
+	    else if (buf->host != 0 && *buf->host == 0)
+	      {
+		buf->host = 0;
+	      }
+	    buf->port = 0;
+	    buf->isGeneric = YES;
+	  }
+	else if (base != 0 && buf->user == 0 && buf->password == 0
+		 && buf->host == 0 && buf->port == 0)
+	  {
+	    buf->user = base->user;
+	    buf->password = base->password;
+	    buf->host = base->host;
+	    buf->port = base->port;
+	  }
+      }
+    /*
+     * Store the path.
+     */
+    buf->path = start;
+    if (0 == base && '\0' == *buf->path && NO == buf->pathIsAbsolute)
+      {
+	buf->hasNoPath = YES;
+      }
+    if (legal(buf->path, filepath) == NO)
+      {
+	[NSException raise:NSInvalidArgumentException
+		    format:@"[%@ %@](%@, %@) "
+			   @"illegal character in path part",
+			   NSStringFromClass([self class]),
+			   NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
+      }
+  }
   NS_HANDLER
-    {
-      NSDebugLog(@"%@", localException);
-      DESTROY(self);
-    }
+  {
+    NSDebugLog(@"%@", localException);
+    DESTROY(self);
+  }
   NS_ENDHANDLER
   return self;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
   if (_clients != 0)
     {
@@ -1255,12 +1273,12 @@ static NSUInteger	urlAlign;
   [super dealloc];
 }
 
-- (id) copyWithZone: (NSZone*)zone
+- (id)copyWithZone:(NSZone *)zone
 {
   if (NSShouldRetainWithZone(self, zone) == NO)
     {
-      return [[[self class] allocWithZone: zone] initWithString: _urlString
-						  relativeToURL: _baseURL];
+      return [[[self class] allocWithZone:zone] initWithString:_urlString
+						 relativeToURL:_baseURL];
     }
   else
     {
@@ -1268,45 +1286,45 @@ static NSUInteger	urlAlign;
     }
 }
 
-- (NSString*) description
+- (NSString *)description
 {
-  NSString	*dscr = _urlString;
+  NSString *dscr = _urlString;
 
   if (_baseURL != nil)
     {
-      dscr = [dscr stringByAppendingFormat: @" -- %@", _baseURL];
+      dscr = [dscr stringByAppendingFormat:@" -- %@", _baseURL];
     }
   return dscr;
 }
 
-- (void) encodeWithCoder: (NSCoder*)aCoder
+- (void)encodeWithCoder:(NSCoder *)aCoder
 {
   if ([aCoder allowsKeyedCoding])
     {
-      [aCoder encodeObject: _baseURL forKey: @"NS.base"];
-      [aCoder encodeObject: _urlString forKey: @"NS.relative"];
+      [aCoder encodeObject:_baseURL forKey:@"NS.base"];
+      [aCoder encodeObject:_urlString forKey:@"NS.relative"];
     }
   else
     {
-      [aCoder encodeObject: _urlString];
-      [aCoder encodeObject: _baseURL];
+      [aCoder encodeObject:_urlString];
+      [aCoder encodeObject:_baseURL];
     }
 }
 
-- (NSUInteger) hash
+- (NSUInteger)hash
 {
   return [[self absoluteString] hash];
 }
 
-- (id) initWithCoder: (NSCoder*)aCoder
+- (id)initWithCoder:(NSCoder *)aCoder
 {
-  NSURL		*base;
-  NSString	*rel;
+  NSURL *   base;
+  NSString *rel;
 
   if ([aCoder allowsKeyedCoding])
     {
-      base = [aCoder decodeObjectForKey: @"NS.base"];
-      rel = [aCoder decodeObjectForKey: @"NS.relative"];
+      base = [aCoder decodeObjectForKey:@"NS.base"];
+      rel = [aCoder decodeObjectForKey:@"NS.relative"];
     }
   else
     {
@@ -1317,37 +1335,37 @@ static NSUInteger	urlAlign;
     {
       rel = @"";
     }
-  self = [self initWithString: rel relativeToURL: base];
+  self = [self initWithString:rel relativeToURL:base];
   return self;
 }
 
-- (BOOL) isEqual: (id)other
+- (BOOL)isEqual:(id)other
 {
-  if (other == nil || [other isKindOfClass: [NSURL class]] == NO)
+  if (other == nil || [other isKindOfClass:[NSURL class]] == NO)
     {
       return NO;
     }
-  return [[self absoluteString] isEqualToString: [other absoluteString]];
+  return [[self absoluteString] isEqualToString:[other absoluteString]];
 }
 
-- (NSString*) absoluteString
+- (NSString *)absoluteString
 {
-  NSString	*absString = myData->absolute;
+  NSString *absString = myData->absolute;
 
   if (absString == nil)
     {
-      char	*url = buildURL(baseData, myData, NO);
-      unsigned	len = strlen(url);
+      char *   url = buildURL(baseData, myData, NO);
+      unsigned len = strlen(url);
 
-      absString = [[NSString alloc] initWithCStringNoCopy: url
-						   length: len
-					     freeWhenDone: YES];
+      absString = [[NSString alloc] initWithCStringNoCopy:url
+						   length:len
+					     freeWhenDone:YES];
       myData->absolute = absString;
     }
   return absString;
 }
 
-- (NSURL*) absoluteURL
+- (NSURL *)absoluteURL
 {
   if (_baseURL == nil)
     {
@@ -1355,35 +1373,35 @@ static NSUInteger	urlAlign;
     }
   else
     {
-      return [NSURL URLWithString: [self absoluteString]];
+      return [NSURL URLWithString:[self absoluteString]];
     }
 }
 
-- (NSURL*) baseURL
+- (NSURL *)baseURL
 {
   return _baseURL;
 }
 
-- (BOOL) checkResourceIsReachableAndReturnError: (NSError **)error
+- (BOOL)checkResourceIsReachableAndReturnError:(NSError **)error
 {
   NSString *errorStr = nil;
 
   if ([self isFileURL])
     {
       NSFileManager *mgr = [NSFileManager defaultManager];
-      NSString *path = [self path];
-      
-      if ([mgr fileExistsAtPath: path])
-        {
-          if (![mgr isReadableFileAtPath: path])
-            {
-              errorStr = @"File not readable";
-            }
-        }
+      NSString *     path = [self path];
+
+      if ([mgr fileExistsAtPath:path])
+	{
+	  if (![mgr isReadableFileAtPath:path])
+	    {
+	      errorStr = @"File not readable";
+	    }
+	}
       else
-        {
-          errorStr = @"File does not exist";
-        }
+	{
+	  errorStr = @"File does not exist";
+	}
     }
   else
     {
@@ -1392,32 +1410,30 @@ static NSUInteger	urlAlign;
 
   if ((errorStr != nil) && (error != NULL))
     {
-      NSDictionary	*info;
+      NSDictionary *info;
 
-      info = [NSDictionary dictionaryWithObjectsAndKeys:
-	errorStr, NSLocalizedDescriptionKey, nil];
-      *error = [NSError errorWithDomain: @"NSURLError"
-                                   code: 0 
-                               userInfo: info];
+      info = [NSDictionary
+	dictionaryWithObjectsAndKeys:errorStr, NSLocalizedDescriptionKey, nil];
+      *error = [NSError errorWithDomain:@"NSURLError" code:0 userInfo:info];
     }
   return nil == errorStr ? YES : NO;
 }
 
-- (NSString*) fragment
+- (NSString *)fragment
 {
-  NSString	*fragment = nil;
+  NSString *fragment = nil;
 
   if (myData->fragment != 0)
     {
-      fragment = [NSString stringWithUTF8String: myData->fragment];
+      fragment = [NSString stringWithUTF8String:myData->fragment];
     }
   return fragment;
 }
 
-- (char*) _path: (char*)buf withEscapes: (BOOL)withEscapes
+- (char *)_path:(char *)buf withEscapes:(BOOL)withEscapes
 {
-  char	*ptr = buf;
-  char	*tmp = buf;
+  char *ptr = buf;
+  char *tmp = buf;
   int	l;
 
   if (myData->pathIsAbsolute == YES)
@@ -1429,7 +1445,7 @@ static NSUInteger	urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-          memcpy(tmp, myData->path, l + 1);
+	  memcpy(tmp, myData->path, l + 1);
 	}
     }
   else if (nil == _baseURL)
@@ -1437,7 +1453,7 @@ static NSUInteger	urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-          memcpy(tmp, myData->path, l + 1);
+	  memcpy(tmp, myData->path, l + 1);
 	}
     }
   else if (0 == myData->path || 0 == *myData->path)
@@ -1449,13 +1465,13 @@ static NSUInteger	urlAlign;
       if (baseData->path != 0)
 	{
 	  l = strlen(baseData->path);
-          memcpy(tmp, baseData->path, l + 1);
+	  memcpy(tmp, baseData->path, l + 1);
 	}
     }
   else
     {
-      char	*start = baseData->path;
-      char	*end = (start == 0) ? 0 : strrchr(start, '/');
+      char *start = baseData->path;
+      char *end = (start == 0) ? 0 : strrchr(start, '/');
 
       if (end != 0)
 	{
@@ -1467,7 +1483,7 @@ static NSUInteger	urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-          memcpy(tmp, myData->path, l + 1);
+	  memcpy(tmp, myData->path, l + 1);
 	}
     }
 
@@ -1476,7 +1492,7 @@ static NSUInteger	urlAlign;
       unescape(buf, buf);
     }
 
-#if	defined(_WIN32)
+#if defined(_WIN32)
   /* On windows a file URL path may be of the form C:\xxx (ie we should
    * not insert the leading slash).
    * Also the vertical bar symbol may have been used instead of the
@@ -1500,17 +1516,17 @@ static NSUInteger	urlAlign;
   return ptr;
 }
 
-- (NSString*) host
+- (NSString *)host
 {
-  NSString	*host = nil;
+  NSString *host = nil;
 
   if (myData->host != 0)
     {
-      char	buf[strlen(myData->host)+1];
+      char buf[strlen(myData->host) + 1];
 
       if (*myData->host == '[')
 	{
-	  char	*end = unescape(myData->host + 1, buf);
+	  char *end = unescape(myData->host + 1, buf);
 
 	  if (end[-1] == ']')
 	    {
@@ -1519,73 +1535,73 @@ static NSUInteger	urlAlign;
 	}
       else
 	{
-          unescape(myData->host, buf);
+	  unescape(myData->host, buf);
 	}
-      host = [NSString stringWithUTF8String: buf];
+      host = [NSString stringWithUTF8String:buf];
     }
   return host;
 }
 
-- (BOOL) isFileURL
+- (BOOL)isFileURL
 {
   return myData->isFile;
 }
 
-- (NSString*) lastPathComponent
+- (NSString *)lastPathComponent
 {
   return [[self path] lastPathComponent];
 }
 
-- (BOOL) isFileReferenceURL
+- (BOOL)isFileReferenceURL
 {
   return NO;
 }
 
-- (NSURL *) fileReferenceURL
+- (NSURL *)fileReferenceURL
 {
-  if ([self isFileURL]) 
+  if ([self isFileURL])
     {
       return self;
     }
   return nil;
 }
 
-- (NSURL *) filePathURL
+- (NSURL *)filePathURL
 {
-  if ([self isFileURL]) 
+  if ([self isFileURL])
     {
       return self;
     }
   return nil;
 }
 
-- (BOOL) getResourceValue: (id*)value 
-                   forKey: (NSString *)key 
-                    error: (NSError**)error
+- (BOOL)getResourceValue:(id *)value
+		  forKey:(NSString *)key
+		   error:(NSError **)error
 {
   // TODO: unimplemented
   return NO;
 }
 
-- (void) loadResourceDataNotifyingClient: (id)client
-			      usingCache: (BOOL)shouldUseCache
+- (void)loadResourceDataNotifyingClient:(id)client
+			     usingCache:(BOOL)shouldUseCache
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
-  NSData	*d;
+  NSURLHandle *handle = [self URLHandleUsingCache:YES];
+  NSData *     d;
 
   if (shouldUseCache == YES && (d = [handle availableResourceData]) != nil)
     {
       /*
        * We already have cached data we should use.
        */
-      if ([client respondsToSelector:
-	@selector(URL:resourceDataDidBecomeAvailable:)])
+      if ([client respondsToSelector:@selector(URL:
+				       resourceDataDidBecomeAvailable:)])
 	{
-	  [client URL: self resourceDataDidBecomeAvailable: d];
+	  [client URL:self resourceDataDidBecomeAvailable:d];
 	}
-      if ([client respondsToSelector: @selector(URLResourceDidFinishLoading:)])
+      if ([client respondsToSelector:@selector(URLResourceDidFinishLoading:)])
 	{
-	  [client URLResourceDidFinishLoading: self];
+	  [client URLResourceDidFinishLoading:self];
 	}
     }
   else
@@ -1595,12 +1611,14 @@ static NSUInteger	urlAlign;
 	  [clientsLock lock];
 	  if (_clients == 0)
 	    {
-	      _clients = NSCreateMapTable (NSObjectMapKeyCallBacks,
-		NSNonRetainedObjectMapValueCallBacks, 0);
+	      _clients
+		= NSCreateMapTable(NSObjectMapKeyCallBacks,
+				   NSNonRetainedObjectMapValueCallBacks, 0);
 	    }
-	  NSMapInsert((NSMapTable*)_clients, (void*)handle, (void*)client);
+	  NSMapInsert((NSMapTable *) _clients, (void *) handle,
+		      (void *) client);
 	  [clientsLock unlock];
-	  [handle addClient: self];
+	  [handle addClient:self];
 	}
 
       /*
@@ -1610,135 +1628,135 @@ static NSUInteger	urlAlign;
     }
 }
 
-- (NSString*) parameterString
+- (NSString *)parameterString
 {
-  NSString	*parameters = nil;
+  NSString *parameters = nil;
 
   if (myData->parameters != 0)
     {
-      parameters = [NSString stringWithUTF8String: myData->parameters];
+      parameters = [NSString stringWithUTF8String:myData->parameters];
     }
   return parameters;
 }
 
-- (NSString*) password
+- (NSString *)password
 {
-  NSString	*password = nil;
+  NSString *password = nil;
 
   if (myData->password != 0)
     {
-      char	buf[strlen(myData->password)+1];
+      char buf[strlen(myData->password) + 1];
 
       unescape(myData->password, buf);
-      password = [NSString stringWithUTF8String: buf];
+      password = [NSString stringWithUTF8String:buf];
     }
   return password;
 }
 
-- (NSString*) _pathWithEscapes: (BOOL)withEscapes
+- (NSString *)_pathWithEscapes:(BOOL)withEscapes
 {
-  NSString	*path = nil;
+  NSString *path = nil;
 
   if (YES == myData->isGeneric || 0 == myData->scheme)
     {
-      unsigned int	len = 3;
+      unsigned int len = 3;
 
       if (_baseURL != nil)
-        {
-          if (baseData->path && *baseData->path)
-            {
-              len += strlen(baseData->path);
-            }
-          else if (baseData->hasNoPath == NO)
-            {
-              len++;
-            }
-        }
+	{
+	  if (baseData->path && *baseData->path)
+	    {
+	      len += strlen(baseData->path);
+	    }
+	  else if (baseData->hasNoPath == NO)
+	    {
+	      len++;
+	    }
+	}
       if (myData->path && *myData->path)
-        {
-          len += strlen(myData->path);
-        }
+	{
+	  len += strlen(myData->path);
+	}
       else if (myData->hasNoPath == NO)
-        {
-          len++;
-        }
+	{
+	  len++;
+	}
       if (len > 3)
-        {
-          char		buf[len];
-          char		*ptr;
-          char		*tmp;
+	{
+	  char	buf[len];
+	  char *ptr;
+	  char *tmp;
 
-          ptr = [self _path: buf withEscapes: withEscapes];
+	  ptr = [self _path:buf withEscapes:withEscapes];
 
-          /* Remove any trailing '/' from the path for MacOS-X compatibility.
-           */
-          tmp = ptr + strlen(ptr) - 1;
-          if (tmp > ptr && *tmp == '/')
-            {
-              *tmp = '\0';
-            }
+	  /* Remove any trailing '/' from the path for MacOS-X compatibility.
+	   */
+	  tmp = ptr + strlen(ptr) - 1;
+	  if (tmp > ptr && *tmp == '/')
+	    {
+	      *tmp = '\0';
+	    }
 
-          path = [NSString stringWithUTF8String: ptr];
-        }
+	  path = [NSString stringWithUTF8String:ptr];
+	}
       else if (YES == myData->emptyPath)
-        {
-          /* OSX seems to use an empty string for some schemes,
-           * though it normally uses nil.
-           */
-          path = @"";
-        }
+	{
+	  /* OSX seems to use an empty string for some schemes,
+	   * though it normally uses nil.
+	   */
+	  path = @"";
+	}
     }
   return path;
 }
 
-- (NSString*) path
+- (NSString *)path
 {
-  return [self _pathWithEscapes: NO];
+  return [self _pathWithEscapes:NO];
 }
 
-- (NSArray*) pathComponents 
+- (NSArray *)pathComponents
 {
   return [[self path] pathComponents];
 }
 
-- (NSString*) pathExtension 
+- (NSString *)pathExtension
 {
   return [[self path] pathExtension];
 }
 
-- (NSNumber*) port
+- (NSNumber *)port
 {
-  NSNumber	*port = nil;
+  NSNumber *port = nil;
 
   if (myData->port != 0)
     {
-      char	buf[strlen(myData->port)+1];
+      char buf[strlen(myData->port) + 1];
 
       unescape(myData->port, buf);
-      port = [NSNumber numberWithUnsignedShort: atol(buf)];
+      port = [NSNumber numberWithUnsignedShort:atol(buf)];
     }
   return port;
 }
 
-- (id) propertyForKey: (NSString*)propertyKey
+- (id)propertyForKey:(NSString *)propertyKey
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSURLHandle *handle = [self URLHandleUsingCache:YES];
 
-  return [handle propertyForKey: propertyKey];
+  return [handle propertyForKey:propertyKey];
 }
 
-- (NSString*) query
+- (NSString *)query
 {
-  NSString	*query = nil;
+  NSString *query = nil;
 
   if (myData->query != 0)
     {
-      query = [NSString stringWithUTF8String: myData->query];
+      query = [NSString stringWithUTF8String:myData->query];
     }
   return query;
 }
 
-- (NSString*) relativePath
+- (NSString *)relativePath
 {
   if (nil == _baseURL)
     {
@@ -1746,38 +1764,38 @@ static NSUInteger	urlAlign;
     }
   else
     {
-      NSString	*path = nil;
+      NSString *path = nil;
 
       if (myData->path != 0)
 	{
-          char		buf[strlen(myData->path) + 1];
+	  char buf[strlen(myData->path) + 1];
 
-          strcpy(buf, myData->path);
-          unescape(buf, buf);
-	  path = [NSString stringWithUTF8String: buf];
+	  strcpy(buf, myData->path);
+	  unescape(buf, buf);
+	  path = [NSString stringWithUTF8String:buf];
 	}
       return path;
     }
 }
 
-- (NSString*) relativeString
+- (NSString *)relativeString
 {
   return _urlString;
 }
 
 /* Encode bycopy unless explicitly requested otherwise.
  */
-- (id) replacementObjectForPortCoder: (NSPortCoder*)aCoder
+- (id)replacementObjectForPortCoder:(NSPortCoder *)aCoder
 {
   if ([aCoder isByref] == NO)
     return self;
-  return [super replacementObjectForPortCoder: aCoder];
+  return [super replacementObjectForPortCoder:aCoder];
 }
 
-- (NSData*) resourceDataUsingCache: (BOOL)shouldUseCache
+- (NSData *)resourceDataUsingCache:(BOOL)shouldUseCache
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
-  NSData	*data = nil;
+  NSURLHandle *handle = [self URLHandleUsingCache:YES];
+  NSData *     data = nil;
 
   if ([handle status] == NSURLHandleLoadSucceeded)
     {
@@ -1794,80 +1812,79 @@ static NSUInteger	urlAlign;
   return data;
 }
 
-- (NSString*) resourceSpecifier
+- (NSString *)resourceSpecifier
 {
   if (YES == myData->isGeneric)
     {
-      NSRange	range = [_urlString rangeOfString: @"://"];
+      NSRange range = [_urlString rangeOfString:@"://"];
 
       if (range.length > 0)
-        {
-          NSString *specifier;
+	{
+	  NSString *specifier;
 
-          /* MacOSX compatibility - in the case where there is no
-           * host in the URL, just return the path (without the "//").
-           * For all other cases we return the whole specifier.
-           */
-          if (nil == [self host])
-            {
-              specifier = [_urlString substringFromIndex: NSMaxRange(range)];
-            }
-          else
-            {
-              specifier = [_urlString substringFromIndex: range.location+1];
-            }
-          return specifier;
-        }
+	  /* MacOSX compatibility - in the case where there is no
+	   * host in the URL, just return the path (without the "//").
+	   * For all other cases we return the whole specifier.
+	   */
+	  if (nil == [self host])
+	    {
+	      specifier = [_urlString substringFromIndex:NSMaxRange(range)];
+	    }
+	  else
+	    {
+	      specifier = [_urlString substringFromIndex:range.location + 1];
+	    }
+	  return specifier;
+	}
       else
-        {
-          /*
-           * Cope with URLs missing net_path info -  <scheme>:/<path>...
-           */
-          range = [_urlString rangeOfString: @":"];
-          if (range.length > 0)
-            {
-              return [_urlString substringFromIndex: range.location + 1];
-            }
-          else
-            {
-              return _urlString;
-            }
-        }
+	{
+	  /*
+	   * Cope with URLs missing net_path info -  <scheme>:/<path>...
+	   */
+	  range = [_urlString rangeOfString:@":"];
+	  if (range.length > 0)
+	    {
+	      return [_urlString substringFromIndex:range.location + 1];
+	    }
+	  else
+	    {
+	      return _urlString;
+	    }
+	}
     }
   else
     {
-      return [NSString stringWithUTF8String: myData->path];
+      return [NSString stringWithUTF8String:myData->path];
     }
 }
 
-- (NSString*) scheme
+- (NSString *)scheme
 {
-  NSString	*scheme = nil;
+  NSString *scheme = nil;
 
   if (myData->scheme != 0)
     {
-      scheme = [NSString stringWithUTF8String: myData->scheme];
+      scheme = [NSString stringWithUTF8String:myData->scheme];
     }
   return scheme;
 }
 
-- (BOOL) setProperty: (id)property
-	      forKey: (NSString*)propertyKey
+- (BOOL)setProperty:(id)property forKey:(NSString *)propertyKey
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSURLHandle *handle = [self URLHandleUsingCache:YES];
 
-  return [handle writeProperty: property forKey: propertyKey];
+  return [handle writeProperty:property forKey:propertyKey];
 }
 
-- (BOOL) setResourceData: (NSData*)data
+- (BOOL)setResourceData:(NSData *)data
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSURLHandle *handle = [self URLHandleUsingCache:YES];
 
   if (handle == nil)
     {
       return NO;
     }
-  if ([handle writeData: data] == NO)
+  if ([handle writeData:data] == NO)
     {
       return NO;
     }
@@ -1878,183 +1895,182 @@ static NSUInteger	urlAlign;
   return YES;
 }
 
-- (NSURL*) standardizedURL
+- (NSURL *)standardizedURL
 {
-  char		*url = buildURL(baseData, myData, YES);
-  unsigned	len = strlen(url);
-  NSString	*str;
-  NSURL		*tmp;
+  char *    url = buildURL(baseData, myData, YES);
+  unsigned  len = strlen(url);
+  NSString *str;
+  NSURL *   tmp;
 
-  str = [[NSString alloc] initWithCStringNoCopy: url
-					 length: len
-				   freeWhenDone: YES];
-  tmp = [NSURL URLWithString: str];
+  str = [[NSString alloc] initWithCStringNoCopy:url
+					 length:len
+				   freeWhenDone:YES];
+  tmp = [NSURL URLWithString:str];
   RELEASE(str);
   return tmp;
 }
 
-- (NSURLHandle*) URLHandleUsingCache: (BOOL)shouldUseCache
+- (NSURLHandle *)URLHandleUsingCache:(BOOL)shouldUseCache
 {
-  NSURLHandle	*handle = nil;
+  NSURLHandle *handle = nil;
 
   if (shouldUseCache)
     {
-      handle = [NSURLHandle cachedHandleForURL: self];
+      handle = [NSURLHandle cachedHandleForURL:self];
     }
   if (handle == nil)
     {
-      Class	c = [NSURLHandle URLHandleClassForURL: self];
+      Class c = [NSURLHandle URLHandleClassForURL:self];
 
       if (c != 0)
 	{
-	  handle = [[c alloc] initWithURL: self cached: shouldUseCache];
+	  handle = [[c alloc] initWithURL:self cached:shouldUseCache];
 	  IF_NO_GC([handle autorelease];)
 	}
     }
   return handle;
 }
 
-- (NSString*) user
+- (NSString *)user
 {
-  NSString	*user = nil;
+  NSString *user = nil;
 
   if (myData->user != 0)
     {
-      char	buf[strlen(myData->user)+1];
+      char buf[strlen(myData->user) + 1];
 
       unescape(myData->user, buf);
-      user = [NSString stringWithUTF8String: buf];
+      user = [NSString stringWithUTF8String:buf];
     }
   return user;
 }
 
-- (NSURL*) URLByAppendingPathComponent: (NSString*)pathComponent 
+- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
 {
-  return [self _URLBySettingPath:
-    [[self path] stringByAppendingPathComponent: pathComponent]];
+  return
+    [self _URLBySettingPath:[[self path]
+			      stringByAppendingPathComponent:pathComponent]];
 }
 
-- (NSURL*) URLByAppendingPathExtension: (NSString*)pathExtension
+- (NSURL *)URLByAppendingPathExtension:(NSString *)pathExtension
 {
-  return [self _URLBySettingPath:
-    [[self path] stringByAppendingPathExtension: pathExtension]];
+  return
+    [self _URLBySettingPath:[[self path]
+			      stringByAppendingPathExtension:pathExtension]];
 }
 
-- (NSURL*) URLByDeletingLastPathComponent 
+- (NSURL *)URLByDeletingLastPathComponent
 {
-  return [self _URLBySettingPath:
-    [[self path] stringByDeletingLastPathComponent]];
+  return
+    [self _URLBySettingPath:[[self path] stringByDeletingLastPathComponent]];
 }
 
-- (NSURL*) URLByDeletingPathExtension 
+- (NSURL *)URLByDeletingPathExtension
 {
-  return [self _URLBySettingPath:
-    [[self path] stringByDeletingPathExtension]];
+  return [self _URLBySettingPath:[[self path] stringByDeletingPathExtension]];
 }
 
-- (NSURL*) URLByResolvingSymlinksInPath 
+- (NSURL *)URLByResolvingSymlinksInPath
 {
-  if ([self isFileURL]) 
+  if ([self isFileURL])
     {
-      return [NSURL fileURLWithPath:
-	[[self path] stringByResolvingSymlinksInPath]];
+      return
+	[NSURL fileURLWithPath:[[self path] stringByResolvingSymlinksInPath]];
     }
   return self;
 }
 
-- (NSURL*) URLByStandardizingPath 
+- (NSURL *)URLByStandardizingPath
 {
-  if ([self isFileURL]) 
+  if ([self isFileURL])
     {
-      return [NSURL fileURLWithPath: [[self path] stringByStandardizingPath]];
+      return [NSURL fileURLWithPath:[[self path] stringByStandardizingPath]];
     }
   return self;
 }
 
-- (NSURL *) URLByAppendingPathComponent:(NSString *)pathComponent
-                            isDirectory:(BOOL)isDirectory
+- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
+			   isDirectory:(BOOL)isDirectory
 {
-  NSString *path = [[self path] stringByAppendingPathComponent: pathComponent];
+  NSString *path = [[self path] stringByAppendingPathComponent:pathComponent];
   if (isDirectory)
     {
-      path = [path stringByAppendingString: @"/"];
+      path = [path stringByAppendingString:@"/"];
     }
-  return [self _URLBySettingPath: path];
+  return [self _URLBySettingPath:path];
 }
 
-- (void) URLHandle: (NSURLHandle*)sender
-  resourceDataDidBecomeAvailable: (NSData*)newData
+- (void)URLHandle:(NSURLHandle *)sender
+  resourceDataDidBecomeAvailable:(NSData *)newData
 {
-  id	c = clientForHandle(_clients, sender);
+  id c = clientForHandle(_clients, sender);
 
-  if ([c respondsToSelector: @selector(URL:resourceDataDidBecomeAvailable:)])
+  if ([c respondsToSelector:@selector(URL:resourceDataDidBecomeAvailable:)])
     {
-      [c URL: self resourceDataDidBecomeAvailable: newData];
+      [c URL:self resourceDataDidBecomeAvailable:newData];
     }
 }
 
-- (void) URLHandle: (NSURLHandle*)sender
-  resourceDidFailLoadingWithReason: (NSString*)reason
+- (void)URLHandle:(NSURLHandle *)sender
+  resourceDidFailLoadingWithReason:(NSString *)reason
 {
-  id	c = clientForHandle(_clients, sender);
+  id c = clientForHandle(_clients, sender);
 
   if (c != nil)
     {
-      if ([c respondsToSelector:
-	@selector(URL:resourceDidFailLoadingWithReason:)])
+      if ([c respondsToSelector:@selector(URL:
+				  resourceDidFailLoadingWithReason:)])
 	{
-	  [c URL: self resourceDidFailLoadingWithReason: reason];
+	  [c URL:self resourceDidFailLoadingWithReason:reason];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable*)_clients, (void*)sender);
+      NSMapRemove((NSMapTable *) _clients, (void *) sender);
       [clientsLock unlock];
     }
-  [sender removeClient: self];
+  [sender removeClient:self];
 }
 
-- (void) URLHandleResourceDidBeginLoading: (NSURLHandle*)sender
+- (void)URLHandleResourceDidBeginLoading:(NSURLHandle *)sender
 {
 }
 
-- (void) URLHandleResourceDidCancelLoading: (NSURLHandle*)sender
+- (void)URLHandleResourceDidCancelLoading:(NSURLHandle *)sender
 {
-  id	c = clientForHandle(_clients, sender);
+  id c = clientForHandle(_clients, sender);
 
   if (c != nil)
     {
-      if ([c respondsToSelector: @selector(URLResourceDidCancelLoading:)])
+      if ([c respondsToSelector:@selector(URLResourceDidCancelLoading:)])
 	{
-	  [c URLResourceDidCancelLoading: self];
+	  [c URLResourceDidCancelLoading:self];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable*)_clients, (void*)sender);
+      NSMapRemove((NSMapTable *) _clients, (void *) sender);
       [clientsLock unlock];
     }
-  [sender removeClient: self];
+  [sender removeClient:self];
 }
 
-- (void) URLHandleResourceDidFinishLoading: (NSURLHandle*)sender
+- (void)URLHandleResourceDidFinishLoading:(NSURLHandle *)sender
 {
-  id	c = clientForHandle(_clients, sender);
+  id c = clientForHandle(_clients, sender);
 
   IF_NO_GC([self retain];)
-  [sender removeClient: self];
+  [sender removeClient:self];
   if (c != nil)
     {
-      if ([c respondsToSelector: @selector(URLResourceDidFinishLoading:)])
+      if ([c respondsToSelector:@selector(URLResourceDidFinishLoading:)])
 	{
-	  [c URLResourceDidFinishLoading: self];
+	  [c URLResourceDidFinishLoading:self];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable*)_clients, (void*)sender);
+      NSMapRemove((NSMapTable *) _clients, (void *) sender);
       [clientsLock unlock];
     }
   RELEASE(self);
 }
 
 @end
-
-
 
 /**
  * An informal protocol to which clients may conform if they wish to be
@@ -2064,120 +2080,114 @@ static NSUInteger	urlAlign;
  */
 @implementation NSObject (NSURLClient)
 
-- (void) URL: (NSURL*)sender
-  resourceDataDidBecomeAvailable: (NSData*)newBytes
+- (void)URL:(NSURL *)sender resourceDataDidBecomeAvailable:(NSData *)newBytes
 {
 }
 
-- (void) URL: (NSURL*)sender
-  resourceDidFailLoadingWithReason: (NSString*)reason
+- (void)URL:(NSURL *)sender resourceDidFailLoadingWithReason:(NSString *)reason
 {
 }
 
-- (void) URLResourceDidCancelLoading: (NSURL*)sender
+- (void)URLResourceDidCancelLoading:(NSURL *)sender
 {
 }
 
-- (void) URLResourceDidFinishLoading: (NSURL*)sender
+- (void)URLResourceDidFinishLoading:(NSURL *)sender
 {
 }
 
 @end
 
 @implementation NSURL (GNUstepBase)
-- (NSString*) fullPath
+- (NSString *)fullPath
 {
-  NSString	*path = nil;
+  NSString *path = nil;
 
   if (YES == myData->isGeneric || 0 == myData->scheme)
     {
-      unsigned int	len = 3;
+      unsigned int len = 3;
 
       if (_baseURL != nil)
-        {
-          if (baseData->path && *baseData->path)
-            {
-              len += strlen(baseData->path);
-            }
-          else if (baseData->hasNoPath == NO)
-            {
-              len++;
-            }
-        }
+	{
+	  if (baseData->path && *baseData->path)
+	    {
+	      len += strlen(baseData->path);
+	    }
+	  else if (baseData->hasNoPath == NO)
+	    {
+	      len++;
+	    }
+	}
       if (myData->path && *myData->path)
-        {
-          len += strlen(myData->path);
-        }
+	{
+	  len += strlen(myData->path);
+	}
       else if (myData->hasNoPath == NO)
-        {
-          len++;
-        }
+	{
+	  len++;
+	}
       if (len > 3)
-        {
-          char		buf[len];
-          char		*ptr;
+	{
+	  char	buf[len];
+	  char *ptr;
 
-          ptr = [self _path: buf withEscapes: NO];
-          path = [NSString stringWithUTF8String: ptr];
-        }
+	  ptr = [self _path:buf withEscapes:NO];
+	  path = [NSString stringWithUTF8String:ptr];
+	}
     }
   return path;
 }
 
-- (NSString*) pathWithEscapes
+- (NSString *)pathWithEscapes
 {
-  return [self _pathWithEscapes: YES];
+  return [self _pathWithEscapes:YES];
 }
 @end
 
-
-#define	GSInternal	NSURLQueryItemInternal
-#include	"GSInternal.h"
+#define GSInternal NSURLQueryItemInternal
+#include "GSInternal.h"
 GS_PRIVATE_INTERNAL(NSURLQueryItem)
-
 
 @implementation NSURLQueryItem
 
 // Creating query items.
-+ (instancetype)queryItemWithName:(NSString *)name 
-                            value:(NSString *)value
++ (instancetype)queryItemWithName:(NSString *)name value:(NSString *)value
 {
-  NSURLQueryItem *newQueryItem = [[NSURLQueryItem alloc] initWithName: name
-                                                                value: value];
+  NSURLQueryItem *newQueryItem = [[NSURLQueryItem alloc] initWithName:name
+								value:value];
   return AUTORELEASE(newQueryItem);
 }
 
-- (instancetype) init
+- (instancetype)init
 {
   self = [self initWithName:nil value:nil];
-  if(self != nil)
+  if (self != nil)
     {
-    
     }
   return self;
 }
 
-- (instancetype)initWithName:(NSString *)name 
-                       value:(NSString *)value
+- (instancetype)initWithName:(NSString *)name value:(NSString *)value
 {
   self = [super init];
-  if(self != nil)
-  {
-    GS_CREATE_INTERNAL(NSURLQueryItem);
-    if(name)
-      {
-        ASSIGNCOPY(internal->_name, name);
-      }
-    else
-      {
-        ASSIGN(internal->_name, @""); //OSX behaviour is to set an empty string for nil name property
-      }
-    ASSIGNCOPY(internal->_value, value);
-  }
+  if (self != nil)
+    {
+      GS_CREATE_INTERNAL(NSURLQueryItem);
+      if (name)
+	{
+	  ASSIGNCOPY(internal->_name, name);
+	}
+      else
+	{
+	  ASSIGN(internal->_name, @""); // OSX behaviour is to set an empty
+					// string for nil name property
+	}
+      ASSIGNCOPY(internal->_value, value);
+    }
   return self;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
   RELEASE(internal->_name);
   RELEASE(internal->_value);
@@ -2186,73 +2196,71 @@ GS_PRIVATE_INTERNAL(NSURLQueryItem)
 }
 
 // Reading a name and value from a query
-- (NSString *) name
+- (NSString *)name
 {
   return internal->_name;
 }
 
-- (NSString *) value
+- (NSString *)value
 {
   return internal->_value;
 }
 
-- (id) initWithCoder: (NSCoder *)acoder
+- (id)initWithCoder:(NSCoder *)acoder
 {
   if ((self = [super init]) != nil)
     {
       if ([acoder allowsKeyedCoding])
-        {
-          internal->_name = [acoder decodeObjectForKey: @"NS.name"];
-          internal->_value = [acoder decodeObjectForKey: @"NS.value"];
-        }
+	{
+	  internal->_name = [acoder decodeObjectForKey:@"NS.name"];
+	  internal->_value = [acoder decodeObjectForKey:@"NS.value"];
+	}
       else
-        {
-          internal->_name = [acoder decodeObject];
-          internal->_value = [acoder decodeObject];
-        }
+	{
+	  internal->_name = [acoder decodeObject];
+	  internal->_value = [acoder decodeObject];
+	}
     }
   return self;
 }
 
-- (void) encodeWithCoder: (NSCoder *)acoder
+- (void)encodeWithCoder:(NSCoder *)acoder
 {
   if ([acoder allowsKeyedCoding])
     {
-      [acoder encodeObject: internal->_name forKey: @"NS.name"];
-      [acoder encodeObject: internal->_value forKey: @"NS.value"];
+      [acoder encodeObject:internal->_name forKey:@"NS.name"];
+      [acoder encodeObject:internal->_value forKey:@"NS.value"];
     }
   else
     {
-      [acoder encodeObject: internal->_name];
-      [acoder encodeObject: internal->_value];
+      [acoder encodeObject:internal->_name];
+      [acoder encodeObject:internal->_value];
     }
 }
 
-- (id) copyWithZone: (NSZone *)zone
+- (id)copyWithZone:(NSZone *)zone
 {
-    return [[[self class] allocWithZone: zone] initWithName: internal->_name
-                                                      value: internal->_value];
+  return [[[self class] allocWithZone:zone] initWithName:internal->_name
+						   value:internal->_value];
 }
 
 @end
 
-
-#undef	GSInternal
-#define	GSInternal NSURLComponentsInternal
+#undef GSInternal
+#define GSInternal NSURLComponentsInternal
 #include "GSInternal.h"
 GS_PRIVATE_INTERNAL(NSURLComponents)
 
+@implementation NSURLComponents
 
-@implementation NSURLComponents 
+static NSCharacterSet *queryItemCharSet = nil;
 
-static NSCharacterSet	*queryItemCharSet = nil;
-
-+ (void) initialize
++ (void)initialize
 {
   if (nil == queryItemCharSet)
     {
       ENTER_POOL
-      NSMutableCharacterSet	*m;
+      NSMutableCharacterSet *m;
 
       m = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
 
@@ -2263,49 +2271,50 @@ static NSCharacterSet	*queryItemCharSet = nil;
        * where the name ends and the value starts, so we cannot permit that
        * character either.
        */
-      [m removeCharactersInString: @"&="];
+      [m removeCharactersInString:@"&="];
       queryItemCharSet = [m copy];
       LEAVE_POOL
     }
 }
 
 // Creating URL components...
-+ (instancetype) componentsWithString: (NSString *)urlString
++ (instancetype)componentsWithString:(NSString *)urlString
 {
-  return  AUTORELEASE([[NSURLComponents alloc] initWithString: urlString]);
+  return AUTORELEASE([[NSURLComponents alloc] initWithString:urlString]);
 }
 
-+ (instancetype) componentsWithURL: (NSURL *)url 
-           resolvingAgainstBaseURL: (BOOL)resolve
++ (instancetype)componentsWithURL:(NSURL *)url
+	  resolvingAgainstBaseURL:(BOOL)resolve
 {
-  return  AUTORELEASE([[NSURLComponents alloc] initWithURL: url
-                      resolvingAgainstBaseURL: resolve]);
+  return AUTORELEASE([[NSURLComponents alloc] initWithURL:url
+				  resolvingAgainstBaseURL:resolve]);
 }
 
-- (instancetype) init
+- (instancetype)init
 {
   self = [super init];
   if (self != nil)
     {
       GS_CREATE_INTERNAL(NSURLComponents);
-      
+
       internal->_rangeOfFragment = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfHost     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfHost = NSMakeRange(NSNotFound, 0);
       internal->_rangeOfPassword = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfPath     = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfPort     = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfQuery    = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfScheme   = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfUser     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPath = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPort = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfQuery = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfScheme = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfUser = NSMakeRange(NSNotFound, 0);
     }
   return self;
 }
 
-- (instancetype) initWithString: (NSString *)URLString
+- (instancetype)initWithString:(NSString *)URLString
 {
-  //OSX behavior is to return nil for a string which cannot be used to initialize valid NSURL object
-  NSURL* url = [NSURL URLWithString:URLString];
-  if(url)
+  // OSX behavior is to return nil for a string which cannot be used to
+  // initialize valid NSURL object
+  NSURL *url = [NSURL URLWithString:URLString];
+  if (url)
     {
       return [self initWithURL:url resolvingAgainstBaseURL:NO];
     }
@@ -2315,8 +2324,7 @@ static NSCharacterSet	*queryItemCharSet = nil;
     }
 }
 
-- (instancetype) initWithURL: (NSURL *)url 
-     resolvingAgainstBaseURL: (BOOL)resolve
+- (instancetype)initWithURL:(NSURL *)url resolvingAgainstBaseURL:(BOOL)resolve
 {
   self = [self init];
   if (self != nil)
@@ -2324,15 +2332,15 @@ static NSCharacterSet	*queryItemCharSet = nil;
       NSURL *tempURL = url;
 
       if (resolve)
-        {
-          tempURL = [url absoluteURL];
-        }
-      [self setURL: tempURL];
+	{
+	  tempURL = [url absoluteURL];
+	}
+      [self setURL:tempURL];
     }
   return self;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
   RELEASE(internal->_string);
   RELEASE(internal->_fragment);
@@ -2347,35 +2355,35 @@ static NSCharacterSet	*queryItemCharSet = nil;
   [super dealloc];
 }
 
-- (id) copyWithZone: (NSZone *)zone
+- (id)copyWithZone:(NSZone *)zone
 {
-  return [[NSURLComponents allocWithZone: zone] initWithURL: [self URL]
-                                    resolvingAgainstBaseURL: NO];
+  return [[NSURLComponents allocWithZone:zone] initWithURL:[self URL]
+				   resolvingAgainstBaseURL:NO];
 }
 
 // Regenerate URL when components are changed...
-- (void) _regenerateURL
+- (void)_regenerateURL
 {
-  NSMutableString	*urlString;
-  NSString		*component;
-  NSUInteger 	 	location;
-  NSUInteger 		len;
-  
+  NSMutableString *urlString;
+  NSString *	   component;
+  NSUInteger	   location;
+  NSUInteger	   len;
+
   if (internal->_dirty == NO)
     {
       return;
     }
 
-  urlString = [[NSMutableString alloc] initWithCapacity: 1000];
+  urlString = [[NSMutableString alloc] initWithCapacity:1000];
   location = 0;
   // Build up the URL from components...
   if (internal->_scheme != nil)
     {
       component = [self scheme];
-      [urlString appendString: component];
+      [urlString appendString:component];
       len = [component length];
       internal->_rangeOfScheme = NSMakeRange(location, len);
-      [urlString appendString: @"://"];
+      [urlString appendString:@"://"];
       location += len + 3;
     }
   else
@@ -2383,40 +2391,40 @@ static NSCharacterSet	*queryItemCharSet = nil;
       internal->_rangeOfScheme = NSMakeRange(NSNotFound, 0);
     }
 
-  if (internal->_user != nil) 
+  if (internal->_user != nil)
     {
       if (internal->_password != nil)
-        {
-          component = [self percentEncodedUser];
+	{
+	  component = [self percentEncodedUser];
 	  len = [component length];
-          [urlString appendString: component];
-          internal->_rangeOfUser = NSMakeRange(location, len);
-          [urlString appendString: @":"];
-          location += len + 1;
+	  [urlString appendString:component];
+	  internal->_rangeOfUser = NSMakeRange(location, len);
+	  [urlString appendString:@":"];
+	  location += len + 1;
 
-          component = [self percentEncodedPassword];
+	  component = [self percentEncodedPassword];
 	  len = [component length];
-          [urlString appendString: component];
-          internal->_rangeOfUser = NSMakeRange(location, len);
-          [urlString appendString: @"@"];
-          location += len + 1;
-        }
+	  [urlString appendString:component];
+	  internal->_rangeOfUser = NSMakeRange(location, len);
+	  [urlString appendString:@"@"];
+	  location += len + 1;
+	}
       else
-        {
-          component = [self percentEncodedUser];
+	{
+	  component = [self percentEncodedUser];
 	  len = [component length];
-          [urlString appendString: component];
-          internal->_rangeOfUser = NSMakeRange(location, len);
-          [urlString appendString: @"@"];
-          location += len + 1;
-        }
+	  [urlString appendString:component];
+	  internal->_rangeOfUser = NSMakeRange(location, len);
+	  [urlString appendString:@"@"];
+	  location += len + 1;
+	}
     }
 
   if (internal->_host != nil)
     {
       component = [self percentEncodedHost];
       len = [component length];
-      [urlString appendString: component];
+      [urlString appendString:component];
       internal->_rangeOfHost = NSMakeRange(location, len);
       location += len;
     }
@@ -2425,9 +2433,9 @@ static NSCharacterSet	*queryItemCharSet = nil;
     {
       component = [[self port] stringValue];
       len = [component length];
-      [urlString appendString: @":"];
+      [urlString appendString:@":"];
       location += 1;
-      [urlString appendString: component];
+      [urlString appendString:component];
       internal->_rangeOfPort = NSMakeRange(location, len);
       location += len;
     }
@@ -2438,7 +2446,7 @@ static NSCharacterSet	*queryItemCharSet = nil;
     {
       component = [self percentEncodedPath];
       len = [component length];
-      [urlString appendString: component];
+      [urlString appendString:component];
       internal->_rangeOfPath = NSMakeRange(location, len);
       location += len;
     }
@@ -2447,9 +2455,9 @@ static NSCharacterSet	*queryItemCharSet = nil;
     {
       component = [self percentEncodedQuery];
       len = [component length];
-      [urlString appendString: @"?"];
+      [urlString appendString:@"?"];
       location += 1;
-      [urlString appendString: component];
+      [urlString appendString:component];
       internal->_rangeOfQuery = NSMakeRange(location, len);
       location += len;
     }
@@ -2458,147 +2466,147 @@ static NSCharacterSet	*queryItemCharSet = nil;
     {
       component = [self percentEncodedFragment];
       len = [component length];
-      [urlString appendString: @"#"];
+      [urlString appendString:@"#"];
       location += 1;
-      [urlString appendString: component];
+      [urlString appendString:component];
       internal->_rangeOfFragment = NSMakeRange(location, len);
       location += len;
     }
-    
+
   ASSIGNCOPY(internal->_string, urlString);
   RELEASE(urlString);
   internal->_dirty = NO;
 }
 
 // Getting the URL
-- (NSString *) string
+- (NSString *)string
 {
   [self _regenerateURL];
   return internal->_string;
 }
 
-- (void) setString: (NSString *)urlString
+- (void)setString:(NSString *)urlString
 {
-  NSURL *url = [NSURL URLWithString: urlString];
-  [self setURL: url];
+  NSURL *url = [NSURL URLWithString:urlString];
+  [self setURL:url];
 }
 
-- (NSURL *) URL
+- (NSURL *)URL
 {
-  return AUTORELEASE([[NSURL alloc] initWithScheme: [self scheme]
-                                              user: [self user]
-                                          password: [self password]
-                                              host: [self host]
-                                              port: [self port]
-                                          fullPath: [self path]
-                                   parameterString: nil
-                                             query: [self percentEncodedQuery]
-                                          fragment: [self fragment]]);
+  return AUTORELEASE([[NSURL alloc] initWithScheme:[self scheme]
+					      user:[self user]
+					  password:[self password]
+					      host:[self host]
+					      port:[self port]
+					  fullPath:[self path]
+				   parameterString:nil
+					     query:[self percentEncodedQuery]
+					  fragment:[self fragment]]);
 }
 
-- (void) setURL: (NSURL *)url
+- (void)setURL:(NSURL *)url
 {
   // Set all the components...
-  [self setScheme: [url scheme]];
-  [self setHost: [url host]];
-  [self setPort: [url port]];
-  [self setUser: [url user]];
-  [self setPassword: [url password]];
-  [self setPath: [url path]];
+  [self setScheme:[url scheme]];
+  [self setHost:[url host]];
+  [self setPort:[url port]];
+  [self setUser:[url user]];
+  [self setPassword:[url password]];
+  [self setPath:[url path]];
   [self setPercentEncodedQuery:[url query]];
-  [self setFragment: [url fragment]];
+  [self setFragment:[url fragment]];
 }
 
-- (NSURL *) URLRelativeToURL: (NSURL *)baseURL
+- (NSURL *)URLRelativeToURL:(NSURL *)baseURL
 {
   return nil;
 }
 
 // Accessing Components in Native Format
-- (NSString *) fragment
+- (NSString *)fragment
 {
   return internal->_fragment;
 }
 
-- (void) setFragment: (NSString *)fragment
+- (void)setFragment:(NSString *)fragment
 {
   ASSIGNCOPY(internal->_fragment, fragment);
   internal->_dirty = YES;
 }
 
-- (NSString *) host
+- (NSString *)host
 {
   return internal->_host;
 }
 
-- (void) setHost: (NSString *)host
+- (void)setHost:(NSString *)host
 {
   ASSIGNCOPY(internal->_host, host);
   internal->_dirty = YES;
 }
 
-- (NSString *) password
+- (NSString *)password
 {
   return internal->_password;
 }
 
-- (void) setPassword: (NSString *)password
+- (void)setPassword:(NSString *)password
 {
   ASSIGNCOPY(internal->_password, password);
   internal->_dirty = YES;
 }
 
-- (NSString *) path
+- (NSString *)path
 {
   return internal->_path;
 }
 
-- (void) setPath: (NSString *)path
+- (void)setPath:(NSString *)path
 {
   ASSIGNCOPY(internal->_path, path);
   internal->_dirty = YES;
 }
 
-- (NSNumber *) port
+- (NSNumber *)port
 {
   return internal->_port;
 }
 
-- (void) setPort: (NSNumber *)port
+- (void)setPort:(NSNumber *)port
 {
   ASSIGNCOPY(internal->_port, port);
   internal->_dirty = YES;
 }
 
-- (NSString *) query
+- (NSString *)query
 {
-  NSString	*result = nil;
+  NSString *result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableString	*query = nil;
-      NSURLQueryItem	*item = nil;
-      NSEnumerator	*en;
+      NSMutableString *query = nil;
+      NSURLQueryItem * item = nil;
+      NSEnumerator *   en;
 
       en = [internal->_queryItems objectEnumerator];
-      while ((item = (NSURLQueryItem *)[en nextObject]) != nil)
+      while ((item = (NSURLQueryItem *) [en nextObject]) != nil)
 	{
-	  NSString	*name = [item name];
-	  NSString	*value = [item value];
+	  NSString *name = [item name];
+	  NSString *value = [item value];
 
 	  if (nil == query)
 	    {
-	      query = [[NSMutableString alloc] initWithCapacity: 1000];
+	      query = [[NSMutableString alloc] initWithCapacity:1000];
 	    }
 	  else
 	    {
-	      [query appendString: @"&"];
+	      [query appendString:@"&"];
 	    }
-	  [query appendString: name];
+	  [query appendString:name];
 	  if (value != nil)
 	    {
-	      [query appendString: @"="];
-	      [query appendString: value];
+	      [query appendString:@"="];
+	      [query appendString:value];
 	    }
 	}
       if (nil == query)
@@ -2614,30 +2622,31 @@ static NSCharacterSet	*queryItemCharSet = nil;
   return result;
 }
 
-- (void) _setQuery: (NSString *)query fromPercentEncodedString: (BOOL)encoded
+- (void)_setQuery:(NSString *)query fromPercentEncodedString:(BOOL)encoded
 {
-  /* Parse according to https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems?language=objc
+  /* Parse according to
+   * https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems?language=objc
    */
   if (nil == query)
     {
-      [self setQueryItems: nil];
+      [self setQueryItems:nil];
     }
   else if ([query length] == 0)
     {
-      [self setQueryItems: [NSArray array]];
+      [self setQueryItems:[NSArray array]];
     }
   else
     {
-      NSMutableArray	*result = [NSMutableArray arrayWithCapacity: 5];
-      NSArray 		*items = [query componentsSeparatedByString: @"&"];
-      NSEnumerator	*en = [items objectEnumerator];
-      id		item = nil;
+      NSMutableArray *result = [NSMutableArray arrayWithCapacity:5];
+      NSArray *	      items = [query componentsSeparatedByString:@"&"];
+      NSEnumerator *  en = [items objectEnumerator];
+      id	      item = nil;
 
       while ((item = [en nextObject]) != nil)
-        {
-          NSURLQueryItem	*qitem;
-	  NSString		*name;
-	  NSString		*value;
+	{
+	  NSURLQueryItem *qitem;
+	  NSString *	  name;
+	  NSString *	  value;
 
 	  if ([item length] == 0)
 	    {
@@ -2646,7 +2655,7 @@ static NSCharacterSet	*queryItemCharSet = nil;
 	    }
 	  else
 	    {
-	      NSRange	r = [item rangeOfString: @"="];
+	      NSRange r = [item rangeOfString:@"="];
 
 	      if (0 == r.length)
 		{
@@ -2656,8 +2665,8 @@ static NSCharacterSet	*queryItemCharSet = nil;
 		}
 	      else
 		{
-		  name = [item substringToIndex: r.location];
-		  value = [item substringFromIndex: NSMaxRange(r)];
+		  name = [item substringToIndex:r.location];
+		  value = [item substringFromIndex:NSMaxRange(r)];
 		}
 	    }
 	  if (encoded)
@@ -2665,129 +2674,127 @@ static NSCharacterSet	*queryItemCharSet = nil;
 	      name = [name stringByRemovingPercentEncoding];
 	      value = [value stringByRemovingPercentEncoding];
 	    }
-          qitem = [NSURLQueryItem queryItemWithName: name value: value];
-          [result addObject: qitem];
-        }
-      [self setQueryItems: result];
+	  qitem = [NSURLQueryItem queryItemWithName:name value:value];
+	  [result addObject:qitem];
+	}
+      [self setQueryItems:result];
     }
 }
 
-- (void) setQuery: (NSString *)query
+- (void)setQuery:(NSString *)query
 {
-  [self _setQuery: query fromPercentEncodedString: NO];
+  [self _setQuery:query fromPercentEncodedString:NO];
 }
 
-- (NSArray *) queryItems
+- (NSArray *)queryItems
 {
   return AUTORELEASE(RETAIN(internal->_queryItems));
 }
 
-- (void) setQueryItems: (NSArray *)queryItems
-{ 
+- (void)setQueryItems:(NSArray *)queryItems
+{
   ASSIGNCOPY(internal->_queryItems, queryItems);
   internal->_dirty = YES;
 }
 
-- (NSString *) scheme
+- (NSString *)scheme
 {
   return internal->_scheme;
 }
 
-- (void) setScheme: (NSString *)scheme
+- (void)setScheme:(NSString *)scheme
 {
   ASSIGNCOPY(internal->_scheme, scheme);
   internal->_dirty = YES;
 }
 
-- (NSString *) user
+- (NSString *)user
 {
   return internal->_user;
 }
 
-- (void) setUser: (NSString *)user
+- (void)setUser:(NSString *)user
 {
   ASSIGNCOPY(internal->_user, user);
   internal->_dirty = YES;
 }
 
 // Accessing Components in PercentEncoded Format
-- (NSString *) percentEncodedFragment
+- (NSString *)percentEncodedFragment
 {
-  return [internal->_fragment
-    stringByAddingPercentEncodingWithAllowedCharacters:
-    [NSCharacterSet URLFragmentAllowedCharacterSet]];
+  return
+    [internal->_fragment stringByAddingPercentEncodingWithAllowedCharacters:
+			   [NSCharacterSet URLFragmentAllowedCharacterSet]];
 }
 
-- (void) setPercentEncodedFragment: (NSString *)fragment
+- (void)setPercentEncodedFragment:(NSString *)fragment
 {
-  [self setFragment: [fragment stringByRemovingPercentEncoding]];
+  [self setFragment:[fragment stringByRemovingPercentEncoding]];
 }
 
-- (NSString *) percentEncodedHost
+- (NSString *)percentEncodedHost
 {
-  return [internal->_host
-    stringByAddingPercentEncodingWithAllowedCharacters:
-    [NSCharacterSet URLHostAllowedCharacterSet]];
+  return [internal->_host stringByAddingPercentEncodingWithAllowedCharacters:
+			    [NSCharacterSet URLHostAllowedCharacterSet]];
 }
 
-- (void) setPercentEncodedHost: (NSString *)host
+- (void)setPercentEncodedHost:(NSString *)host
 {
-  [self setHost: [host stringByRemovingPercentEncoding]];
+  [self setHost:[host stringByRemovingPercentEncoding]];
 }
 
-- (NSString *) percentEncodedPassword
+- (NSString *)percentEncodedPassword
 {
-  return [internal->_password
-    stringByAddingPercentEncodingWithAllowedCharacters:
-    [NSCharacterSet URLPasswordAllowedCharacterSet]];
+  return
+    [internal->_password stringByAddingPercentEncodingWithAllowedCharacters:
+			   [NSCharacterSet URLPasswordAllowedCharacterSet]];
 }
 
-- (void) setPercentEncodedPassword: (NSString *)password
+- (void)setPercentEncodedPassword:(NSString *)password
 {
-  [self setPassword: [password stringByRemovingPercentEncoding]];
+  [self setPassword:[password stringByRemovingPercentEncoding]];
 }
 
-- (NSString *) percentEncodedPath
+- (NSString *)percentEncodedPath
 {
-  return [internal->_path
-    stringByAddingPercentEncodingWithAllowedCharacters:
-    [NSCharacterSet URLPathAllowedCharacterSet]];
+  return [internal->_path stringByAddingPercentEncodingWithAllowedCharacters:
+			    [NSCharacterSet URLPathAllowedCharacterSet]];
 }
 
-- (void) setPercentEncodedPath: (NSString *)path
+- (void)setPercentEncodedPath:(NSString *)path
 {
-  [self setPath: [path stringByRemovingPercentEncoding]];
+  [self setPath:[path stringByRemovingPercentEncoding]];
 }
 
-- (NSString *) percentEncodedQuery
+- (NSString *)percentEncodedQuery
 {
-  NSString	*result = nil;
+  NSString *result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableString	*query = nil;
-      NSURLQueryItem	*item = nil;
-      NSEnumerator	*en;
+      NSMutableString *query = nil;
+      NSURLQueryItem * item = nil;
+      NSEnumerator *   en;
 
       en = [[self percentEncodedQueryItems] objectEnumerator];
-      while ((item = (NSURLQueryItem *)[en nextObject]) != nil)
+      while ((item = (NSURLQueryItem *) [en nextObject]) != nil)
 	{
-	  NSString	*name = [item name];
-	  NSString	*value = [item value];
+	  NSString *name = [item name];
+	  NSString *value = [item value];
 
 	  if (nil == query)
 	    {
-	      query = [[NSMutableString alloc] initWithCapacity: 1000];
+	      query = [[NSMutableString alloc] initWithCapacity:1000];
 	    }
 	  else
 	    {
-	      [query appendString: @"&"];
+	      [query appendString:@"&"];
 	    }
-	  [query appendString: name];
+	  [query appendString:name];
 	  if (value != nil)
 	    {
-	      [query appendString: @"="];
-	      [query appendString: value];
+	      [query appendString:@"="];
+	      [query appendString:value];
 	    }
 	}
       if (nil == query)
@@ -2803,36 +2810,35 @@ static NSCharacterSet	*queryItemCharSet = nil;
   return result;
 }
 
-- (void) setPercentEncodedQuery: (NSString *)query
+- (void)setPercentEncodedQuery:(NSString *)query
 {
-  [self _setQuery: query fromPercentEncodedString: YES];
+  [self _setQuery:query fromPercentEncodedString:YES];
 }
 
-- (NSArray *) percentEncodedQueryItems
+- (NSArray *)percentEncodedQueryItems
 {
-  NSArray	*result = nil;
+  NSArray *result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableArray	*items;
-      NSEnumerator 	*en = [internal->_queryItems objectEnumerator];
-      NSURLQueryItem	*i = nil;
+      NSMutableArray *items;
+      NSEnumerator *  en = [internal->_queryItems objectEnumerator];
+      NSURLQueryItem *i = nil;
 
-      items = [[NSMutableArray alloc]
-	initWithCapacity: [internal->_queryItems count]];
+      items =
+	[[NSMutableArray alloc] initWithCapacity:[internal->_queryItems count]];
       while ((i = [en nextObject]) != nil)
 	{
-	  NSURLQueryItem	*ni;
-	  NSString		*name = [i name];
-	  NSString		*value = [i value];
+	  NSURLQueryItem *ni;
+	  NSString *	  name = [i name];
+	  NSString *	  value = [i value];
 
 	  name = [name stringByAddingPercentEncodingWithAllowedCharacters:
-	    queryItemCharSet];
+			 queryItemCharSet];
 	  value = [value stringByAddingPercentEncodingWithAllowedCharacters:
-	    queryItemCharSet];
-	  ni = [NSURLQueryItem queryItemWithName: name
-					   value: value];
-	  [items addObject: ni];
+			   queryItemCharSet];
+	  ni = [NSURLQueryItem queryItemWithName:name value:value];
+	  [items addObject:ni];
 	}
       result = AUTORELEASE([items copy]);
       RELEASE(items);
@@ -2840,90 +2846,90 @@ static NSCharacterSet	*queryItemCharSet = nil;
   return result;
 }
 
-- (void) setPercentEncodedQueryItems: (NSArray *)queryItems
+- (void)setPercentEncodedQueryItems:(NSArray *)queryItems
 {
-  NSMutableArray	*items = nil;
+  NSMutableArray *items = nil;
 
   if (queryItems != nil)
     {
-      NSEnumerator	*en = [queryItems objectEnumerator];
-      NSURLQueryItem 	*i = nil;
+      NSEnumerator *  en = [queryItems objectEnumerator];
+      NSURLQueryItem *i = nil;
 
-      items = [NSMutableArray arrayWithCapacity: [queryItems count]];
+      items = [NSMutableArray arrayWithCapacity:[queryItems count]];
       while ((i = [en nextObject]) != nil)
 	{
-	  NSString		*name;
-	  NSString		*value;
-	  NSURLQueryItem	*ni;
+	  NSString *	  name;
+	  NSString *	  value;
+	  NSURLQueryItem *ni;
 
 	  name = [[i name] stringByRemovingPercentEncoding];
 	  value = [[i value] stringByRemovingPercentEncoding];
-	  ni = [NSURLQueryItem queryItemWithName: name value: value];
-	  [items addObject: ni];
+	  ni = [NSURLQueryItem queryItemWithName:name value:value];
+	  [items addObject:ni];
 	}
     }
 
-  [self setQueryItems: items];
+  [self setQueryItems:items];
 }
 
-- (NSString *) percentEncodedUser
+- (NSString *)percentEncodedUser
 {
   return [internal->_user stringByAddingPercentEncodingWithAllowedCharacters:
-    [NSCharacterSet URLUserAllowedCharacterSet]];
+			    [NSCharacterSet URLUserAllowedCharacterSet]];
 }
 
-- (void) setPercentEncodedUser: (NSString *)user
+- (void)setPercentEncodedUser:(NSString *)user
 {
-  [self setUser: [user stringByRemovingPercentEncoding]];
+  [self setUser:[user stringByRemovingPercentEncoding]];
 }
 
 // Locating components of the URL string representation
-- (NSRange) rangeOfFragment
+- (NSRange)rangeOfFragment
 {
   [self _regenerateURL];
   return internal->_rangeOfFragment;
 }
 
-- (NSRange) rangeOfHost
+- (NSRange)rangeOfHost
 {
   [self _regenerateURL];
   return internal->_rangeOfHost;
 }
 
-- (NSRange) rangeOfPassword
+- (NSRange)rangeOfPassword
 {
   [self _regenerateURL];
   return internal->_rangeOfPassword;
 }
 
-- (NSRange) rangeOfPath
+- (NSRange)rangeOfPath
 {
   [self _regenerateURL];
   return internal->_rangeOfPath;
 }
 
-- (NSRange) rangeOfPort
+- (NSRange)rangeOfPort
 {
   [self _regenerateURL];
   return internal->_rangeOfPort;
 }
 
-- (NSRange) rangeOfQuery
+- (NSRange)rangeOfQuery
 {
   [self _regenerateURL];
   return internal->_rangeOfQuery;
 }
 
-- (NSRange) rangeOfScheme
+- (NSRange)rangeOfScheme
 {
   [self _regenerateURL];
   return internal->_rangeOfScheme;
 }
 
-- (NSRange) rangeOfUser
+- (NSRange)rangeOfUser
 {
   [self _regenerateURL];
   return internal->_rangeOfUser;
 }
-  
+
 @end

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -7,7 +7,7 @@
    Rewrite by: 	Richard Frith-Macdonald <rfm@gnu.org>
    Date: 	Jun 2002
 
-   Add'l by:    Gregory John Casamento <greg.casamento@gmail.com>
+   Add'l by:    Gregory John Casamento <greg.casamento@gmail.com>  
    Date: 	Jan 2020
 
    This file is part of the GNUstep Library.
@@ -40,33 +40,33 @@ function may be incorrect
 * Some functions are not implemented
 */
 
-#define GS_NSURLQueryItem_IVARS                                                \
-  NSString *_name;                                                             \
-  NSString *_value;
+#define	GS_NSURLQueryItem_IVARS \
+  NSString *_name; \
+  NSString *_value; 
 
-#define GS_NSURLComponents_IVARS                                               \
-  NSString *_string;                                                           \
-  NSString *_fragment;                                                         \
-  NSString *_host;                                                             \
-  NSString *_password;                                                         \
-  NSString *_path;                                                             \
-  NSNumber *_port;                                                             \
-  NSArray * _queryItems;                                                       \
-  NSString *_scheme;                                                           \
-  NSString *_user;                                                             \
-  NSRange   _rangeOfFragment;                                                  \
-  NSRange   _rangeOfHost;                                                      \
-  NSRange   _rangeOfPassword;                                                  \
-  NSRange   _rangeOfPath;                                                      \
-  NSRange   _rangeOfPort;                                                      \
-  NSRange   _rangeOfQuery;                                                     \
-  NSRange   _rangeOfQueryItems;                                                \
-  NSRange   _rangeOfScheme;                                                    \
-  NSRange   _rangeOfUser;                                                      \
-  BOOL	    _dirty;
+#define	GS_NSURLComponents_IVARS \
+  NSString *_string; \
+  NSString *_fragment; \
+  NSString *_host; \
+  NSString *_password; \
+  NSString *_path; \
+  NSNumber *_port; \
+  NSArray  *_queryItems; \
+  NSString *_scheme; \
+  NSString *_user; \
+  NSRange   _rangeOfFragment; \
+  NSRange   _rangeOfHost; \
+  NSRange   _rangeOfPassword; \
+  NSRange   _rangeOfPath; \
+  NSRange   _rangeOfPort; \
+  NSRange   _rangeOfQuery; \
+  NSRange   _rangeOfQueryItems; \
+  NSRange   _rangeOfScheme; \
+  NSRange   _rangeOfUser; \
+  BOOL      _dirty;
 
 #import "common.h"
-#define EXPOSE_NSURL_IVARS 1
+#define	EXPOSE_NSURL_IVARS	1
 #import "Foundation/NSArray.h"
 #import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSCoder.h"
@@ -87,31 +87,31 @@ function may be incorrect
 
 #import "GNUstepBase/NSURL+GNUstepBase.h"
 
-@interface NSURL (GSPrivate)
-- (NSURL *)_URLBySettingPath:(NSString *)newPath;
+@interface	NSURL (GSPrivate)
+- (NSURL*) _URLBySettingPath: (NSString*)newPath; 
 @end
 
-@implementation NSURL (GSPrivate)
+@implementation	NSURL (GSPrivate)
 
-- (NSURL *)_URLBySettingPath:(NSString *)newPath
+- (NSURL*) _URLBySettingPath: (NSString*)newPath 
 {
-  if ([self isFileURL])
+  if ([self isFileURL]) 
     {
-      return [NSURL fileURLWithPath:newPath];
+      return [NSURL fileURLWithPath: newPath];
     }
   else
     {
-      NSURL *u;
+      NSURL	*u;
 
-      u = [[NSURL alloc] initWithScheme:[self scheme]
-				   user:[self user]
-			       password:[self password]
-				   host:[self host]
-				   port:[self port]
-			       fullPath:newPath
-			parameterString:[self parameterString]
-				  query:[self query]
-			       fragment:[self fragment]];
+      u = [[NSURL alloc] initWithScheme: [self scheme]
+				   user: [self user]
+			       password: [self password]
+				   host: [self host]
+				   port: [self port]
+			       fullPath: newPath
+			parameterString: [self parameterString]
+				  query: [self query]
+			       fragment: [self fragment]];
       return [u autorelease];
     }
 }
@@ -123,18 +123,17 @@ function may be incorrect
  * All the char* fields may be NULL pointers, except path, which
  * is *always* non-null (though it may be an empty string).
  */
-typedef struct
-{
-  id	absolute; // Cache absolute string or nil
-  char *scheme;
-  char *user;
-  char *password;
-  char *host;
-  char *port;
-  char *path; // May never be NULL
-  char *parameters;
-  char *query;
-  char *fragment;
+typedef struct {
+  id	absolute;		// Cache absolute string or nil
+  char	*scheme;
+  char	*user;
+  char	*password;
+  char	*host;
+  char	*port;
+  char	*path;			// May never be NULL
+  char	*parameters;
+  char	*query;
+  char	*fragment;
   BOOL	pathIsAbsolute;
   BOOL	emptyPath;
   BOOL	hasNoPath;
@@ -142,64 +141,58 @@ typedef struct
   BOOL	isFile;
 } parsedURL;
 
-#define myData ((parsedURL *) (self->_data))
-#define baseData                                                               \
-  ((self->_baseURL == 0) ? 0 : ((parsedURL *) (self->_baseURL->_data)))
+#define	myData ((parsedURL*)(self->_data))
+#define	baseData ((self->_baseURL == 0)?0:((parsedURL*)(self->_baseURL->_data)))
 
-static NSLock *clientsLock = nil;
+static NSLock	*clientsLock = nil;
 
 /*
  * Local utility functions.
  */
-static char *
-buildURL(parsedURL *base, parsedURL *rel, BOOL standardize);
-static id
-clientForHandle(void *data, NSURLHandle *hdl);
-static char *
-findUp(char *str);
-static char *
-unescape(const char *from, char *to);
+static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize);
+static id clientForHandle(void *data, NSURLHandle *hdl);
+static char *findUp(char *str);
+static char *unescape(const char *from, char * to);
 
 /**
  * Build an absolute URL as a C string
  */
-static char *
-buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
+static char *buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
 {
-  const char * rpath;
-  char *       buf;
-  char *       ptr;
-  char *       tmp;
-  int	       l;
-  unsigned int len = 1;
+  const char	*rpath;
+  char		*buf;
+  char		*ptr;
+  char		*tmp;
+  int		l;
+  unsigned int	len = 1;
 
   if (NO == rel->hasNoPath)
     {
-      len += 1; // trailing '/' to be added
+      len += 1;                         // trailing '/' to be added
     }
   if (rel->scheme != 0)
     {
-      len += strlen(rel->scheme) + 3; // scheme://
+      len += strlen(rel->scheme) + 3;	// scheme://
     }
   else if (YES == rel->isGeneric)
     {
-      len += 2; // need '//' even if no scheme
+      len += 2;                         // need '//' even if no scheme
     }
   if (rel->user != 0)
     {
-      len += strlen(rel->user) + 1; // user...@
+      len += strlen(rel->user) + 1;	// user...@
     }
   if (rel->password != 0)
     {
-      len += strlen(rel->password) + 1; // :password
+      len += strlen(rel->password) + 1;	// :password
     }
   if (rel->host != 0)
     {
-      len += strlen(rel->host) + 1; // host.../
+      len += strlen(rel->host) + 1;	// host.../
     }
   if (rel->port != 0)
     {
-      len += strlen(rel->port) + 1; // :port
+      len += strlen(rel->port) + 1;	// :port
     }
   if (rel->path != 0)
     {
@@ -209,25 +202,25 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
     {
       rpath = "";
     }
-  len += strlen(rpath) + 1; // path
+  len += strlen(rpath) + 1;	// path
   if (base != 0 && base->path != 0)
     {
-      len += strlen(base->path) + 1; // path
+      len += strlen(base->path) + 1;	// path
     }
   if (rel->parameters != 0)
     {
-      len += strlen(rel->parameters) + 1; // ;parameters
+      len += strlen(rel->parameters) + 1;	// ;parameters
     }
   if (rel->query != 0)
     {
-      len += strlen(rel->query) + 1; // ?query
+      len += strlen(rel->query) + 1;		// ?query
     }
   if (rel->fragment != 0)
     {
-      len += strlen(rel->fragment) + 1; // #fragment
+      len += strlen(rel->fragment) + 1;		// #fragment
     }
 
-  ptr = buf = (char *) NSZoneMalloc(NSDefaultMallocZone(), len);
+  ptr = buf = (char*)NSZoneMalloc(NSDefaultMallocZone(), len);
 
   if (rel->scheme != 0)
     {
@@ -236,8 +229,8 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       ptr += l;
       *ptr++ = ':';
     }
-  if (rel->isGeneric == YES || rel->user != 0 || rel->password != 0
-      || rel->host != 0 || rel->port != 0)
+  if (rel->isGeneric == YES
+    || rel->user != 0 || rel->password != 0 || rel->host != 0 || rel->port != 0)
     {
       *ptr++ = '/';
       *ptr++ = '/';
@@ -312,19 +305,19 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
     }
   else
     {
-      char *start = base->path;
+      char	*start = base->path;
 
       if (start != 0)
-	{
-	  char *end = strrchr(start, '/');
+        {
+          char	*end = strrchr(start, '/');
 
-	  if (end != 0)
-	    {
-	      *tmp++ = '/';
-	      memcpy(tmp, start, end - start);
-	      tmp += (end - start);
-	    }
-	}
+          if (end != 0)
+            {
+              *tmp++ = '/';
+              memcpy(tmp, start, end - start);
+              tmp += (end - start);
+            }
+        }
       *tmp++ = '/';
       l = strlen(rpath);
       memcpy(tmp, rpath, l);
@@ -341,7 +334,7 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       while (*tmp != '\0')
 	{
 	  if (tmp[0] == '/' && tmp[1] == '.'
-	      && (tmp[2] == '/' || tmp[2] == '\0'))
+	    && (tmp[2] == '/' || tmp[2] == '\0'))
 	    {
 	      /*
 	       * Ensure we don't remove the leading '/'
@@ -384,7 +377,7 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
       tmp = ptr;
       while ((tmp = findUp(tmp)) != 0)
 	{
-	  char *next = &tmp[3];
+	  char	*next = &tmp[3];
 
 	  while (tmp > ptr)
 	    {
@@ -442,15 +435,14 @@ buildURL(parsedURL *base, parsedURL *rel, BOOL standardize)
   return buf;
 }
 
-static id
-clientForHandle(void *data, NSURLHandle *hdl)
+static id clientForHandle(void *data, NSURLHandle *hdl)
 {
-  id client = nil;
+  id	client = nil;
 
   if (data != 0)
     {
       [clientsLock lock];
-      client = (id) NSMapGet((NSMapTable *) data, hdl);
+      client = (id)NSMapGet((NSMapTable*)data, hdl);
       [clientsLock unlock];
     }
   return client;
@@ -459,13 +451,12 @@ clientForHandle(void *data, NSURLHandle *hdl)
 /**
  * Locate a '/../ or trailing '/..'
  */
-static char *
-findUp(char *str)
+static char *findUp(char *str)
 {
   while (*str != '\0')
     {
       if (str[0] == '/' && str[1] == '.' && str[2] == '.'
-	  && (str[3] == '/' || str[3] == '\0'))
+	&& (str[3] == '/' || str[3] == '\0'))
 	{
 	  return str;
 	}
@@ -478,10 +469,9 @@ findUp(char *str)
  * Check a string to see if it contains only legal data characters
  * or percent escape sequences.
  */
-static BOOL
-legal(const char *str, const char *extras)
+static BOOL legal(const char *str, const char *extras)
 {
-  const char *mark = "-_.!~*'()";
+  const char	*mark = "-_.!~*'()";
 
   if (str != 0)
     {
@@ -515,14 +505,13 @@ legal(const char *str, const char *extras)
 /*
  * Convert percent escape sequences to individual characters.
  */
-static char *
-unescape(const char *from, char *to)
+static char *unescape(const char *from, char * to)
 {
   while (*from != '\0')
     {
       if (*from == '%')
 	{
-	  unsigned char c;
+	  unsigned char	c;
 
 	  from++;
 	  if (isxdigit(*from))
@@ -543,9 +532,9 @@ unescape(const char *from, char *to)
 	    }
 	  else
 	    {
-	      c = 0; // Avoid compiler warning
-	      [NSException raise:NSGenericException
-			  format:@"Bad percent escape sequence in URL string"];
+	      c = 0;	// Avoid compiler warning
+	      [NSException raise: NSGenericException
+			  format: @"Bad percent escape sequence in URL string"];
 	    }
 	  c <<= 4;
 	  if (isxdigit(*from))
@@ -567,8 +556,8 @@ unescape(const char *from, char *to)
 	    }
 	  else
 	    {
-	      [NSException raise:NSGenericException
-			  format:@"Bad percent escape sequence in URL string"];
+	      [NSException raise: NSGenericException
+			  format: @"Bad percent escape sequence in URL string"];
 	    }
 	}
       else
@@ -580,25 +569,27 @@ unescape(const char *from, char *to)
   return to;
 }
 
+
+
 @implementation NSURL
 
-static NSCharacterSet *fileCharSet = nil;
-static NSUInteger      urlAlign;
+static NSCharacterSet	*fileCharSet = nil;
+static NSUInteger	urlAlign;
 
-+ (id)fileURLWithPath:(NSString *)aPath
++ (id) fileURLWithPath: (NSString*)aPath
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath]);
 }
 
-+ (id)fileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir
++ (id) fileURLWithPath: (NSString*)aPath isDirectory: (BOOL)isDir
 {
-  return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
-					    isDirectory:isDir]);
+  return AUTORELEASE([[NSURL alloc] initFileURLWithPath: aPath
+					    isDirectory: isDir]);
 }
 
-+ (id)fileURLWithPath:(NSString *)aPath
-	  isDirectory:(BOOL)isDir
-	relativeToURL:(NSURL *)baseURL
++ (id) fileURLWithPath: (NSString *)aPath
+	      isDirectory: (BOOL)isDir
+	    relativeToURL: (NSURL *)baseURL
 {
   return AUTORELEASE([[NSURL alloc] initFileURLWithPath:aPath
 					    isDirectory:isDir
@@ -611,68 +602,66 @@ static NSUInteger      urlAlign;
 					  relativeToURL:baseURL]);
 }
 
-+ (id)fileURLWithPathComponents:(NSArray *)components
++ (id) fileURLWithPathComponents: (NSArray*)components
 {
-  return [self fileURLWithPath:[NSString pathWithComponents:components]];
+  return [self fileURLWithPath: [NSString pathWithComponents: components]];
 }
 
-+ (void)initialize
++ (void) initialize
 {
   if (clientsLock == nil)
     {
       NSGetSizeAndAlignment(@encode(parsedURL), &urlAlign, 0);
       clientsLock = [NSLock new];
-      [[NSObject leakAt:&clientsLock] release];
-      ASSIGN(fileCharSet,
-	     [NSCharacterSet characterSetWithCharactersInString:
-			       @"!$&'()*+,-./"
-			       @"0123456789:=@ABCDEFGHIJKLMNOPQRSTUVWXYZ_"
-			       @"abcdefghijklmnopqrstuvwxyz~"]);
+      [[NSObject leakAt: &clientsLock] release];
+      ASSIGN(fileCharSet, [NSCharacterSet characterSetWithCharactersInString:
+        @"!$&'()*+,-./0123456789:=@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]);
     }
 }
 
-+ (id)URLWithString:(NSString *)aUrlString
++ (id) URLWithString: (NSString*)aUrlString
 {
-  return AUTORELEASE([[NSURL alloc] initWithString:aUrlString]);
+  return AUTORELEASE([[NSURL alloc] initWithString: aUrlString]);
 }
 
-+ (id)URLWithString:(NSString *)aUrlString relativeToURL:(NSURL *)aBaseUrl
++ (id) URLWithString: (NSString*)aUrlString
+       relativeToURL: (NSURL*)aBaseUrl
 {
-  return AUTORELEASE([[NSURL alloc] initWithString:aUrlString
-				     relativeToURL:aBaseUrl]);
+  return AUTORELEASE([[NSURL alloc] initWithString: aUrlString
+				     relativeToURL: aBaseUrl]);
 }
 
-+ (id)URLByResolvingAliasFileAtURL:(NSURL *)url
-			   options:(NSURLBookmarkResolutionOptions)options
-			     error:(NSError **)error
++ (id) URLByResolvingAliasFileAtURL: (NSURL*)url 
+                            options: (NSURLBookmarkResolutionOptions)options 
+                              error: (NSError**)error
 {
   // TODO: unimplemented
   return nil;
 }
 
-- (id)initFileURLWithPath:(NSString *)aPath
+- (id) initFileURLWithPath: (NSString *)aPath
 {
   /* isDirectory flag will be overwritten if a directory exists. */
   self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:nil];
   return self;
 }
 
-- (id)initFileURLWithPath:(NSString *)aPath isDirectory:(BOOL)isDir
+- (id) initFileURLWithPath: (NSString *)aPath isDirectory: (BOOL)isDir
 {
   self = [self initFileURLWithPath:aPath isDirectory:isDir relativeToURL:nil];
   return self;
 }
 
-- (id)initFileURLWithPath:(NSString *)aPath relativeToURL:(NSURL *)baseURL
+- (id) initFileURLWithPath: (NSString *)aPath relativeToURL: (NSURL *)baseURL
 {
   /* isDirectory flag will be overwritten if a directory exists. */
   self = [self initFileURLWithPath:aPath isDirectory:NO relativeToURL:baseURL];
   return self;
 }
 
-- (id)initFileURLWithPath:(NSString *)aPath
-	      isDirectory:(BOOL)isDir
-	    relativeToURL:(NSURL *)baseURL
+- (id) initFileURLWithPath: (NSString *)aPath
+	           isDirectory: (BOOL)isDir
+	         relativeToURL: (NSURL *)baseURL
 {
   NSFileManager *mgr = [NSFileManager defaultManager];
   BOOL		 flag = NO;
@@ -713,46 +702,46 @@ static NSUInteger      urlAlign;
   return self;
 }
 
-- (id)initWithScheme:(NSString *)aScheme
-		host:(NSString *)aHost
-		path:(NSString *)aPath
+- (id) initWithScheme: (NSString*)aScheme
+		 host: (NSString*)aHost
+		 path: (NSString*)aPath
 {
-  NSRange   r = NSMakeRange(NSNotFound, 0);
-  NSString *auth = nil;
-  NSString *aUrlString = [NSString alloc];
+  NSRange	r = NSMakeRange(NSNotFound, 0);
+  NSString	*auth = nil;
+  NSString	*aUrlString = [NSString alloc];
 
-  if ([aScheme isEqualToString:@"file"])
+  if ([aScheme isEqualToString: @"file"])
     {
-      aPath =
-	[aPath stringByAddingPercentEncodingWithAllowedCharacters:fileCharSet];
+      aPath = [aPath stringByAddingPercentEncodingWithAllowedCharacters:
+	fileCharSet];
     }
   else
     {
-      aPath =
-	[aPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+      aPath = [aPath
+	stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
     }
 
-  r = [aHost rangeOfString:@"@"];
+  r = [aHost rangeOfString: @"@"];
 
   /* Allow for authentication (username:password) before actual host.
    */
   if (r.length > 0)
     {
-      auth = [aHost substringToIndex:r.location];
-      aHost = [aHost substringFromIndex:NSMaxRange(r)];
+      auth = [aHost substringToIndex: r.location];
+      aHost = [aHost substringFromIndex: NSMaxRange(r)];
     }
 
   /* Add square brackets around ipv6 address if necessary
    */
-  if ([[aHost componentsSeparatedByString:@":"] count] > 2 &&
-      [aHost hasPrefix:@"["] == NO)
+  if ([[aHost componentsSeparatedByString: @":"] count] > 2
+    && [aHost hasPrefix: @"["] == NO)
     {
-      aHost = [NSString stringWithFormat:@"[%@]", aHost];
+      aHost = [NSString stringWithFormat: @"[%@]", aHost];
     }
 
   if (auth != nil)
     {
-      aHost = [NSString stringWithFormat:@"%@@%@", auth, aHost];
+      aHost = [NSString stringWithFormat: @"%@@%@", auth, aHost];
     }
 
   if ([aPath length] > 0)
@@ -762,33 +751,35 @@ static NSUInteger      urlAlign;
        * a leading slash is intended to have that slash separating
        * the host from the path as specified in the RFC1738
        */
-      if ([aPath hasPrefix:@"/"] == YES)
-	{
-	  aUrlString =
-	    [aUrlString initWithFormat:@"%@://%@%@", aScheme, aHost, aPath];
-	}
+      if ([aPath hasPrefix: @"/"] == YES)
+        {
+          aUrlString = [aUrlString initWithFormat: @"%@://%@%@",
+            aScheme, aHost, aPath];
+        }
       else
-	{
-	  aUrlString =
-	    [aUrlString initWithFormat:@"%@://%@/%@", aScheme, aHost, aPath];
-	}
+        {
+          aUrlString = [aUrlString initWithFormat: @"%@://%@/%@",
+            aScheme, aHost, aPath];
+        }
     }
   else
     {
-      aUrlString = [aUrlString initWithFormat:@"%@://%@/", aScheme, aHost];
+      aUrlString = [aUrlString initWithFormat: @"%@://%@/",
+        aScheme, aHost];
     }
-  self = [self initWithString:aUrlString relativeToURL:nil];
+  self = [self initWithString: aUrlString relativeToURL: nil];
   RELEASE(aUrlString);
   return self;
 }
 
-- (id)initWithString:(NSString *)aUrlString
+- (id) initWithString: (NSString*)aUrlString
 {
-  self = [self initWithString:aUrlString relativeToURL:nil];
+  self = [self initWithString: aUrlString relativeToURL: nil];
   return self;
 }
 
-- (id)initWithString:(NSString *)aUrlString relativeToURL:(NSURL *)aBaseUrl
+- (id) initWithString: (NSString*)aUrlString
+	relativeToURL: (NSURL*)aBaseUrl
 {
   /* RFC 2396 'reserved' characters ...
    * as modified by RFC2732
@@ -801,461 +792,463 @@ static NSUInteger      urlAlign;
   if (nil == aUrlString)
     {
       RELEASE(self);
-      return nil; // OSX behavior is to give up.
+      return nil;       // OSX behavior is to give up.
     }
-  if ([aUrlString isKindOfClass:[NSString class]] == NO)
+  if ([aUrlString isKindOfClass: [NSString class]] == NO)
     {
-      [NSException
-	 raise:NSInvalidArgumentException
-	format:@"[%@ %@] bad string parameter", NSStringFromClass([self class]),
-	       NSStringFromSelector(_cmd)];
+      [NSException raise: NSInvalidArgumentException
+		  format: @"[%@ %@] bad string parameter",
+	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
-  if (aBaseUrl != nil && [aBaseUrl isKindOfClass:[NSURL class]] == NO)
+  if (aBaseUrl != nil
+    && [aBaseUrl isKindOfClass: [NSURL class]] == NO)
     {
-      [NSException
-	 raise:NSInvalidArgumentException
-	format:@"[%@ %@] bad base URL parameter",
-	       NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+      [NSException raise: NSInvalidArgumentException
+		  format: @"[%@ %@] bad base URL parameter",
+	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
   ASSIGNCOPY(_urlString, aUrlString);
   ASSIGN(_baseURL, [aBaseUrl absoluteURL]);
   NS_DURING
-  {
-    parsedURL *buf;
-    parsedURL *base = baseData;
-    unsigned   size = [_urlString length];
-    char *     end;
-    char *     start;
-    char *     ptr;
-    BOOL       usesFragments = YES;
-    BOOL       usesParameters = YES;
-    BOOL       usesQueries = YES;
-    BOOL       canBeGeneric = YES;
+    {
+      parsedURL	*buf;
+      parsedURL	*base = baseData;
+      unsigned	size = [_urlString length];
+      char	*end;
+      char	*start;
+      char	*ptr;
+      BOOL	usesFragments = YES;
+      BOOL	usesParameters = YES;
+      BOOL	usesQueries = YES;
+      BOOL	canBeGeneric = YES;
 
-    size += sizeof(parsedURL) + urlAlign + 1;
-    buf = _data = (parsedURL *) NSZoneMalloc(NSDefaultMallocZone(), size);
-    memset(buf, '\0', size);
-    start = end = ptr = (char *) &buf[1];
-    NS_DURING
-    {
-      [_urlString getCString:start
-		   maxLength:size
-		    encoding:NSASCIIStringEncoding];
-    }
-    NS_HANDLER
-    {
-      /* OSX behavior when given non-ascii text is to return nil.
+      size += sizeof(parsedURL) + urlAlign + 1;
+      buf = _data = (parsedURL*)NSZoneMalloc(NSDefaultMallocZone(), size);
+      memset(buf, '\0', size);
+      start = end = ptr = (char*)&buf[1];
+      NS_DURING
+        {
+          [_urlString getCString: start
+                       maxLength: size
+                        encoding: NSASCIIStringEncoding];
+        }
+      NS_HANDLER
+        {
+          /* OSX behavior when given non-ascii text is to return nil.
+           */
+          RELEASE(self);
+          return nil;
+        }
+      NS_ENDHANDLER
+
+      /*
+       * Parse the scheme if possible.
        */
-      RELEASE(self);
-      return nil;
+      ptr = start;
+      if (isalpha(*ptr))
+	{
+	  ptr++;
+	  while (isalnum(*ptr) || *ptr == '+' || *ptr == '-' || *ptr == '.')
+	    {
+	      ptr++;
+	    }
+	  if (*ptr == ':')
+	    {
+	      buf->scheme = start;		// Got scheme.
+	      *ptr = '\0';			// Terminate it.
+	      end = &ptr[1];
+	      /*
+	       * Standardise uppercase to lower.
+	       */
+	      while (--ptr > start)
+		{
+		  if (isupper(*ptr))
+		    {
+		      *ptr = tolower(*ptr);
+		    }
+		}
+	    }
+	}
+      start = end;
+
+      if (buf->scheme != 0 && base != 0
+        && 0 != strcmp(buf->scheme, base->scheme))
+        {
+          /* The relative URL is of a different scheme to the base ...
+           * so it's actually an absolute URL without a base.
+           */
+          DESTROY(_baseURL);
+          base = 0;
+        }
+
+      if (buf->scheme == 0 && base != 0)
+	{
+	  buf->scheme = base->scheme;
+	}
+
+      /*
+       * Set up scheme specific parsing options.
+       */
+      if (buf->scheme != 0)
+        {
+          if (strcmp(buf->scheme, "file") == 0)
+	    {
+	      buf->isFile = YES;
+	    }
+	  else if (strcmp(buf->scheme, "data") == 0)
+            {
+	      canBeGeneric = NO;
+              DESTROY(_baseURL);
+              base = 0;
+            }
+          else if (strcmp(buf->scheme, "mailto") == 0)
+	    {
+	      usesFragments = NO;
+	      usesParameters = NO;
+	      usesQueries = NO;
+	    }
+          else if (strcmp(buf->scheme, "http") == 0
+            || strcmp(buf->scheme, "https") == 0)
+	    {
+	      buf->emptyPath = YES;
+	    }
+        }
+
+      if (canBeGeneric == YES)
+	{
+	  /*
+	   * Parse the 'authority'
+	   * //user:password@host:port
+	   */
+	  if (start[0] == '/' && start[1] == '/')
+	    {
+	      buf->isGeneric = YES;
+	      start = end = &end[2];
+
+	      /*
+	       * Set 'end' to point to the start of the path, or just past
+	       * the 'authority' if there is no path.
+	       */
+	      end = strchr(start, '/');
+	      if (end == 0)
+		{
+		  buf->hasNoPath = YES;
+		  end = &start[strlen(start)];
+		}
+	      else
+		{
+		  *end++ = '\0';
+		}
+
+	      /*
+	       * Parser username:password part
+	       */
+	      ptr = strchr(start, '@');
+	      if (ptr != 0)
+		{
+		  buf->user = start;
+		  *ptr++ = '\0';
+		  start = ptr;
+		  if (legal(buf->user, ";:&=+$,") == NO)
+		    {
+		      [NSException raise: NSInvalidArgumentException
+                        format: @"[%@ %@](%@, %@) "
+			@"illegal character in user/password part",
+                        NSStringFromClass([self class]),
+                        NSStringFromSelector(_cmd),
+                        aUrlString, aBaseUrl];
+		    }
+		  ptr = strchr(buf->user, ':');
+		  if (ptr != 0)
+		    {
+		      *ptr++ = '\0';
+		      buf->password = ptr;
+		    }
+		}
+
+	      /*
+	       * Parse host:port part
+	       */
+	      buf->host = start;
+	      if (*start == '[')
+		{
+	          ptr = strchr(buf->host, ']');
+		  if (ptr == 0)
+		    {
+		      [NSException raise: NSInvalidArgumentException
+			format: @"[%@ %@](%@, %@) "
+			@"illegal ipv6 host address",
+			NSStringFromClass([self class]),
+			NSStringFromSelector(_cmd),
+			aUrlString, aBaseUrl];
+		    }
+		  else
+		    {
+		      ptr = start + 1;
+		      while (*ptr != ']')
+			{
+			  if (*ptr != ':' && *ptr != '.' && !isxdigit(*ptr))
+			    {
+			      [NSException raise: NSInvalidArgumentException
+				format: @"[%@ %@](%@, %@) "
+				@"illegal ipv6 host address",
+				NSStringFromClass([self class]),
+				NSStringFromSelector(_cmd),
+				aUrlString, aBaseUrl];
+			    }
+			  ptr++;
+			}
+		    }
+	          ptr = strchr(ptr, ':');
+		}
+	      else
+		{
+	          ptr = strchr(buf->host, ':');
+		}
+	      if (ptr != 0)
+		{
+		  const char	*str;
+
+		  *ptr++ = '\0';
+		  buf->port = ptr;
+		  str = buf->port;
+		  while (*str != 0)
+		    {
+		      if (*str == '%' && isxdigit(str[1]) && isxdigit(str[2]))
+			{
+			  unsigned char	c;
+
+			  str++;
+			  if (*str <= '9')
+			    {
+			      c = *str - '0';
+			    }
+			  else if (*str <= 'F')
+			    {
+			      c = *str - 'A' + 10;
+			    }
+			  else
+			    {
+			      c = *str - 'a' + 10;
+			    }
+			  c <<= 4;
+			  str++;
+			  if (*str <= '9')
+			    {
+			      c |= *str - '0';
+			    }
+			  else if (*str <= 'F')
+			    {
+			      c |= *str - 'A' + 10;
+			    }
+			  else
+			    {
+			      c |= *str - 'a' + 10;
+			    }
+
+			  if (isdigit(c))
+			    {
+			      str++;
+			    }
+			  else
+			    {
+			      [NSException raise: NSInvalidArgumentException
+                                format: @"[%@ %@](%@, %@) "
+				@"illegal port part",
+                                NSStringFromClass([self class]),
+                                NSStringFromSelector(_cmd),
+                                aUrlString, aBaseUrl];
+			    }
+			}
+		      else if (isdigit(*str))
+			{
+			  str++;
+			}
+		      else
+			{
+			  [NSException raise: NSInvalidArgumentException
+                            format: @"[%@ %@](%@, %@) "
+			    @"illegal character in port part",
+                            NSStringFromClass([self class]),
+                            NSStringFromSelector(_cmd),
+                            aUrlString, aBaseUrl];
+			}
+		    }
+		}
+	      start = end;
+	      /* Check for a legal host, unless it's an ipv6 address
+	       * (which would have been checked earlier).
+	       */
+	      if (*buf->host != '[' && legal(buf->host, "-") == NO)
+		{
+		  [NSException raise: NSInvalidArgumentException
+                    format: @"[%@ %@](%@, %@) "
+		    @"illegal character in host part",
+                    NSStringFromClass([self class]),
+                    NSStringFromSelector(_cmd),
+                    aUrlString, aBaseUrl];
+		}
+
+	      /*
+	       * If we have an authority component,
+	       * this must be an absolute URL
+	       */
+	      buf->pathIsAbsolute = YES;
+	      base = 0;
+	    }
+	  else
+	    {
+	      if (base != 0)
+		{
+		  buf->isGeneric = base->isGeneric;
+		}
+	      if (*start == '/')
+		{
+		  buf->pathIsAbsolute = YES;
+		  start++;
+		}
+	    }
+
+	  if (usesFragments == YES)
+	    {
+	      /*
+	       * Strip fragment string from end of url.
+	       */
+	      ptr = strchr(start, '#');
+	      if (ptr != 0)
+		{
+		  *ptr++ = '\0';
+		  if (*ptr != 0)
+		    {
+		      buf->fragment = ptr;
+		    }
+		}
+	      if (buf->fragment == 0 && base != 0)
+		{
+		  buf->fragment = base->fragment;
+		}
+	      if (legal(buf->fragment, filepath) == NO)
+		{
+		  [NSException raise: NSInvalidArgumentException
+		    format: @"[%@ %@](%@, %@) "
+		    @"illegal character in fragment part",
+		    NSStringFromClass([self class]),
+		    NSStringFromSelector(_cmd),
+		    aUrlString, aBaseUrl];
+		}
+	    }
+
+	  if (usesQueries == YES)
+	    {
+	      /*
+	       * Strip query string from end of url.
+	       */
+	      ptr = strchr(start, '?');
+	      if (ptr != 0)
+		{
+		  *ptr++ = '\0';
+		  if (*ptr != 0)
+		    {
+		      buf->query = ptr;
+		    }
+		}
+	      if (buf->query == 0 && base != 0)
+		{
+		  buf->query = base->query;
+		}
+	      if (legal(buf->query, filepath) == NO)
+		{
+		  [NSException raise: NSInvalidArgumentException
+		    format: @"[%@ %@](%@, %@) "
+		    @"illegal character in query part",
+		    NSStringFromClass([self class]),
+		    NSStringFromSelector(_cmd),
+		    aUrlString, aBaseUrl];
+		}
+	    }
+
+	  if (usesParameters == YES)
+	    {
+	      /*
+	       * Strip parameters string from end of url.
+	       */
+	      ptr = strchr(start, ';');
+	      if (ptr != 0)
+		{
+		  *ptr++ = '\0';
+		  if (*ptr != 0)
+		    {
+		      buf->parameters = ptr;
+		    }
+		}
+	      if (buf->parameters == 0 && base != 0)
+		{
+		  buf->parameters = base->parameters;
+		}
+	      if (legal(buf->parameters, filepath) == NO)
+		{
+		  [NSException raise: NSInvalidArgumentException
+		    format: @"[%@ %@](%@, %@) "
+		    @"illegal character in parameters part",
+		    NSStringFromClass([self class]),
+		    NSStringFromSelector(_cmd),
+		    aUrlString, aBaseUrl];
+		}
+	    }
+
+	  if (buf->isFile == YES)
+	    {
+	      buf->user = 0;
+	      buf->password = 0;
+	      if (base != 0 && base->host != 0)
+		{
+		  buf->host = base->host;
+		}
+	      else if (buf->host != 0 && *buf->host == 0)
+		{
+		  buf->host = 0;
+		}
+	      buf->port = 0;
+	      buf->isGeneric = YES;
+	    }
+	  else if (base != 0
+	    && buf->user == 0 && buf->password == 0
+	    && buf->host == 0 && buf->port == 0)
+	    {
+	      buf->user = base->user;
+	      buf->password = base->password;
+	      buf->host = base->host;
+	      buf->port = base->port;
+	    }
+	}
+      /*
+       * Store the path.
+       */
+      buf->path = start;
+      if (0 == base && '\0' == *buf->path && NO == buf->pathIsAbsolute)
+	{
+	  buf->hasNoPath = YES;
+	}
+      if (legal(buf->path, filepath) == NO)
+	{
+	  [NSException raise: NSInvalidArgumentException
+            format: @"[%@ %@](%@, %@) "
+	    @"illegal character in path part",
+            NSStringFromClass([self class]),
+            NSStringFromSelector(_cmd),
+            aUrlString, aBaseUrl];
+	}
     }
-    NS_ENDHANDLER
-
-    /*
-     * Parse the scheme if possible.
-     */
-    ptr = start;
-    if (isalpha(*ptr))
-      {
-	ptr++;
-	while (isalnum(*ptr) || *ptr == '+' || *ptr == '-' || *ptr == '.')
-	  {
-	    ptr++;
-	  }
-	if (*ptr == ':')
-	  {
-	    buf->scheme = start; // Got scheme.
-	    *ptr = '\0';	 // Terminate it.
-	    end = &ptr[1];
-	    /*
-	     * Standardise uppercase to lower.
-	     */
-	    while (--ptr > start)
-	      {
-		if (isupper(*ptr))
-		  {
-		    *ptr = tolower(*ptr);
-		  }
-	      }
-	  }
-      }
-    start = end;
-
-    if (buf->scheme != 0 && base != 0 && 0 != strcmp(buf->scheme, base->scheme))
-      {
-	/* The relative URL is of a different scheme to the base ...
-	 * so it's actually an absolute URL without a base.
-	 */
-	DESTROY(_baseURL);
-	base = 0;
-      }
-
-    if (buf->scheme == 0 && base != 0)
-      {
-	buf->scheme = base->scheme;
-      }
-
-    /*
-     * Set up scheme specific parsing options.
-     */
-    if (buf->scheme != 0)
-      {
-	if (strcmp(buf->scheme, "file") == 0)
-	  {
-	    buf->isFile = YES;
-	  }
-	else if (strcmp(buf->scheme, "data") == 0)
-	  {
-	    canBeGeneric = NO;
-	    DESTROY(_baseURL);
-	    base = 0;
-	  }
-	else if (strcmp(buf->scheme, "mailto") == 0)
-	  {
-	    usesFragments = NO;
-	    usesParameters = NO;
-	    usesQueries = NO;
-	  }
-	else if (strcmp(buf->scheme, "http") == 0
-		 || strcmp(buf->scheme, "https") == 0)
-	  {
-	    buf->emptyPath = YES;
-	  }
-      }
-
-    if (canBeGeneric == YES)
-      {
-	/*
-	 * Parse the 'authority'
-	 * //user:password@host:port
-	 */
-	if (start[0] == '/' && start[1] == '/')
-	  {
-	    buf->isGeneric = YES;
-	    start = end = &end[2];
-
-	    /*
-	     * Set 'end' to point to the start of the path, or just past
-	     * the 'authority' if there is no path.
-	     */
-	    end = strchr(start, '/');
-	    if (end == 0)
-	      {
-		buf->hasNoPath = YES;
-		end = &start[strlen(start)];
-	      }
-	    else
-	      {
-		*end++ = '\0';
-	      }
-
-	    /*
-	     * Parser username:password part
-	     */
-	    ptr = strchr(start, '@');
-	    if (ptr != 0)
-	      {
-		buf->user = start;
-		*ptr++ = '\0';
-		start = ptr;
-		if (legal(buf->user, ";:&=+$,") == NO)
-		  {
-		    [NSException
-		       raise:NSInvalidArgumentException
-		      format:@"[%@ %@](%@, %@) "
-			     @"illegal character in user/password part",
-			     NSStringFromClass([self class]),
-			     NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-		  }
-		ptr = strchr(buf->user, ':');
-		if (ptr != 0)
-		  {
-		    *ptr++ = '\0';
-		    buf->password = ptr;
-		  }
-	      }
-
-	    /*
-	     * Parse host:port part
-	     */
-	    buf->host = start;
-	    if (*start == '[')
-	      {
-		ptr = strchr(buf->host, ']');
-		if (ptr == 0)
-		  {
-		    [NSException
-		       raise:NSInvalidArgumentException
-		      format:@"[%@ %@](%@, %@) "
-			     @"illegal ipv6 host address",
-			     NSStringFromClass([self class]),
-			     NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-		  }
-		else
-		  {
-		    ptr = start + 1;
-		    while (*ptr != ']')
-		      {
-			if (*ptr != ':' && *ptr != '.' && !isxdigit(*ptr))
-			  {
-			    [NSException raise:NSInvalidArgumentException
-					format:@"[%@ %@](%@, %@) "
-					       @"illegal ipv6 host address",
-					       NSStringFromClass([self class]),
-					       NSStringFromSelector(_cmd),
-					       aUrlString, aBaseUrl];
-			  }
-			ptr++;
-		      }
-		  }
-		ptr = strchr(ptr, ':');
-	      }
-	    else
-	      {
-		ptr = strchr(buf->host, ':');
-	      }
-	    if (ptr != 0)
-	      {
-		const char *str;
-
-		*ptr++ = '\0';
-		buf->port = ptr;
-		str = buf->port;
-		while (*str != 0)
-		  {
-		    if (*str == '%' && isxdigit(str[1]) && isxdigit(str[2]))
-		      {
-			unsigned char c;
-
-			str++;
-			if (*str <= '9')
-			  {
-			    c = *str - '0';
-			  }
-			else if (*str <= 'F')
-			  {
-			    c = *str - 'A' + 10;
-			  }
-			else
-			  {
-			    c = *str - 'a' + 10;
-			  }
-			c <<= 4;
-			str++;
-			if (*str <= '9')
-			  {
-			    c |= *str - '0';
-			  }
-			else if (*str <= 'F')
-			  {
-			    c |= *str - 'A' + 10;
-			  }
-			else
-			  {
-			    c |= *str - 'a' + 10;
-			  }
-
-			if (isdigit(c))
-			  {
-			    str++;
-			  }
-			else
-			  {
-			    [NSException raise:NSInvalidArgumentException
-					format:@"[%@ %@](%@, %@) "
-					       @"illegal port part",
-					       NSStringFromClass([self class]),
-					       NSStringFromSelector(_cmd),
-					       aUrlString, aBaseUrl];
-			  }
-		      }
-		    else if (isdigit(*str))
-		      {
-			str++;
-		      }
-		    else
-		      {
-			[NSException raise:NSInvalidArgumentException
-				    format:@"[%@ %@](%@, %@) "
-					   @"illegal character in port part",
-					   NSStringFromClass([self class]),
-					   NSStringFromSelector(_cmd),
-					   aUrlString, aBaseUrl];
-		      }
-		  }
-	      }
-	    start = end;
-	    /* Check for a legal host, unless it's an ipv6 address
-	     * (which would have been checked earlier).
-	     */
-	    if (*buf->host != '[' && legal(buf->host, "-") == NO)
-	      {
-		[NSException
-		   raise:NSInvalidArgumentException
-		  format:@"[%@ %@](%@, %@) "
-			 @"illegal character in host part",
-			 NSStringFromClass([self class]),
-			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-	      }
-
-	    /*
-	     * If we have an authority component,
-	     * this must be an absolute URL
-	     */
-	    buf->pathIsAbsolute = YES;
-	    base = 0;
-	  }
-	else
-	  {
-	    if (base != 0)
-	      {
-		buf->isGeneric = base->isGeneric;
-	      }
-	    if (*start == '/')
-	      {
-		buf->pathIsAbsolute = YES;
-		start++;
-	      }
-	  }
-
-	if (usesFragments == YES)
-	  {
-	    /*
-	     * Strip fragment string from end of url.
-	     */
-	    ptr = strchr(start, '#');
-	    if (ptr != 0)
-	      {
-		*ptr++ = '\0';
-		if (*ptr != 0)
-		  {
-		    buf->fragment = ptr;
-		  }
-	      }
-	    if (buf->fragment == 0 && base != 0)
-	      {
-		buf->fragment = base->fragment;
-	      }
-	    if (legal(buf->fragment, filepath) == NO)
-	      {
-		[NSException
-		   raise:NSInvalidArgumentException
-		  format:@"[%@ %@](%@, %@) "
-			 @"illegal character in fragment part",
-			 NSStringFromClass([self class]),
-			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-	      }
-	  }
-
-	if (usesQueries == YES)
-	  {
-	    /*
-	     * Strip query string from end of url.
-	     */
-	    ptr = strchr(start, '?');
-	    if (ptr != 0)
-	      {
-		*ptr++ = '\0';
-		if (*ptr != 0)
-		  {
-		    buf->query = ptr;
-		  }
-	      }
-	    if (buf->query == 0 && base != 0)
-	      {
-		buf->query = base->query;
-	      }
-	    if (legal(buf->query, filepath) == NO)
-	      {
-		[NSException
-		   raise:NSInvalidArgumentException
-		  format:@"[%@ %@](%@, %@) "
-			 @"illegal character in query part",
-			 NSStringFromClass([self class]),
-			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-	      }
-	  }
-
-	if (usesParameters == YES)
-	  {
-	    /*
-	     * Strip parameters string from end of url.
-	     */
-	    ptr = strchr(start, ';');
-	    if (ptr != 0)
-	      {
-		*ptr++ = '\0';
-		if (*ptr != 0)
-		  {
-		    buf->parameters = ptr;
-		  }
-	      }
-	    if (buf->parameters == 0 && base != 0)
-	      {
-		buf->parameters = base->parameters;
-	      }
-	    if (legal(buf->parameters, filepath) == NO)
-	      {
-		[NSException
-		   raise:NSInvalidArgumentException
-		  format:@"[%@ %@](%@, %@) "
-			 @"illegal character in parameters part",
-			 NSStringFromClass([self class]),
-			 NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-	      }
-	  }
-
-	if (buf->isFile == YES)
-	  {
-	    buf->user = 0;
-	    buf->password = 0;
-	    if (base != 0 && base->host != 0)
-	      {
-		buf->host = base->host;
-	      }
-	    else if (buf->host != 0 && *buf->host == 0)
-	      {
-		buf->host = 0;
-	      }
-	    buf->port = 0;
-	    buf->isGeneric = YES;
-	  }
-	else if (base != 0 && buf->user == 0 && buf->password == 0
-		 && buf->host == 0 && buf->port == 0)
-	  {
-	    buf->user = base->user;
-	    buf->password = base->password;
-	    buf->host = base->host;
-	    buf->port = base->port;
-	  }
-      }
-    /*
-     * Store the path.
-     */
-    buf->path = start;
-    if (0 == base && '\0' == *buf->path && NO == buf->pathIsAbsolute)
-      {
-	buf->hasNoPath = YES;
-      }
-    if (legal(buf->path, filepath) == NO)
-      {
-	[NSException raise:NSInvalidArgumentException
-		    format:@"[%@ %@](%@, %@) "
-			   @"illegal character in path part",
-			   NSStringFromClass([self class]),
-			   NSStringFromSelector(_cmd), aUrlString, aBaseUrl];
-      }
-  }
   NS_HANDLER
-  {
-    NSDebugLog(@"%@", localException);
-    DESTROY(self);
-  }
+    {
+      NSDebugLog(@"%@", localException);
+      DESTROY(self);
+    }
   NS_ENDHANDLER
   return self;
 }
 
-- (void)dealloc
+- (void) dealloc
 {
   if (_clients != 0)
     {
@@ -1273,12 +1266,12 @@ static NSUInteger      urlAlign;
   [super dealloc];
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id) copyWithZone: (NSZone*)zone
 {
   if (NSShouldRetainWithZone(self, zone) == NO)
     {
-      return [[[self class] allocWithZone:zone] initWithString:_urlString
-						 relativeToURL:_baseURL];
+      return [[[self class] allocWithZone: zone] initWithString: _urlString
+						  relativeToURL: _baseURL];
     }
   else
     {
@@ -1286,45 +1279,45 @@ static NSUInteger      urlAlign;
     }
 }
 
-- (NSString *)description
+- (NSString*) description
 {
-  NSString *dscr = _urlString;
+  NSString	*dscr = _urlString;
 
   if (_baseURL != nil)
     {
-      dscr = [dscr stringByAppendingFormat:@" -- %@", _baseURL];
+      dscr = [dscr stringByAppendingFormat: @" -- %@", _baseURL];
     }
   return dscr;
 }
 
-- (void)encodeWithCoder:(NSCoder *)aCoder
+- (void) encodeWithCoder: (NSCoder*)aCoder
 {
   if ([aCoder allowsKeyedCoding])
     {
-      [aCoder encodeObject:_baseURL forKey:@"NS.base"];
-      [aCoder encodeObject:_urlString forKey:@"NS.relative"];
+      [aCoder encodeObject: _baseURL forKey: @"NS.base"];
+      [aCoder encodeObject: _urlString forKey: @"NS.relative"];
     }
   else
     {
-      [aCoder encodeObject:_urlString];
-      [aCoder encodeObject:_baseURL];
+      [aCoder encodeObject: _urlString];
+      [aCoder encodeObject: _baseURL];
     }
 }
 
-- (NSUInteger)hash
+- (NSUInteger) hash
 {
   return [[self absoluteString] hash];
 }
 
-- (id)initWithCoder:(NSCoder *)aCoder
+- (id) initWithCoder: (NSCoder*)aCoder
 {
-  NSURL *   base;
-  NSString *rel;
+  NSURL		*base;
+  NSString	*rel;
 
   if ([aCoder allowsKeyedCoding])
     {
-      base = [aCoder decodeObjectForKey:@"NS.base"];
-      rel = [aCoder decodeObjectForKey:@"NS.relative"];
+      base = [aCoder decodeObjectForKey: @"NS.base"];
+      rel = [aCoder decodeObjectForKey: @"NS.relative"];
     }
   else
     {
@@ -1335,37 +1328,37 @@ static NSUInteger      urlAlign;
     {
       rel = @"";
     }
-  self = [self initWithString:rel relativeToURL:base];
+  self = [self initWithString: rel relativeToURL: base];
   return self;
 }
 
-- (BOOL)isEqual:(id)other
+- (BOOL) isEqual: (id)other
 {
-  if (other == nil || [other isKindOfClass:[NSURL class]] == NO)
+  if (other == nil || [other isKindOfClass: [NSURL class]] == NO)
     {
       return NO;
     }
-  return [[self absoluteString] isEqualToString:[other absoluteString]];
+  return [[self absoluteString] isEqualToString: [other absoluteString]];
 }
 
-- (NSString *)absoluteString
+- (NSString*) absoluteString
 {
-  NSString *absString = myData->absolute;
+  NSString	*absString = myData->absolute;
 
   if (absString == nil)
     {
-      char *   url = buildURL(baseData, myData, NO);
-      unsigned len = strlen(url);
+      char	*url = buildURL(baseData, myData, NO);
+      unsigned	len = strlen(url);
 
-      absString = [[NSString alloc] initWithCStringNoCopy:url
-						   length:len
-					     freeWhenDone:YES];
+      absString = [[NSString alloc] initWithCStringNoCopy: url
+						   length: len
+					     freeWhenDone: YES];
       myData->absolute = absString;
     }
   return absString;
 }
 
-- (NSURL *)absoluteURL
+- (NSURL*) absoluteURL
 {
   if (_baseURL == nil)
     {
@@ -1373,35 +1366,35 @@ static NSUInteger      urlAlign;
     }
   else
     {
-      return [NSURL URLWithString:[self absoluteString]];
+      return [NSURL URLWithString: [self absoluteString]];
     }
 }
 
-- (NSURL *)baseURL
+- (NSURL*) baseURL
 {
   return _baseURL;
 }
 
-- (BOOL)checkResourceIsReachableAndReturnError:(NSError **)error
+- (BOOL) checkResourceIsReachableAndReturnError: (NSError **)error
 {
   NSString *errorStr = nil;
 
   if ([self isFileURL])
     {
       NSFileManager *mgr = [NSFileManager defaultManager];
-      NSString *     path = [self path];
-
-      if ([mgr fileExistsAtPath:path])
-	{
-	  if (![mgr isReadableFileAtPath:path])
-	    {
-	      errorStr = @"File not readable";
-	    }
-	}
+      NSString *path = [self path];
+      
+      if ([mgr fileExistsAtPath: path])
+        {
+          if (![mgr isReadableFileAtPath: path])
+            {
+              errorStr = @"File not readable";
+            }
+        }
       else
-	{
-	  errorStr = @"File does not exist";
-	}
+        {
+          errorStr = @"File does not exist";
+        }
     }
   else
     {
@@ -1410,30 +1403,32 @@ static NSUInteger      urlAlign;
 
   if ((errorStr != nil) && (error != NULL))
     {
-      NSDictionary *info;
+      NSDictionary	*info;
 
-      info = [NSDictionary
-	dictionaryWithObjectsAndKeys:errorStr, NSLocalizedDescriptionKey, nil];
-      *error = [NSError errorWithDomain:@"NSURLError" code:0 userInfo:info];
+      info = [NSDictionary dictionaryWithObjectsAndKeys:
+	errorStr, NSLocalizedDescriptionKey, nil];
+      *error = [NSError errorWithDomain: @"NSURLError"
+                                   code: 0 
+                               userInfo: info];
     }
   return nil == errorStr ? YES : NO;
 }
 
-- (NSString *)fragment
+- (NSString*) fragment
 {
-  NSString *fragment = nil;
+  NSString	*fragment = nil;
 
   if (myData->fragment != 0)
     {
-      fragment = [NSString stringWithUTF8String:myData->fragment];
+      fragment = [NSString stringWithUTF8String: myData->fragment];
     }
   return fragment;
 }
 
-- (char *)_path:(char *)buf withEscapes:(BOOL)withEscapes
+- (char*) _path: (char*)buf withEscapes: (BOOL)withEscapes
 {
-  char *ptr = buf;
-  char *tmp = buf;
+  char	*ptr = buf;
+  char	*tmp = buf;
   int	l;
 
   if (myData->pathIsAbsolute == YES)
@@ -1445,7 +1440,7 @@ static NSUInteger      urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-	  memcpy(tmp, myData->path, l + 1);
+          memcpy(tmp, myData->path, l + 1);
 	}
     }
   else if (nil == _baseURL)
@@ -1453,7 +1448,7 @@ static NSUInteger      urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-	  memcpy(tmp, myData->path, l + 1);
+          memcpy(tmp, myData->path, l + 1);
 	}
     }
   else if (0 == myData->path || 0 == *myData->path)
@@ -1465,13 +1460,13 @@ static NSUInteger      urlAlign;
       if (baseData->path != 0)
 	{
 	  l = strlen(baseData->path);
-	  memcpy(tmp, baseData->path, l + 1);
+          memcpy(tmp, baseData->path, l + 1);
 	}
     }
   else
     {
-      char *start = baseData->path;
-      char *end = (start == 0) ? 0 : strrchr(start, '/');
+      char	*start = baseData->path;
+      char	*end = (start == 0) ? 0 : strrchr(start, '/');
 
       if (end != 0)
 	{
@@ -1483,7 +1478,7 @@ static NSUInteger      urlAlign;
       if (myData->path != 0)
 	{
 	  l = strlen(myData->path);
-	  memcpy(tmp, myData->path, l + 1);
+          memcpy(tmp, myData->path, l + 1);
 	}
     }
 
@@ -1492,7 +1487,7 @@ static NSUInteger      urlAlign;
       unescape(buf, buf);
     }
 
-#if defined(_WIN32)
+#if	defined(_WIN32)
   /* On windows a file URL path may be of the form C:\xxx (ie we should
    * not insert the leading slash).
    * Also the vertical bar symbol may have been used instead of the
@@ -1516,17 +1511,17 @@ static NSUInteger      urlAlign;
   return ptr;
 }
 
-- (NSString *)host
+- (NSString*) host
 {
-  NSString *host = nil;
+  NSString	*host = nil;
 
   if (myData->host != 0)
     {
-      char buf[strlen(myData->host) + 1];
+      char	buf[strlen(myData->host)+1];
 
       if (*myData->host == '[')
 	{
-	  char *end = unescape(myData->host + 1, buf);
+	  char	*end = unescape(myData->host + 1, buf);
 
 	  if (end[-1] == ']')
 	    {
@@ -1535,73 +1530,73 @@ static NSUInteger      urlAlign;
 	}
       else
 	{
-	  unescape(myData->host, buf);
+          unescape(myData->host, buf);
 	}
-      host = [NSString stringWithUTF8String:buf];
+      host = [NSString stringWithUTF8String: buf];
     }
   return host;
 }
 
-- (BOOL)isFileURL
+- (BOOL) isFileURL
 {
   return myData->isFile;
 }
 
-- (NSString *)lastPathComponent
+- (NSString*) lastPathComponent
 {
   return [[self path] lastPathComponent];
 }
 
-- (BOOL)isFileReferenceURL
+- (BOOL) isFileReferenceURL
 {
   return NO;
 }
 
-- (NSURL *)fileReferenceURL
+- (NSURL *) fileReferenceURL
 {
-  if ([self isFileURL])
+  if ([self isFileURL]) 
     {
       return self;
     }
   return nil;
 }
 
-- (NSURL *)filePathURL
+- (NSURL *) filePathURL
 {
-  if ([self isFileURL])
+  if ([self isFileURL]) 
     {
       return self;
     }
   return nil;
 }
 
-- (BOOL)getResourceValue:(id *)value
-		  forKey:(NSString *)key
-		   error:(NSError **)error
+- (BOOL) getResourceValue: (id*)value 
+                   forKey: (NSString *)key 
+                    error: (NSError**)error
 {
   // TODO: unimplemented
   return NO;
 }
 
-- (void)loadResourceDataNotifyingClient:(id)client
-			     usingCache:(BOOL)shouldUseCache
+- (void) loadResourceDataNotifyingClient: (id)client
+			      usingCache: (BOOL)shouldUseCache
 {
-  NSURLHandle *handle = [self URLHandleUsingCache:YES];
-  NSData *     d;
+  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSData	*d;
 
   if (shouldUseCache == YES && (d = [handle availableResourceData]) != nil)
     {
       /*
        * We already have cached data we should use.
        */
-      if ([client respondsToSelector:@selector(URL:
-				       resourceDataDidBecomeAvailable:)])
+      if ([client respondsToSelector:
+	@selector(URL:resourceDataDidBecomeAvailable:)])
 	{
-	  [client URL:self resourceDataDidBecomeAvailable:d];
+	  [client URL: self resourceDataDidBecomeAvailable: d];
 	}
-      if ([client respondsToSelector:@selector(URLResourceDidFinishLoading:)])
+      if ([client respondsToSelector: @selector(URLResourceDidFinishLoading:)])
 	{
-	  [client URLResourceDidFinishLoading:self];
+	  [client URLResourceDidFinishLoading: self];
 	}
     }
   else
@@ -1611,14 +1606,12 @@ static NSUInteger      urlAlign;
 	  [clientsLock lock];
 	  if (_clients == 0)
 	    {
-	      _clients
-		= NSCreateMapTable(NSObjectMapKeyCallBacks,
-				   NSNonRetainedObjectMapValueCallBacks, 0);
+	      _clients = NSCreateMapTable (NSObjectMapKeyCallBacks,
+		NSNonRetainedObjectMapValueCallBacks, 0);
 	    }
-	  NSMapInsert((NSMapTable *) _clients, (void *) handle,
-		      (void *) client);
+	  NSMapInsert((NSMapTable*)_clients, (void*)handle, (void*)client);
 	  [clientsLock unlock];
-	  [handle addClient:self];
+	  [handle addClient: self];
 	}
 
       /*
@@ -1628,135 +1621,135 @@ static NSUInteger      urlAlign;
     }
 }
 
-- (NSString *)parameterString
+- (NSString*) parameterString
 {
-  NSString *parameters = nil;
+  NSString	*parameters = nil;
 
   if (myData->parameters != 0)
     {
-      parameters = [NSString stringWithUTF8String:myData->parameters];
+      parameters = [NSString stringWithUTF8String: myData->parameters];
     }
   return parameters;
 }
 
-- (NSString *)password
+- (NSString*) password
 {
-  NSString *password = nil;
+  NSString	*password = nil;
 
   if (myData->password != 0)
     {
-      char buf[strlen(myData->password) + 1];
+      char	buf[strlen(myData->password)+1];
 
       unescape(myData->password, buf);
-      password = [NSString stringWithUTF8String:buf];
+      password = [NSString stringWithUTF8String: buf];
     }
   return password;
 }
 
-- (NSString *)_pathWithEscapes:(BOOL)withEscapes
+- (NSString*) _pathWithEscapes: (BOOL)withEscapes
 {
-  NSString *path = nil;
+  NSString	*path = nil;
 
   if (YES == myData->isGeneric || 0 == myData->scheme)
     {
-      unsigned int len = 3;
+      unsigned int	len = 3;
 
       if (_baseURL != nil)
-	{
-	  if (baseData->path && *baseData->path)
-	    {
-	      len += strlen(baseData->path);
-	    }
-	  else if (baseData->hasNoPath == NO)
-	    {
-	      len++;
-	    }
-	}
+        {
+          if (baseData->path && *baseData->path)
+            {
+              len += strlen(baseData->path);
+            }
+          else if (baseData->hasNoPath == NO)
+            {
+              len++;
+            }
+        }
       if (myData->path && *myData->path)
-	{
-	  len += strlen(myData->path);
-	}
+        {
+          len += strlen(myData->path);
+        }
       else if (myData->hasNoPath == NO)
-	{
-	  len++;
-	}
+        {
+          len++;
+        }
       if (len > 3)
-	{
-	  char	buf[len];
-	  char *ptr;
-	  char *tmp;
+        {
+          char		buf[len];
+          char		*ptr;
+          char		*tmp;
 
-	  ptr = [self _path:buf withEscapes:withEscapes];
+          ptr = [self _path: buf withEscapes: withEscapes];
 
-	  /* Remove any trailing '/' from the path for MacOS-X compatibility.
-	   */
-	  tmp = ptr + strlen(ptr) - 1;
-	  if (tmp > ptr && *tmp == '/')
-	    {
-	      *tmp = '\0';
-	    }
+          /* Remove any trailing '/' from the path for MacOS-X compatibility.
+           */
+          tmp = ptr + strlen(ptr) - 1;
+          if (tmp > ptr && *tmp == '/')
+            {
+              *tmp = '\0';
+            }
 
-	  path = [NSString stringWithUTF8String:ptr];
-	}
+          path = [NSString stringWithUTF8String: ptr];
+        }
       else if (YES == myData->emptyPath)
-	{
-	  /* OSX seems to use an empty string for some schemes,
-	   * though it normally uses nil.
-	   */
-	  path = @"";
-	}
+        {
+          /* OSX seems to use an empty string for some schemes,
+           * though it normally uses nil.
+           */
+          path = @"";
+        }
     }
   return path;
 }
 
-- (NSString *)path
+- (NSString*) path
 {
-  return [self _pathWithEscapes:NO];
+  return [self _pathWithEscapes: NO];
 }
 
-- (NSArray *)pathComponents
+- (NSArray*) pathComponents 
 {
   return [[self path] pathComponents];
 }
 
-- (NSString *)pathExtension
+- (NSString*) pathExtension 
 {
   return [[self path] pathExtension];
 }
 
-- (NSNumber *)port
+- (NSNumber*) port
 {
-  NSNumber *port = nil;
+  NSNumber	*port = nil;
 
   if (myData->port != 0)
     {
-      char buf[strlen(myData->port) + 1];
+      char	buf[strlen(myData->port)+1];
 
       unescape(myData->port, buf);
-      port = [NSNumber numberWithUnsignedShort:atol(buf)];
+      port = [NSNumber numberWithUnsignedShort: atol(buf)];
     }
   return port;
 }
 
-- (id)propertyForKey:(NSString *)propertyKey
+- (id) propertyForKey: (NSString*)propertyKey
 {
-  NSURLHandle *handle = [self URLHandleUsingCache:YES];
+  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
 
-  return [handle propertyForKey:propertyKey];
+  return [handle propertyForKey: propertyKey];
 }
 
-- (NSString *)query
+- (NSString*) query
 {
-  NSString *query = nil;
+  NSString	*query = nil;
 
   if (myData->query != 0)
     {
-      query = [NSString stringWithUTF8String:myData->query];
+      query = [NSString stringWithUTF8String: myData->query];
     }
   return query;
 }
 
-- (NSString *)relativePath
+- (NSString*) relativePath
 {
   if (nil == _baseURL)
     {
@@ -1764,38 +1757,38 @@ static NSUInteger      urlAlign;
     }
   else
     {
-      NSString *path = nil;
+      NSString	*path = nil;
 
       if (myData->path != 0)
 	{
-	  char buf[strlen(myData->path) + 1];
+          char		buf[strlen(myData->path) + 1];
 
-	  strcpy(buf, myData->path);
-	  unescape(buf, buf);
-	  path = [NSString stringWithUTF8String:buf];
+          strcpy(buf, myData->path);
+          unescape(buf, buf);
+	  path = [NSString stringWithUTF8String: buf];
 	}
       return path;
     }
 }
 
-- (NSString *)relativeString
+- (NSString*) relativeString
 {
   return _urlString;
 }
 
 /* Encode bycopy unless explicitly requested otherwise.
  */
-- (id)replacementObjectForPortCoder:(NSPortCoder *)aCoder
+- (id) replacementObjectForPortCoder: (NSPortCoder*)aCoder
 {
   if ([aCoder isByref] == NO)
     return self;
-  return [super replacementObjectForPortCoder:aCoder];
+  return [super replacementObjectForPortCoder: aCoder];
 }
 
-- (NSData *)resourceDataUsingCache:(BOOL)shouldUseCache
+- (NSData*) resourceDataUsingCache: (BOOL)shouldUseCache
 {
-  NSURLHandle *handle = [self URLHandleUsingCache:YES];
-  NSData *     data = nil;
+  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSData	*data = nil;
 
   if ([handle status] == NSURLHandleLoadSucceeded)
     {
@@ -1812,79 +1805,80 @@ static NSUInteger      urlAlign;
   return data;
 }
 
-- (NSString *)resourceSpecifier
+- (NSString*) resourceSpecifier
 {
   if (YES == myData->isGeneric)
     {
-      NSRange range = [_urlString rangeOfString:@"://"];
+      NSRange	range = [_urlString rangeOfString: @"://"];
 
       if (range.length > 0)
-	{
-	  NSString *specifier;
+        {
+          NSString *specifier;
 
-	  /* MacOSX compatibility - in the case where there is no
-	   * host in the URL, just return the path (without the "//").
-	   * For all other cases we return the whole specifier.
-	   */
-	  if (nil == [self host])
-	    {
-	      specifier = [_urlString substringFromIndex:NSMaxRange(range)];
-	    }
-	  else
-	    {
-	      specifier = [_urlString substringFromIndex:range.location + 1];
-	    }
-	  return specifier;
-	}
+          /* MacOSX compatibility - in the case where there is no
+           * host in the URL, just return the path (without the "//").
+           * For all other cases we return the whole specifier.
+           */
+          if (nil == [self host])
+            {
+              specifier = [_urlString substringFromIndex: NSMaxRange(range)];
+            }
+          else
+            {
+              specifier = [_urlString substringFromIndex: range.location+1];
+            }
+          return specifier;
+        }
       else
-	{
-	  /*
-	   * Cope with URLs missing net_path info -  <scheme>:/<path>...
-	   */
-	  range = [_urlString rangeOfString:@":"];
-	  if (range.length > 0)
-	    {
-	      return [_urlString substringFromIndex:range.location + 1];
-	    }
-	  else
-	    {
-	      return _urlString;
-	    }
-	}
+        {
+          /*
+           * Cope with URLs missing net_path info -  <scheme>:/<path>...
+           */
+          range = [_urlString rangeOfString: @":"];
+          if (range.length > 0)
+            {
+              return [_urlString substringFromIndex: range.location + 1];
+            }
+          else
+            {
+              return _urlString;
+            }
+        }
     }
   else
     {
-      return [NSString stringWithUTF8String:myData->path];
+      return [NSString stringWithUTF8String: myData->path];
     }
 }
 
-- (NSString *)scheme
+- (NSString*) scheme
 {
-  NSString *scheme = nil;
+  NSString	*scheme = nil;
 
   if (myData->scheme != 0)
     {
-      scheme = [NSString stringWithUTF8String:myData->scheme];
+      scheme = [NSString stringWithUTF8String: myData->scheme];
     }
   return scheme;
 }
 
-- (BOOL)setProperty:(id)property forKey:(NSString *)propertyKey
+- (BOOL) setProperty: (id)property
+	      forKey: (NSString*)propertyKey
 {
-  NSURLHandle *handle = [self URLHandleUsingCache:YES];
+  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
 
-  return [handle writeProperty:property forKey:propertyKey];
+  return [handle writeProperty: property forKey: propertyKey];
 }
 
-- (BOOL)setResourceData:(NSData *)data
+- (BOOL) setResourceData: (NSData*)data
 {
-  NSURLHandle *handle = [self URLHandleUsingCache:YES];
+  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
 
   if (handle == nil)
     {
       return NO;
     }
-  if ([handle writeData:data] == NO)
+  if ([handle writeData: data] == NO)
     {
       return NO;
     }
@@ -1895,182 +1889,183 @@ static NSUInteger      urlAlign;
   return YES;
 }
 
-- (NSURL *)standardizedURL
+- (NSURL*) standardizedURL
 {
-  char *    url = buildURL(baseData, myData, YES);
-  unsigned  len = strlen(url);
-  NSString *str;
-  NSURL *   tmp;
+  char		*url = buildURL(baseData, myData, YES);
+  unsigned	len = strlen(url);
+  NSString	*str;
+  NSURL		*tmp;
 
-  str = [[NSString alloc] initWithCStringNoCopy:url
-					 length:len
-				   freeWhenDone:YES];
-  tmp = [NSURL URLWithString:str];
+  str = [[NSString alloc] initWithCStringNoCopy: url
+					 length: len
+				   freeWhenDone: YES];
+  tmp = [NSURL URLWithString: str];
   RELEASE(str);
   return tmp;
 }
 
-- (NSURLHandle *)URLHandleUsingCache:(BOOL)shouldUseCache
+- (NSURLHandle*) URLHandleUsingCache: (BOOL)shouldUseCache
 {
-  NSURLHandle *handle = nil;
+  NSURLHandle	*handle = nil;
 
   if (shouldUseCache)
     {
-      handle = [NSURLHandle cachedHandleForURL:self];
+      handle = [NSURLHandle cachedHandleForURL: self];
     }
   if (handle == nil)
     {
-      Class c = [NSURLHandle URLHandleClassForURL:self];
+      Class	c = [NSURLHandle URLHandleClassForURL: self];
 
       if (c != 0)
 	{
-	  handle = [[c alloc] initWithURL:self cached:shouldUseCache];
+	  handle = [[c alloc] initWithURL: self cached: shouldUseCache];
 	  IF_NO_GC([handle autorelease];)
 	}
     }
   return handle;
 }
 
-- (NSString *)user
+- (NSString*) user
 {
-  NSString *user = nil;
+  NSString	*user = nil;
 
   if (myData->user != 0)
     {
-      char buf[strlen(myData->user) + 1];
+      char	buf[strlen(myData->user)+1];
 
       unescape(myData->user, buf);
-      user = [NSString stringWithUTF8String:buf];
+      user = [NSString stringWithUTF8String: buf];
     }
   return user;
 }
 
-- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
+- (NSURL*) URLByAppendingPathComponent: (NSString*)pathComponent 
 {
-  return
-    [self _URLBySettingPath:[[self path]
-			      stringByAppendingPathComponent:pathComponent]];
+  return [self _URLBySettingPath:
+    [[self path] stringByAppendingPathComponent: pathComponent]];
 }
 
-- (NSURL *)URLByAppendingPathExtension:(NSString *)pathExtension
+- (NSURL*) URLByAppendingPathExtension: (NSString*)pathExtension
 {
-  return
-    [self _URLBySettingPath:[[self path]
-			      stringByAppendingPathExtension:pathExtension]];
+  return [self _URLBySettingPath:
+    [[self path] stringByAppendingPathExtension: pathExtension]];
 }
 
-- (NSURL *)URLByDeletingLastPathComponent
+- (NSURL*) URLByDeletingLastPathComponent 
 {
-  return
-    [self _URLBySettingPath:[[self path] stringByDeletingLastPathComponent]];
+  return [self _URLBySettingPath:
+    [[self path] stringByDeletingLastPathComponent]];
 }
 
-- (NSURL *)URLByDeletingPathExtension
+- (NSURL*) URLByDeletingPathExtension 
 {
-  return [self _URLBySettingPath:[[self path] stringByDeletingPathExtension]];
+  return [self _URLBySettingPath:
+    [[self path] stringByDeletingPathExtension]];
 }
 
-- (NSURL *)URLByResolvingSymlinksInPath
+- (NSURL*) URLByResolvingSymlinksInPath 
 {
-  if ([self isFileURL])
+  if ([self isFileURL]) 
     {
-      return
-	[NSURL fileURLWithPath:[[self path] stringByResolvingSymlinksInPath]];
+      return [NSURL fileURLWithPath:
+	[[self path] stringByResolvingSymlinksInPath]];
     }
   return self;
 }
 
-- (NSURL *)URLByStandardizingPath
+- (NSURL*) URLByStandardizingPath 
 {
-  if ([self isFileURL])
+  if ([self isFileURL]) 
     {
-      return [NSURL fileURLWithPath:[[self path] stringByStandardizingPath]];
+      return [NSURL fileURLWithPath: [[self path] stringByStandardizingPath]];
     }
   return self;
 }
 
-- (NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent
-			   isDirectory:(BOOL)isDirectory
+- (NSURL *) URLByAppendingPathComponent:(NSString *)pathComponent
+                            isDirectory:(BOOL)isDirectory
 {
-  NSString *path = [[self path] stringByAppendingPathComponent:pathComponent];
+  NSString *path = [[self path] stringByAppendingPathComponent: pathComponent];
   if (isDirectory)
     {
-      path = [path stringByAppendingString:@"/"];
+      path = [path stringByAppendingString: @"/"];
     }
-  return [self _URLBySettingPath:path];
+  return [self _URLBySettingPath: path];
 }
 
-- (void)URLHandle:(NSURLHandle *)sender
-  resourceDataDidBecomeAvailable:(NSData *)newData
+- (void) URLHandle: (NSURLHandle*)sender
+  resourceDataDidBecomeAvailable: (NSData*)newData
 {
-  id c = clientForHandle(_clients, sender);
+  id	c = clientForHandle(_clients, sender);
 
-  if ([c respondsToSelector:@selector(URL:resourceDataDidBecomeAvailable:)])
+  if ([c respondsToSelector: @selector(URL:resourceDataDidBecomeAvailable:)])
     {
-      [c URL:self resourceDataDidBecomeAvailable:newData];
+      [c URL: self resourceDataDidBecomeAvailable: newData];
     }
 }
 
-- (void)URLHandle:(NSURLHandle *)sender
-  resourceDidFailLoadingWithReason:(NSString *)reason
+- (void) URLHandle: (NSURLHandle*)sender
+  resourceDidFailLoadingWithReason: (NSString*)reason
 {
-  id c = clientForHandle(_clients, sender);
+  id	c = clientForHandle(_clients, sender);
 
   if (c != nil)
     {
-      if ([c respondsToSelector:@selector(URL:
-				  resourceDidFailLoadingWithReason:)])
+      if ([c respondsToSelector:
+	@selector(URL:resourceDidFailLoadingWithReason:)])
 	{
-	  [c URL:self resourceDidFailLoadingWithReason:reason];
+	  [c URL: self resourceDidFailLoadingWithReason: reason];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable *) _clients, (void *) sender);
+      NSMapRemove((NSMapTable*)_clients, (void*)sender);
       [clientsLock unlock];
     }
-  [sender removeClient:self];
+  [sender removeClient: self];
 }
 
-- (void)URLHandleResourceDidBeginLoading:(NSURLHandle *)sender
+- (void) URLHandleResourceDidBeginLoading: (NSURLHandle*)sender
 {
 }
 
-- (void)URLHandleResourceDidCancelLoading:(NSURLHandle *)sender
+- (void) URLHandleResourceDidCancelLoading: (NSURLHandle*)sender
 {
-  id c = clientForHandle(_clients, sender);
+  id	c = clientForHandle(_clients, sender);
 
   if (c != nil)
     {
-      if ([c respondsToSelector:@selector(URLResourceDidCancelLoading:)])
+      if ([c respondsToSelector: @selector(URLResourceDidCancelLoading:)])
 	{
-	  [c URLResourceDidCancelLoading:self];
+	  [c URLResourceDidCancelLoading: self];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable *) _clients, (void *) sender);
+      NSMapRemove((NSMapTable*)_clients, (void*)sender);
       [clientsLock unlock];
     }
-  [sender removeClient:self];
+  [sender removeClient: self];
 }
 
-- (void)URLHandleResourceDidFinishLoading:(NSURLHandle *)sender
+- (void) URLHandleResourceDidFinishLoading: (NSURLHandle*)sender
 {
-  id c = clientForHandle(_clients, sender);
+  id	c = clientForHandle(_clients, sender);
 
   IF_NO_GC([self retain];)
-  [sender removeClient:self];
+  [sender removeClient: self];
   if (c != nil)
     {
-      if ([c respondsToSelector:@selector(URLResourceDidFinishLoading:)])
+      if ([c respondsToSelector: @selector(URLResourceDidFinishLoading:)])
 	{
-	  [c URLResourceDidFinishLoading:self];
+	  [c URLResourceDidFinishLoading: self];
 	}
       [clientsLock lock];
-      NSMapRemove((NSMapTable *) _clients, (void *) sender);
+      NSMapRemove((NSMapTable*)_clients, (void*)sender);
       [clientsLock unlock];
     }
   RELEASE(self);
 }
 
 @end
+
+
 
 /**
  * An informal protocol to which clients may conform if they wish to be
@@ -2080,114 +2075,120 @@ static NSUInteger      urlAlign;
  */
 @implementation NSObject (NSURLClient)
 
-- (void)URL:(NSURL *)sender resourceDataDidBecomeAvailable:(NSData *)newBytes
+- (void) URL: (NSURL*)sender
+  resourceDataDidBecomeAvailable: (NSData*)newBytes
 {
 }
 
-- (void)URL:(NSURL *)sender resourceDidFailLoadingWithReason:(NSString *)reason
+- (void) URL: (NSURL*)sender
+  resourceDidFailLoadingWithReason: (NSString*)reason
 {
 }
 
-- (void)URLResourceDidCancelLoading:(NSURL *)sender
+- (void) URLResourceDidCancelLoading: (NSURL*)sender
 {
 }
 
-- (void)URLResourceDidFinishLoading:(NSURL *)sender
+- (void) URLResourceDidFinishLoading: (NSURL*)sender
 {
 }
 
 @end
 
 @implementation NSURL (GNUstepBase)
-- (NSString *)fullPath
+- (NSString*) fullPath
 {
-  NSString *path = nil;
+  NSString	*path = nil;
 
   if (YES == myData->isGeneric || 0 == myData->scheme)
     {
-      unsigned int len = 3;
+      unsigned int	len = 3;
 
       if (_baseURL != nil)
-	{
-	  if (baseData->path && *baseData->path)
-	    {
-	      len += strlen(baseData->path);
-	    }
-	  else if (baseData->hasNoPath == NO)
-	    {
-	      len++;
-	    }
-	}
+        {
+          if (baseData->path && *baseData->path)
+            {
+              len += strlen(baseData->path);
+            }
+          else if (baseData->hasNoPath == NO)
+            {
+              len++;
+            }
+        }
       if (myData->path && *myData->path)
-	{
-	  len += strlen(myData->path);
-	}
+        {
+          len += strlen(myData->path);
+        }
       else if (myData->hasNoPath == NO)
-	{
-	  len++;
-	}
+        {
+          len++;
+        }
       if (len > 3)
-	{
-	  char	buf[len];
-	  char *ptr;
+        {
+          char		buf[len];
+          char		*ptr;
 
-	  ptr = [self _path:buf withEscapes:NO];
-	  path = [NSString stringWithUTF8String:ptr];
-	}
+          ptr = [self _path: buf withEscapes: NO];
+          path = [NSString stringWithUTF8String: ptr];
+        }
     }
   return path;
 }
 
-- (NSString *)pathWithEscapes
+- (NSString*) pathWithEscapes
 {
-  return [self _pathWithEscapes:YES];
+  return [self _pathWithEscapes: YES];
 }
 @end
 
-#define GSInternal NSURLQueryItemInternal
-#include "GSInternal.h"
+
+#define	GSInternal	NSURLQueryItemInternal
+#include	"GSInternal.h"
 GS_PRIVATE_INTERNAL(NSURLQueryItem)
+
 
 @implementation NSURLQueryItem
 
 // Creating query items.
-+ (instancetype)queryItemWithName:(NSString *)name value:(NSString *)value
++ (instancetype)queryItemWithName:(NSString *)name 
+                            value:(NSString *)value
 {
-  NSURLQueryItem *newQueryItem = [[NSURLQueryItem alloc] initWithName:name
-								value:value];
+  NSURLQueryItem *newQueryItem = [[NSURLQueryItem alloc] initWithName: name
+                                                                value: value];
   return AUTORELEASE(newQueryItem);
 }
 
-- (instancetype)init
+- (instancetype) init
 {
   self = [self initWithName:nil value:nil];
-  if (self != nil)
+  if(self != nil)
     {
+    
     }
   return self;
 }
 
-- (instancetype)initWithName:(NSString *)name value:(NSString *)value
+- (instancetype)initWithName:(NSString *)name 
+                       value:(NSString *)value
 {
   self = [super init];
-  if (self != nil)
-    {
-      GS_CREATE_INTERNAL(NSURLQueryItem);
-      if (name)
-	{
-	  ASSIGNCOPY(internal->_name, name);
-	}
-      else
-	{
-	  ASSIGN(internal->_name, @""); // OSX behaviour is to set an empty
-					// string for nil name property
-	}
-      ASSIGNCOPY(internal->_value, value);
-    }
+  if(self != nil)
+  {
+    GS_CREATE_INTERNAL(NSURLQueryItem);
+    if(name)
+      {
+        ASSIGNCOPY(internal->_name, name);
+      }
+    else
+      {
+        ASSIGN(internal->_name, @""); //OSX behaviour is to set an empty string for nil name property
+      }
+    ASSIGNCOPY(internal->_value, value);
+  }
   return self;
 }
 
-- (void)dealloc
+- (void) dealloc
 {
   RELEASE(internal->_name);
   RELEASE(internal->_value);
@@ -2196,71 +2197,73 @@ GS_PRIVATE_INTERNAL(NSURLQueryItem)
 }
 
 // Reading a name and value from a query
-- (NSString *)name
+- (NSString *) name
 {
   return internal->_name;
 }
 
-- (NSString *)value
+- (NSString *) value
 {
   return internal->_value;
 }
 
-- (id)initWithCoder:(NSCoder *)acoder
+- (id) initWithCoder: (NSCoder *)acoder
 {
   if ((self = [super init]) != nil)
     {
       if ([acoder allowsKeyedCoding])
-	{
-	  internal->_name = [acoder decodeObjectForKey:@"NS.name"];
-	  internal->_value = [acoder decodeObjectForKey:@"NS.value"];
-	}
+        {
+          internal->_name = [acoder decodeObjectForKey: @"NS.name"];
+          internal->_value = [acoder decodeObjectForKey: @"NS.value"];
+        }
       else
-	{
-	  internal->_name = [acoder decodeObject];
-	  internal->_value = [acoder decodeObject];
-	}
+        {
+          internal->_name = [acoder decodeObject];
+          internal->_value = [acoder decodeObject];
+        }
     }
   return self;
 }
 
-- (void)encodeWithCoder:(NSCoder *)acoder
+- (void) encodeWithCoder: (NSCoder *)acoder
 {
   if ([acoder allowsKeyedCoding])
     {
-      [acoder encodeObject:internal->_name forKey:@"NS.name"];
-      [acoder encodeObject:internal->_value forKey:@"NS.value"];
+      [acoder encodeObject: internal->_name forKey: @"NS.name"];
+      [acoder encodeObject: internal->_value forKey: @"NS.value"];
     }
   else
     {
-      [acoder encodeObject:internal->_name];
-      [acoder encodeObject:internal->_value];
+      [acoder encodeObject: internal->_name];
+      [acoder encodeObject: internal->_value];
     }
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id) copyWithZone: (NSZone *)zone
 {
-  return [[[self class] allocWithZone:zone] initWithName:internal->_name
-						   value:internal->_value];
+    return [[[self class] allocWithZone: zone] initWithName: internal->_name
+                                                      value: internal->_value];
 }
 
 @end
 
-#undef GSInternal
-#define GSInternal NSURLComponentsInternal
+
+#undef	GSInternal
+#define	GSInternal NSURLComponentsInternal
 #include "GSInternal.h"
 GS_PRIVATE_INTERNAL(NSURLComponents)
 
-@implementation NSURLComponents
 
-static NSCharacterSet *queryItemCharSet = nil;
+@implementation NSURLComponents 
 
-+ (void)initialize
+static NSCharacterSet	*queryItemCharSet = nil;
+
++ (void) initialize
 {
   if (nil == queryItemCharSet)
     {
       ENTER_POOL
-      NSMutableCharacterSet *m;
+      NSMutableCharacterSet	*m;
 
       m = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
 
@@ -2271,50 +2274,49 @@ static NSCharacterSet *queryItemCharSet = nil;
        * where the name ends and the value starts, so we cannot permit that
        * character either.
        */
-      [m removeCharactersInString:@"&="];
+      [m removeCharactersInString: @"&="];
       queryItemCharSet = [m copy];
       LEAVE_POOL
     }
 }
 
 // Creating URL components...
-+ (instancetype)componentsWithString:(NSString *)urlString
++ (instancetype) componentsWithString: (NSString *)urlString
 {
-  return AUTORELEASE([[NSURLComponents alloc] initWithString:urlString]);
+  return  AUTORELEASE([[NSURLComponents alloc] initWithString: urlString]);
 }
 
-+ (instancetype)componentsWithURL:(NSURL *)url
-	  resolvingAgainstBaseURL:(BOOL)resolve
++ (instancetype) componentsWithURL: (NSURL *)url 
+           resolvingAgainstBaseURL: (BOOL)resolve
 {
-  return AUTORELEASE([[NSURLComponents alloc] initWithURL:url
-				  resolvingAgainstBaseURL:resolve]);
+  return  AUTORELEASE([[NSURLComponents alloc] initWithURL: url
+                      resolvingAgainstBaseURL: resolve]);
 }
 
-- (instancetype)init
+- (instancetype) init
 {
   self = [super init];
   if (self != nil)
     {
       GS_CREATE_INTERNAL(NSURLComponents);
-
+      
       internal->_rangeOfFragment = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfHost = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfHost     = NSMakeRange(NSNotFound, 0);
       internal->_rangeOfPassword = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfPath = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfPort = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfQuery = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfScheme = NSMakeRange(NSNotFound, 0);
-      internal->_rangeOfUser = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPath     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfPort     = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfQuery    = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfScheme   = NSMakeRange(NSNotFound, 0);
+      internal->_rangeOfUser     = NSMakeRange(NSNotFound, 0);
     }
   return self;
 }
 
-- (instancetype)initWithString:(NSString *)URLString
+- (instancetype) initWithString: (NSString *)URLString
 {
-  // OSX behavior is to return nil for a string which cannot be used to
-  // initialize valid NSURL object
-  NSURL *url = [NSURL URLWithString:URLString];
-  if (url)
+  //OSX behavior is to return nil for a string which cannot be used to initialize valid NSURL object
+  NSURL* url = [NSURL URLWithString:URLString];
+  if(url)
     {
       return [self initWithURL:url resolvingAgainstBaseURL:NO];
     }
@@ -2324,7 +2326,8 @@ static NSCharacterSet *queryItemCharSet = nil;
     }
 }
 
-- (instancetype)initWithURL:(NSURL *)url resolvingAgainstBaseURL:(BOOL)resolve
+- (instancetype) initWithURL: (NSURL *)url 
+     resolvingAgainstBaseURL: (BOOL)resolve
 {
   self = [self init];
   if (self != nil)
@@ -2332,15 +2335,15 @@ static NSCharacterSet *queryItemCharSet = nil;
       NSURL *tempURL = url;
 
       if (resolve)
-	{
-	  tempURL = [url absoluteURL];
-	}
-      [self setURL:tempURL];
+        {
+          tempURL = [url absoluteURL];
+        }
+      [self setURL: tempURL];
     }
   return self;
 }
 
-- (void)dealloc
+- (void) dealloc
 {
   RELEASE(internal->_string);
   RELEASE(internal->_fragment);
@@ -2355,35 +2358,35 @@ static NSCharacterSet *queryItemCharSet = nil;
   [super dealloc];
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (id) copyWithZone: (NSZone *)zone
 {
-  return [[NSURLComponents allocWithZone:zone] initWithURL:[self URL]
-				   resolvingAgainstBaseURL:NO];
+  return [[NSURLComponents allocWithZone: zone] initWithURL: [self URL]
+                                    resolvingAgainstBaseURL: NO];
 }
 
 // Regenerate URL when components are changed...
-- (void)_regenerateURL
+- (void) _regenerateURL
 {
-  NSMutableString *urlString;
-  NSString *	   component;
-  NSUInteger	   location;
-  NSUInteger	   len;
-
+  NSMutableString	*urlString;
+  NSString		*component;
+  NSUInteger 	 	location;
+  NSUInteger 		len;
+  
   if (internal->_dirty == NO)
     {
       return;
     }
 
-  urlString = [[NSMutableString alloc] initWithCapacity:1000];
+  urlString = [[NSMutableString alloc] initWithCapacity: 1000];
   location = 0;
   // Build up the URL from components...
   if (internal->_scheme != nil)
     {
       component = [self scheme];
-      [urlString appendString:component];
+      [urlString appendString: component];
       len = [component length];
       internal->_rangeOfScheme = NSMakeRange(location, len);
-      [urlString appendString:@"://"];
+      [urlString appendString: @"://"];
       location += len + 3;
     }
   else
@@ -2391,40 +2394,40 @@ static NSCharacterSet *queryItemCharSet = nil;
       internal->_rangeOfScheme = NSMakeRange(NSNotFound, 0);
     }
 
-  if (internal->_user != nil)
+  if (internal->_user != nil) 
     {
       if (internal->_password != nil)
-	{
-	  component = [self percentEncodedUser];
+        {
+          component = [self percentEncodedUser];
 	  len = [component length];
-	  [urlString appendString:component];
-	  internal->_rangeOfUser = NSMakeRange(location, len);
-	  [urlString appendString:@":"];
-	  location += len + 1;
+          [urlString appendString: component];
+          internal->_rangeOfUser = NSMakeRange(location, len);
+          [urlString appendString: @":"];
+          location += len + 1;
 
-	  component = [self percentEncodedPassword];
+          component = [self percentEncodedPassword];
 	  len = [component length];
-	  [urlString appendString:component];
-	  internal->_rangeOfUser = NSMakeRange(location, len);
-	  [urlString appendString:@"@"];
-	  location += len + 1;
-	}
+          [urlString appendString: component];
+          internal->_rangeOfUser = NSMakeRange(location, len);
+          [urlString appendString: @"@"];
+          location += len + 1;
+        }
       else
-	{
-	  component = [self percentEncodedUser];
+        {
+          component = [self percentEncodedUser];
 	  len = [component length];
-	  [urlString appendString:component];
-	  internal->_rangeOfUser = NSMakeRange(location, len);
-	  [urlString appendString:@"@"];
-	  location += len + 1;
-	}
+          [urlString appendString: component];
+          internal->_rangeOfUser = NSMakeRange(location, len);
+          [urlString appendString: @"@"];
+          location += len + 1;
+        }
     }
 
   if (internal->_host != nil)
     {
       component = [self percentEncodedHost];
       len = [component length];
-      [urlString appendString:component];
+      [urlString appendString: component];
       internal->_rangeOfHost = NSMakeRange(location, len);
       location += len;
     }
@@ -2433,9 +2436,9 @@ static NSCharacterSet *queryItemCharSet = nil;
     {
       component = [[self port] stringValue];
       len = [component length];
-      [urlString appendString:@":"];
+      [urlString appendString: @":"];
       location += 1;
-      [urlString appendString:component];
+      [urlString appendString: component];
       internal->_rangeOfPort = NSMakeRange(location, len);
       location += len;
     }
@@ -2446,7 +2449,7 @@ static NSCharacterSet *queryItemCharSet = nil;
     {
       component = [self percentEncodedPath];
       len = [component length];
-      [urlString appendString:component];
+      [urlString appendString: component];
       internal->_rangeOfPath = NSMakeRange(location, len);
       location += len;
     }
@@ -2455,9 +2458,9 @@ static NSCharacterSet *queryItemCharSet = nil;
     {
       component = [self percentEncodedQuery];
       len = [component length];
-      [urlString appendString:@"?"];
+      [urlString appendString: @"?"];
       location += 1;
-      [urlString appendString:component];
+      [urlString appendString: component];
       internal->_rangeOfQuery = NSMakeRange(location, len);
       location += len;
     }
@@ -2466,147 +2469,147 @@ static NSCharacterSet *queryItemCharSet = nil;
     {
       component = [self percentEncodedFragment];
       len = [component length];
-      [urlString appendString:@"#"];
+      [urlString appendString: @"#"];
       location += 1;
-      [urlString appendString:component];
+      [urlString appendString: component];
       internal->_rangeOfFragment = NSMakeRange(location, len);
       location += len;
     }
-
+    
   ASSIGNCOPY(internal->_string, urlString);
   RELEASE(urlString);
   internal->_dirty = NO;
 }
 
 // Getting the URL
-- (NSString *)string
+- (NSString *) string
 {
   [self _regenerateURL];
   return internal->_string;
 }
 
-- (void)setString:(NSString *)urlString
+- (void) setString: (NSString *)urlString
 {
-  NSURL *url = [NSURL URLWithString:urlString];
-  [self setURL:url];
+  NSURL *url = [NSURL URLWithString: urlString];
+  [self setURL: url];
 }
 
-- (NSURL *)URL
+- (NSURL *) URL
 {
-  return AUTORELEASE([[NSURL alloc] initWithScheme:[self scheme]
-					      user:[self user]
-					  password:[self password]
-					      host:[self host]
-					      port:[self port]
-					  fullPath:[self path]
-				   parameterString:nil
-					     query:[self percentEncodedQuery]
-					  fragment:[self fragment]]);
+  return AUTORELEASE([[NSURL alloc] initWithScheme: [self scheme]
+                                              user: [self user]
+                                          password: [self password]
+                                              host: [self host]
+                                              port: [self port]
+                                          fullPath: [self path]
+                                   parameterString: nil
+                                             query: [self percentEncodedQuery]
+                                          fragment: [self fragment]]);
 }
 
-- (void)setURL:(NSURL *)url
+- (void) setURL: (NSURL *)url
 {
   // Set all the components...
-  [self setScheme:[url scheme]];
-  [self setHost:[url host]];
-  [self setPort:[url port]];
-  [self setUser:[url user]];
-  [self setPassword:[url password]];
-  [self setPath:[url path]];
+  [self setScheme: [url scheme]];
+  [self setHost: [url host]];
+  [self setPort: [url port]];
+  [self setUser: [url user]];
+  [self setPassword: [url password]];
+  [self setPath: [url path]];
   [self setPercentEncodedQuery:[url query]];
-  [self setFragment:[url fragment]];
+  [self setFragment: [url fragment]];
 }
 
-- (NSURL *)URLRelativeToURL:(NSURL *)baseURL
+- (NSURL *) URLRelativeToURL: (NSURL *)baseURL
 {
   return nil;
 }
 
 // Accessing Components in Native Format
-- (NSString *)fragment
+- (NSString *) fragment
 {
   return internal->_fragment;
 }
 
-- (void)setFragment:(NSString *)fragment
+- (void) setFragment: (NSString *)fragment
 {
   ASSIGNCOPY(internal->_fragment, fragment);
   internal->_dirty = YES;
 }
 
-- (NSString *)host
+- (NSString *) host
 {
   return internal->_host;
 }
 
-- (void)setHost:(NSString *)host
+- (void) setHost: (NSString *)host
 {
   ASSIGNCOPY(internal->_host, host);
   internal->_dirty = YES;
 }
 
-- (NSString *)password
+- (NSString *) password
 {
   return internal->_password;
 }
 
-- (void)setPassword:(NSString *)password
+- (void) setPassword: (NSString *)password
 {
   ASSIGNCOPY(internal->_password, password);
   internal->_dirty = YES;
 }
 
-- (NSString *)path
+- (NSString *) path
 {
   return internal->_path;
 }
 
-- (void)setPath:(NSString *)path
+- (void) setPath: (NSString *)path
 {
   ASSIGNCOPY(internal->_path, path);
   internal->_dirty = YES;
 }
 
-- (NSNumber *)port
+- (NSNumber *) port
 {
   return internal->_port;
 }
 
-- (void)setPort:(NSNumber *)port
+- (void) setPort: (NSNumber *)port
 {
   ASSIGNCOPY(internal->_port, port);
   internal->_dirty = YES;
 }
 
-- (NSString *)query
+- (NSString *) query
 {
-  NSString *result = nil;
+  NSString	*result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableString *query = nil;
-      NSURLQueryItem * item = nil;
-      NSEnumerator *   en;
+      NSMutableString	*query = nil;
+      NSURLQueryItem	*item = nil;
+      NSEnumerator	*en;
 
       en = [internal->_queryItems objectEnumerator];
-      while ((item = (NSURLQueryItem *) [en nextObject]) != nil)
+      while ((item = (NSURLQueryItem *)[en nextObject]) != nil)
 	{
-	  NSString *name = [item name];
-	  NSString *value = [item value];
+	  NSString	*name = [item name];
+	  NSString	*value = [item value];
 
 	  if (nil == query)
 	    {
-	      query = [[NSMutableString alloc] initWithCapacity:1000];
+	      query = [[NSMutableString alloc] initWithCapacity: 1000];
 	    }
 	  else
 	    {
-	      [query appendString:@"&"];
+	      [query appendString: @"&"];
 	    }
-	  [query appendString:name];
+	  [query appendString: name];
 	  if (value != nil)
 	    {
-	      [query appendString:@"="];
-	      [query appendString:value];
+	      [query appendString: @"="];
+	      [query appendString: value];
 	    }
 	}
       if (nil == query)
@@ -2622,31 +2625,30 @@ static NSCharacterSet *queryItemCharSet = nil;
   return result;
 }
 
-- (void)_setQuery:(NSString *)query fromPercentEncodedString:(BOOL)encoded
+- (void) _setQuery: (NSString *)query fromPercentEncodedString: (BOOL)encoded
 {
-  /* Parse according to
-   * https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems?language=objc
+  /* Parse according to https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems?language=objc
    */
   if (nil == query)
     {
-      [self setQueryItems:nil];
+      [self setQueryItems: nil];
     }
   else if ([query length] == 0)
     {
-      [self setQueryItems:[NSArray array]];
+      [self setQueryItems: [NSArray array]];
     }
   else
     {
-      NSMutableArray *result = [NSMutableArray arrayWithCapacity:5];
-      NSArray *	      items = [query componentsSeparatedByString:@"&"];
-      NSEnumerator *  en = [items objectEnumerator];
-      id	      item = nil;
+      NSMutableArray	*result = [NSMutableArray arrayWithCapacity: 5];
+      NSArray 		*items = [query componentsSeparatedByString: @"&"];
+      NSEnumerator	*en = [items objectEnumerator];
+      id		item = nil;
 
       while ((item = [en nextObject]) != nil)
-	{
-	  NSURLQueryItem *qitem;
-	  NSString *	  name;
-	  NSString *	  value;
+        {
+          NSURLQueryItem	*qitem;
+	  NSString		*name;
+	  NSString		*value;
 
 	  if ([item length] == 0)
 	    {
@@ -2655,7 +2657,7 @@ static NSCharacterSet *queryItemCharSet = nil;
 	    }
 	  else
 	    {
-	      NSRange r = [item rangeOfString:@"="];
+	      NSRange	r = [item rangeOfString: @"="];
 
 	      if (0 == r.length)
 		{
@@ -2665,8 +2667,8 @@ static NSCharacterSet *queryItemCharSet = nil;
 		}
 	      else
 		{
-		  name = [item substringToIndex:r.location];
-		  value = [item substringFromIndex:NSMaxRange(r)];
+		  name = [item substringToIndex: r.location];
+		  value = [item substringFromIndex: NSMaxRange(r)];
 		}
 	    }
 	  if (encoded)
@@ -2674,127 +2676,129 @@ static NSCharacterSet *queryItemCharSet = nil;
 	      name = [name stringByRemovingPercentEncoding];
 	      value = [value stringByRemovingPercentEncoding];
 	    }
-	  qitem = [NSURLQueryItem queryItemWithName:name value:value];
-	  [result addObject:qitem];
-	}
-      [self setQueryItems:result];
+          qitem = [NSURLQueryItem queryItemWithName: name value: value];
+          [result addObject: qitem];
+        }
+      [self setQueryItems: result];
     }
 }
 
-- (void)setQuery:(NSString *)query
+- (void) setQuery: (NSString *)query
 {
-  [self _setQuery:query fromPercentEncodedString:NO];
+  [self _setQuery: query fromPercentEncodedString: NO];
 }
 
-- (NSArray *)queryItems
+- (NSArray *) queryItems
 {
   return AUTORELEASE(RETAIN(internal->_queryItems));
 }
 
-- (void)setQueryItems:(NSArray *)queryItems
-{
+- (void) setQueryItems: (NSArray *)queryItems
+{ 
   ASSIGNCOPY(internal->_queryItems, queryItems);
   internal->_dirty = YES;
 }
 
-- (NSString *)scheme
+- (NSString *) scheme
 {
   return internal->_scheme;
 }
 
-- (void)setScheme:(NSString *)scheme
+- (void) setScheme: (NSString *)scheme
 {
   ASSIGNCOPY(internal->_scheme, scheme);
   internal->_dirty = YES;
 }
 
-- (NSString *)user
+- (NSString *) user
 {
   return internal->_user;
 }
 
-- (void)setUser:(NSString *)user
+- (void) setUser: (NSString *)user
 {
   ASSIGNCOPY(internal->_user, user);
   internal->_dirty = YES;
 }
 
 // Accessing Components in PercentEncoded Format
-- (NSString *)percentEncodedFragment
+- (NSString *) percentEncodedFragment
 {
-  return
-    [internal->_fragment stringByAddingPercentEncodingWithAllowedCharacters:
-			   [NSCharacterSet URLFragmentAllowedCharacterSet]];
+  return [internal->_fragment
+    stringByAddingPercentEncodingWithAllowedCharacters:
+    [NSCharacterSet URLFragmentAllowedCharacterSet]];
 }
 
-- (void)setPercentEncodedFragment:(NSString *)fragment
+- (void) setPercentEncodedFragment: (NSString *)fragment
 {
-  [self setFragment:[fragment stringByRemovingPercentEncoding]];
+  [self setFragment: [fragment stringByRemovingPercentEncoding]];
 }
 
-- (NSString *)percentEncodedHost
+- (NSString *) percentEncodedHost
 {
-  return [internal->_host stringByAddingPercentEncodingWithAllowedCharacters:
-			    [NSCharacterSet URLHostAllowedCharacterSet]];
+  return [internal->_host
+    stringByAddingPercentEncodingWithAllowedCharacters:
+    [NSCharacterSet URLHostAllowedCharacterSet]];
 }
 
-- (void)setPercentEncodedHost:(NSString *)host
+- (void) setPercentEncodedHost: (NSString *)host
 {
-  [self setHost:[host stringByRemovingPercentEncoding]];
+  [self setHost: [host stringByRemovingPercentEncoding]];
 }
 
-- (NSString *)percentEncodedPassword
+- (NSString *) percentEncodedPassword
 {
-  return
-    [internal->_password stringByAddingPercentEncodingWithAllowedCharacters:
-			   [NSCharacterSet URLPasswordAllowedCharacterSet]];
+  return [internal->_password
+    stringByAddingPercentEncodingWithAllowedCharacters:
+    [NSCharacterSet URLPasswordAllowedCharacterSet]];
 }
 
-- (void)setPercentEncodedPassword:(NSString *)password
+- (void) setPercentEncodedPassword: (NSString *)password
 {
-  [self setPassword:[password stringByRemovingPercentEncoding]];
+  [self setPassword: [password stringByRemovingPercentEncoding]];
 }
 
-- (NSString *)percentEncodedPath
+- (NSString *) percentEncodedPath
 {
-  return [internal->_path stringByAddingPercentEncodingWithAllowedCharacters:
-			    [NSCharacterSet URLPathAllowedCharacterSet]];
+  return [internal->_path
+    stringByAddingPercentEncodingWithAllowedCharacters:
+    [NSCharacterSet URLPathAllowedCharacterSet]];
 }
 
-- (void)setPercentEncodedPath:(NSString *)path
+- (void) setPercentEncodedPath: (NSString *)path
 {
-  [self setPath:[path stringByRemovingPercentEncoding]];
+  [self setPath: [path stringByRemovingPercentEncoding]];
 }
 
-- (NSString *)percentEncodedQuery
+- (NSString *) percentEncodedQuery
 {
-  NSString *result = nil;
+  NSString	*result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableString *query = nil;
-      NSURLQueryItem * item = nil;
-      NSEnumerator *   en;
+      NSMutableString	*query = nil;
+      NSURLQueryItem	*item = nil;
+      NSEnumerator	*en;
 
       en = [[self percentEncodedQueryItems] objectEnumerator];
-      while ((item = (NSURLQueryItem *) [en nextObject]) != nil)
+      while ((item = (NSURLQueryItem *)[en nextObject]) != nil)
 	{
-	  NSString *name = [item name];
-	  NSString *value = [item value];
+	  NSString	*name = [item name];
+	  NSString	*value = [item value];
 
 	  if (nil == query)
 	    {
-	      query = [[NSMutableString alloc] initWithCapacity:1000];
+	      query = [[NSMutableString alloc] initWithCapacity: 1000];
 	    }
 	  else
 	    {
-	      [query appendString:@"&"];
+	      [query appendString: @"&"];
 	    }
-	  [query appendString:name];
+	  [query appendString: name];
 	  if (value != nil)
 	    {
-	      [query appendString:@"="];
-	      [query appendString:value];
+	      [query appendString: @"="];
+	      [query appendString: value];
 	    }
 	}
       if (nil == query)
@@ -2810,35 +2814,36 @@ static NSCharacterSet *queryItemCharSet = nil;
   return result;
 }
 
-- (void)setPercentEncodedQuery:(NSString *)query
+- (void) setPercentEncodedQuery: (NSString *)query
 {
-  [self _setQuery:query fromPercentEncodedString:YES];
+  [self _setQuery: query fromPercentEncodedString: YES];
 }
 
-- (NSArray *)percentEncodedQueryItems
+- (NSArray *) percentEncodedQueryItems
 {
-  NSArray *result = nil;
+  NSArray	*result = nil;
 
   if (internal->_queryItems != nil)
     {
-      NSMutableArray *items;
-      NSEnumerator *  en = [internal->_queryItems objectEnumerator];
-      NSURLQueryItem *i = nil;
+      NSMutableArray	*items;
+      NSEnumerator 	*en = [internal->_queryItems objectEnumerator];
+      NSURLQueryItem	*i = nil;
 
-      items =
-	[[NSMutableArray alloc] initWithCapacity:[internal->_queryItems count]];
+      items = [[NSMutableArray alloc]
+	initWithCapacity: [internal->_queryItems count]];
       while ((i = [en nextObject]) != nil)
 	{
-	  NSURLQueryItem *ni;
-	  NSString *	  name = [i name];
-	  NSString *	  value = [i value];
+	  NSURLQueryItem	*ni;
+	  NSString		*name = [i name];
+	  NSString		*value = [i value];
 
 	  name = [name stringByAddingPercentEncodingWithAllowedCharacters:
-			 queryItemCharSet];
+	    queryItemCharSet];
 	  value = [value stringByAddingPercentEncodingWithAllowedCharacters:
-			   queryItemCharSet];
-	  ni = [NSURLQueryItem queryItemWithName:name value:value];
-	  [items addObject:ni];
+	    queryItemCharSet];
+	  ni = [NSURLQueryItem queryItemWithName: name
+					   value: value];
+	  [items addObject: ni];
 	}
       result = AUTORELEASE([items copy]);
       RELEASE(items);
@@ -2846,90 +2851,90 @@ static NSCharacterSet *queryItemCharSet = nil;
   return result;
 }
 
-- (void)setPercentEncodedQueryItems:(NSArray *)queryItems
+- (void) setPercentEncodedQueryItems: (NSArray *)queryItems
 {
-  NSMutableArray *items = nil;
+  NSMutableArray	*items = nil;
 
   if (queryItems != nil)
     {
-      NSEnumerator *  en = [queryItems objectEnumerator];
-      NSURLQueryItem *i = nil;
+      NSEnumerator	*en = [queryItems objectEnumerator];
+      NSURLQueryItem 	*i = nil;
 
-      items = [NSMutableArray arrayWithCapacity:[queryItems count]];
+      items = [NSMutableArray arrayWithCapacity: [queryItems count]];
       while ((i = [en nextObject]) != nil)
 	{
-	  NSString *	  name;
-	  NSString *	  value;
-	  NSURLQueryItem *ni;
+	  NSString		*name;
+	  NSString		*value;
+	  NSURLQueryItem	*ni;
 
 	  name = [[i name] stringByRemovingPercentEncoding];
 	  value = [[i value] stringByRemovingPercentEncoding];
-	  ni = [NSURLQueryItem queryItemWithName:name value:value];
-	  [items addObject:ni];
+	  ni = [NSURLQueryItem queryItemWithName: name value: value];
+	  [items addObject: ni];
 	}
     }
 
-  [self setQueryItems:items];
+  [self setQueryItems: items];
 }
 
-- (NSString *)percentEncodedUser
+- (NSString *) percentEncodedUser
 {
   return [internal->_user stringByAddingPercentEncodingWithAllowedCharacters:
-			    [NSCharacterSet URLUserAllowedCharacterSet]];
+    [NSCharacterSet URLUserAllowedCharacterSet]];
 }
 
-- (void)setPercentEncodedUser:(NSString *)user
+- (void) setPercentEncodedUser: (NSString *)user
 {
-  [self setUser:[user stringByRemovingPercentEncoding]];
+  [self setUser: [user stringByRemovingPercentEncoding]];
 }
 
 // Locating components of the URL string representation
-- (NSRange)rangeOfFragment
+- (NSRange) rangeOfFragment
 {
   [self _regenerateURL];
   return internal->_rangeOfFragment;
 }
 
-- (NSRange)rangeOfHost
+- (NSRange) rangeOfHost
 {
   [self _regenerateURL];
   return internal->_rangeOfHost;
 }
 
-- (NSRange)rangeOfPassword
+- (NSRange) rangeOfPassword
 {
   [self _regenerateURL];
   return internal->_rangeOfPassword;
 }
 
-- (NSRange)rangeOfPath
+- (NSRange) rangeOfPath
 {
   [self _regenerateURL];
   return internal->_rangeOfPath;
 }
 
-- (NSRange)rangeOfPort
+- (NSRange) rangeOfPort
 {
   [self _regenerateURL];
   return internal->_rangeOfPort;
 }
 
-- (NSRange)rangeOfQuery
+- (NSRange) rangeOfQuery
 {
   [self _regenerateURL];
   return internal->_rangeOfQuery;
 }
 
-- (NSRange)rangeOfScheme
+- (NSRange) rangeOfScheme
 {
   [self _regenerateURL];
   return internal->_rangeOfScheme;
 }
 
-- (NSRange)rangeOfUser
+- (NSRange) rangeOfUser
 {
   [self _regenerateURL];
   return internal->_rangeOfUser;
 }
-
+  
 @end


### PR DESCRIPTION
I noticed that the **initFileURLWithPath:relativeToURL:**, **initFileURLWithPath:isDirectory:relativeToURL:**, **fileURLWithPath:relativeToURL:** and **fileURLWithPath:isDirectory:relativeToURL:** initializers (and convenience initializers) are not present in gnustep-base. They were added in macOS 10.11.

Here is a full implementation of all initializers listed above with some cleanup in the initialization process (duplicate code removal).

My editor automatically formats the source as described in the _.clang-format_ file. Turns out that the source code did not follow the spec. Most of the changes are automatic clang-format adjustments.