### PR TITLE
Annotate NSBundle localized string function with NS_FORMAT_ARGUMENT

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-11-11 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSBundle.h:
+	Annotate NSBundle localized string function with NS_FORMAT_ARGUMENT.
+
 2021-09-20 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSFileManager.m:

--- a/Headers/Foundation/NSBundle.h
+++ b/Headers/Foundation/NSBundle.h
@@ -345,7 +345,7 @@ GS_EXPORT_CLASS
  */
 - (NSString*) localizedStringForKey: (NSString*)key
 			      value: (NSString*)value
-			      table: (NSString*)tableName;
+			      table: (NSString*)tableName NS_FORMAT_ARGUMENT(1);
 
 /** Returns the absolute path to the resources directory of the bundle.  */
 - (NSString*) resourcePath;

--- a/Headers/GNUstepBase/GSVersionMacros.h
+++ b/Headers/GNUstepBase/GSVersionMacros.h
@@ -423,7 +423,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
 #if defined(__clang__) || GS_GCC_MINREQ(4,2)
 #  define NS_FORMAT_ARGUMENT(A) __attribute__((format_arg(A)))
 #else
-#  define NS_FORMAT_ARGUMENT(F,A) 
+#  define NS_FORMAT_ARGUMENT(A)
 #endif
 #endif
 


### PR DESCRIPTION
Fixes warnings like the following when using a localized string as a format argument:
```c
[NSString stringWithFormat:NSLocalizedString(@"localized string")]

warning: format string is not a string literal (potentially insecure) [-Wformat-security]
```