### PR TITLE
Restrict NS_FORMAT_ARGUMENT() to Clang.

### DIFF
--- a/Headers/GNUstepBase/GSVersionMacros.h
+++ b/Headers/GNUstepBase/GSVersionMacros.h
@@ -420,7 +420,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
  */
 
 #ifndef NS_FORMAT_ARGUMENT
-#if defined(__clang__) || GS_GCC_MINREQ(4,2)
+#if defined(__clang__)
 #  define NS_FORMAT_ARGUMENT(A) __attribute__((format_arg(A)))
 #else
 #  define NS_FORMAT_ARGUMENT(A)


### PR DESCRIPTION
The macro causes the following warning even with recent GCC versions:
`'format_arg' attribute directive ignored [-Wattributes]`

This disables the macro with GCC as discussed on the mailing list.