### PR TITLE
Fix `NSGetSizeAndAlignment` usage

### DIFF
--- a/Source/Additions/GSObjCRuntime.m
+++ b/Source/Additions/GSObjCRuntime.m
@@ -1862,7 +1862,7 @@ GSObjCSetVal(NSObject *self, const char *key, id val, SEL sel,
               {
 		NSUInteger	size;
 
-		NSGetSizeAndAlignment(type, &size, 0);
+		NSGetSizeAndAlignment(type, &size, NULL);
                 if (sel == 0)
                   {
 		    [val getValue: ((char *)self + offset)];

--- a/Source/GSConcreteValueTemplate.m
+++ b/Source/GSConcreteValueTemplate.m
@@ -113,7 +113,7 @@
 		  format: @"Cannot copy value into NULL buffer"];
 	/* NOT REACHED */
     }
-  NSGetSizeAndAlignment([self objCType], 0, &size);
+  NSGetSizeAndAlignment([self objCType], &size, NULL);
   memcpy(value, &data, size);
 }
 

--- a/Source/GSValue.m
+++ b/Source/GSValue.m
@@ -73,7 +73,7 @@ typeSize(const char* type)
 	{
 	  NSUInteger	size;
 
-	  NSGetSizeAndAlignment(type, &size, 0);
+	  NSGetSizeAndAlignment(type, &size, NULL);
 	  return (int)size;
 	}
       case _C_VOID:	return 0;
@@ -265,7 +265,7 @@ typeSize(const char* type)
   size = strlen(objctype)+1;
   [coder encodeValueOfObjCType: @encode(unsigned) at: &size];
   [coder encodeArrayOfObjCType: @encode(signed char) count: size at: objctype];
-  NSGetSizeAndAlignment(objctype, 0, &tsize);
+  NSGetSizeAndAlignment(objctype, &tsize, NULL);
   size = tsize;
   d = [NSMutableData new];
   [d serializeDataAt: data ofObjCType: objctype context: nil];

--- a/Source/NSKeyedUnarchiver.m
+++ b/Source/NSKeyedUnarchiver.m
@@ -427,7 +427,7 @@ static NSMapTable	*globalClassMap = 0;
 		  format: @"[%@ +%@]: count mismatch for %@",
 	NSStringFromClass([self class]), NSStringFromSelector(_cmd), o];
     }
-  NSGetSizeAndAlignment(type, 0, &size);
+  NSGetSizeAndAlignment(type, &size, NULL);
   memcpy(buf, [o bytes], expected * size);
 }
 

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -611,7 +611,7 @@ static NSUInteger	urlAlign;
 {
   if (clientsLock == nil)
     {
-      NSGetSizeAndAlignment(@encode(parsedURL), &urlAlign, 0);
+      NSGetSizeAndAlignment(@encode(parsedURL), NULL, &urlAlign);
       clientsLock = [NSLock new];
       [[NSObject leakAt: &clientsLock] release];
       ASSIGN(fileCharSet, [NSCharacterSet characterSetWithCharactersInString:

--- a/Source/NSValue.m
+++ b/Source/NSValue.m
@@ -440,7 +440,7 @@ static NSLock			*placeholderLock;
       return;
     }
 
-  NSGetSizeAndAlignment(objctype, 0, &tsize);
+  NSGetSizeAndAlignment(objctype, &tsize, NULL);
   data = (void *)NSZoneMalloc([self zone], tsize);
   [self getValue: (void*)data];
   d = [NSMutableData new];
@@ -583,7 +583,7 @@ static NSLock			*placeholderLock;
 	   * For performance, decode small values directly onto the stack,
 	   * For larger values we allocate and deallocate heap space.
 	   */
-	  NSGetSizeAndAlignment(objctype, 0, &tsize);
+	  NSGetSizeAndAlignment(objctype, &tsize, NULL);
 	  if (tsize <= 64)
 	    {
 	      unsigned char data[tsize];
@@ -625,7 +625,7 @@ static NSLock			*placeholderLock;
        * For performance, decode small values directly onto the stack,
        * For larger values we allocate and deallocate heap space.
        */
-      NSGetSizeAndAlignment(objctype, 0, &tsize);
+      NSGetSizeAndAlignment(objctype, &tsize, NULL);
       if (tsize <= 64)
 	{
 	  unsigned char	data[tsize];

--- a/Tests/base/NSValue/basic.m
+++ b/Tests/base/NSValue/basic.m
@@ -1,0 +1,28 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+int main()
+{
+  NSAutoreleasePool   *arp = [NSAutoreleasePool new];
+  NSValue *testObj;
+
+  test_alloc_only(@"NSValue");
+
+  int val = 5;
+  int out;
+  testObj = [NSValue valueWithBytes: &val objCType: @encode(int)];
+  [testObj getValue: &out];
+  PASS_EQUAL(val, out, "NSValue -getValue returned the same integer");
+
+  NSRange range_val = NSMakeRange(1, 1);
+  NSRange range_out;
+  testObj = [NSValue valueWithBytes: &range_val objCType: @encode(NSRange)];
+  [testObj getValue: &range_out];
+  PASS(NSEqualRanges(range_val, range_out), "NSValue -getValue returned the same NSRange");
+  range_out = [testObj rangeValue];
+  PASS(NSEqualRanges(range_val, range_out), "NSValue -rangeValue returned the same NSRange");
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
The argument order is `(*sizep, *alignp)`, but it was often incorrectly used the other way around.

This is probably the source of several bugs, but the one that hit me was that an `NSValue` containing `NSRange` didn't return the proper value in `-getValue`. I've added a test for that case, correct me if it's wrong, I'm not familiar with your testing setup.