### PR TITLE
Add required cast in case nil is not defined as id

### DIFF
--- a/Source/NSKeyedUnarchiver.m
+++ b/Source/NSKeyedUnarchiver.m
@@ -853,7 +853,7 @@ static NSMapTable	*globalClassMap = 0;
 	  // Add markers for unencoded objects.
 	  for (i = 1; i < count; i++)
 	    {
-	      GSIArrayAddItem(_objMap, (GSIArrayItem)nil);
+	      GSIArrayAddItem(_objMap, (GSIArrayItem)(id)nil);
 	    }
 	}
     }

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -1166,7 +1166,7 @@ static NSNotificationCenter *default_center = nil;
 	      /*
 	       * Now observers with a nil object.
 	       */
-	      n = GSIMapNodeForSimpleKey(m, (GSIMapKey)nil);
+	      n = GSIMapNodeForSimpleKey(m, (GSIMapKey)(id)nil);
 	      if (n != 0)
 		{
 	          o = purgeCollectedFromMapNode(m, n);


### PR DESCRIPTION
On Apple platforms, `nil` is defined as `NULL`, whereas libobjc2 defines it as `(id)((void*)0)`.

I’ve created https://github.com/gnustep/libobjc2/pull/212 to have libobjc2 match Apple’s implementation, but this results in errors when building libs-base because the GSUNION for GSIArrayItem doesn’t contain an entry for `void*`. This change adds the required cast in libs-base, which doesn’t hurt if it’s already present in the runtime.