### PR TITLE
Implement NSURLSessionDownloadTask and NSURLSessionDownloadDelegate

### DIFF
--- a/Headers/Foundation/NSURLSession.h
+++ b/Headers/Foundation/NSURLSession.h
@@ -24,6 +24,7 @@
 @class NSURLResponse;
 @class NSURLSessionConfiguration;
 @class NSURLSessionDataTask;
+@class NSURLSessionDownloadTask;
 
 
 /**
@@ -109,6 +110,12 @@ GS_EXPORT_CLASS
 
 /* Creates a data task to retrieve the contents of the given URL. */
 - (NSURLSessionDataTask*) dataTaskWithURL: (NSURL*)url;
+
+/* Creates a download task with the given request. */
+- (NSURLSessionDownloadTask *) downloadTaskWithRequest: (NSURLRequest *)request;
+
+/* Creates a download task to download the contents of the given URL. */
+- (NSURLSessionDownloadTask *) downloadTaskWithURL: (NSURL *)url;
 
 @end
 
@@ -427,6 +434,37 @@ didReceiveChallenge: (NSURLAuthenticationChallenge*)challenge
            dataTask: (NSURLSessionDataTask*)dataTask
  didReceiveResponse: (NSURLResponse*)response
   completionHandler: (void (^)(NSURLSessionResponseDisposition disposition))completionHandler;
+
+@end
+
+@protocol NSURLSessionDownloadDelegate <NSURLSessionTaskDelegate>
+
+/* Sent when a download task that has completed a download.  The delegate should 
+ * copy or move the file at the given location to a new location as it will be 
+ * removed when the delegate message returns. URLSession:task:didCompleteWithError: will
+ * still be called.
+ */
+- (void)         URLSession: (NSURLSession *)session
+               downloadTask: (NSURLSessionDownloadTask *)downloadTask
+  didFinishDownloadingToURL: (NSURL *)location;
+
+@optional
+/* Sent periodically to notify the delegate of download progress. */
+- (void)         URLSession: (NSURLSession *)session
+               downloadTask: (NSURLSessionDownloadTask *)downloadTask
+               didWriteData: (int64_t)bytesWritten
+          totalBytesWritten: (int64_t)totalBytesWritten
+  totalBytesExpectedToWrite: (int64_t)totalBytesExpectedToWrite;
+
+/* Sent when a download has been resumed. If a download failed with an
+ * error, the -userInfo dictionary of the error will contain an
+ * NSURLSessionDownloadTaskResumeData key, whose value is the resume
+ * data. 
+ */
+- (void)  URLSession: (NSURLSession *)session
+        downloadTask: (NSURLSessionDownloadTask *)downloadTask
+   didResumeAtOffset: (int64_t)fileOffset
+  expectedTotalBytes: (int64_t)expectedTotalBytes;
 
 @end
 

--- a/Source/NSURLSession.m
+++ b/Source/NSURLSession.m
@@ -612,6 +612,27 @@ static int nextSessionIdentifier()
 
   if (nil != delegate)
     {
+      // Send delegate with temporary fileURL
+      if ([task isKindOfClass: [NSURLSessionDownloadTask class]]
+        && [delegate respondsToSelector: @selector(URLSession:downloadTask:didFinishDownloadingToURL:)])
+        {
+          id<NSURLSessionDownloadDelegate> downloadDelegate;
+          NSURLSessionDownloadTask         *downloadTask;
+          NSURL                            *fileURL;
+
+          downloadDelegate = (id<NSURLSessionDownloadDelegate>)delegate;
+          downloadTask = (NSURLSessionDownloadTask *)task;
+          fileURL = [NSURLProtocol propertyForKey: @"tempFileURL"
+                                        inRequest: [protocol request]];
+
+          [delegateQueue addOperationWithBlock:
+            ^{
+              [downloadDelegate URLSession: session
+                              downloadTask: downloadTask
+                 didFinishDownloadingToURL: fileURL];
+            }];
+        }
+
       [delegateQueue addOperationWithBlock: 
         ^{
           if (NSURLSessionTaskStateCompleted == [task state])


### PR DESCRIPTION
The GNUstep NSURLSession API only implements NSURLSessionDataTask. This pull request adds the download functionality. 

An URLSessionDownloadTask will directly write the response data to a temporary file.  When completed, the delegate is sent URLSession:downloadTask:didFinishDownloadingToURL: and given an opportunity to move this file to a permanent location or to otherwise read the file.

But what about the resume functionality?

In Cocoa NSURLSessionDownloadTask creates an opaque data blob to resume a failed download task.
This method relies on an Apple-maintained XPC process to manage the bookmarking of partially downloaded data. Therefore, we'd need to create a similar bookmarking process. Any ideas on how to implement this?

Throughout the testing process I encountered a bug in the GNUstep NSURLSession implementation:
NSURLSessionTask does not retain the NSURLSession object. This results in a segmentation fault when ARC is used. I fixed it by retaining and releasing the object accordingly.