### PR TITLE
Default to UTF-8 when reading localized string files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-12-14 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSBundle.m:
+	Default to UTF-8 when reading localized string files without BOM.
+
 2021-12-07 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/GSTLS.m: (-disconnect:) try once if we are closing the TCP

--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -3025,7 +3025,7 @@ GSPrivateICUCStringEncoding()
   if (icuEnc == GSUndefinedEncoding)
     {
       const char        *encoding = 0;
-#if HAVE_UNICODE_UCNV_H
+#if defined(HAVE_UNICODE_UCNV_H) || defined(HAVE_ICU_H)
       const char *defaultName;
       UErrorCode err = U_ZERO_ERROR;
 

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -2639,10 +2639,10 @@ IF_NO_GC(
           bytes = [tableData bytes];
           length = [tableData length];
           /*
-           * A localisation file can be ...
-           * UTF16 with a leading BOM,
-           * UTF8 with a leading BOM,
-           * or ASCII (the original standard) with \U escapes.
+           * A localisation file can be:
+           * - UTF-16 with a leading BOM,
+           * - UTF-8,
+           * - or ASCII with \U escapes.
            */
           if (length > 2
               && ((bytes[0] == 0xFF && bytes[1] == 0xFE)
@@ -2650,30 +2650,25 @@ IF_NO_GC(
             {
               encoding = NSUnicodeStringEncoding;
             }
-          else if (length > 2
-                   && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+          else
             {
               encoding = NSUTF8StringEncoding;
             }
-          else
-            {
-              encoding = NSASCIIStringEncoding;
-            }
           tableContent = [[NSString alloc] initWithData: tableData
                                            encoding: encoding];
-          if (tableContent == nil && encoding == NSASCIIStringEncoding)
+          if (tableContent == nil && encoding == NSUTF8StringEncoding)
             {
               encoding = [NSString defaultCStringEncoding];
               tableContent = [[NSString alloc] initWithData: tableData
                                                encoding: encoding];
               if (tableContent != nil)
                 {
-                  NSWarnMLog (@"Localisation file %@ not in portable encoding"
-		    @" so I'm using the default encoding for the current"
-		    @" system, which may not display messages correctly.\n"
-		    @"The file should be ASCII (using \\U escapes for unicode"
-		    @" characters) or Unicode (UTF16 or UTF8) with a leading "
-		    @"byte-order-marker.\n", tablePath);
+                  NSWarnMLog (@"Localisation file %@ not in portable encoding,"
+                    @" so I'm using the default encoding for the current"
+                    @" system, which may not display messages correctly.\n"
+                    @"The file should be UTF-8, UTF-16 with a leading"
+                    @" byte-order-marker, or ASCII (using \\U escapes for"
+                    @" unicode characters.\n", tablePath);
                 }
             }
           if (tableContent == nil)

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -740,7 +740,7 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
   return NULL;
 }
 
-#if defined(HAVE_UNICODE_UNORM2_H)
+#if defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H)
 - (NSString *) _normalizedICUStringOfType: (const char*)normalization
                                      mode: (UNormalization2Mode)mode
 {
@@ -1856,7 +1856,7 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
 
 - (NSString *) decomposedStringWithCompatibilityMapping
 {
-#if (GS_USE_ICU == 1) && defined(HAVE_UNICODE_UNORM2_H)
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
   return [self _normalizedICUStringOfType: "nfkc" mode: UNORM2_DECOMPOSE];
 #else
   return [self notImplemented: _cmd];
@@ -1865,7 +1865,7 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
 
 - (NSString *) decomposedStringWithCanonicalMapping
 {
-#if (GS_USE_ICU == 1) && defined(HAVE_UNICODE_UNORM2_H)
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
   return [self _normalizedICUStringOfType: "nfc" mode: UNORM2_DECOMPOSE];
 #else
   return [self notImplemented: _cmd];
@@ -4492,7 +4492,7 @@ static NSFileManager *fm = nil;
 
 - (NSString *) precomposedStringWithCompatibilityMapping
 {
-#if (GS_USE_ICU == 1) && defined(HAVE_UNICODE_UNORM2_H)
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
   return [self _normalizedICUStringOfType: "nfkc" mode: UNORM2_COMPOSE];
 #else
   return [self notImplemented: _cmd];
@@ -4501,7 +4501,7 @@ static NSFileManager *fm = nil;
  
 - (NSString *) precomposedStringWithCanonicalMapping
 {
-#if (GS_USE_ICU == 1) && defined(HAVE_UNICODE_UNORM2_H)
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
    return [self _normalizedICUStringOfType: "nfc" mode: UNORM2_COMPOSE];
 #else
   return [self notImplemented: _cmd];


### PR DESCRIPTION
Background: We usually use Xcode to edit our Localizable.strings files for all platforms, which defaults to writing them in UTF-8. Currently when launching our app we get a warning about "Localisation file ... not in portable encoding" for every strings file being loaded. Unfortunately we cannot fix this by adding a BOM marker, as Xcode will reliably delete it on every change.

I’m not sure what "the original standard" in the comment in NSBundle.m refers to exactly, but it seems to me that defaulting to ASCII might no longer be the best choice (the [original commit](https://github.com/gnustep/libs-base/commit/9526fb065f59463b2856c03dbe612fffb2990ad7) that introduced this logic is 13 years old). With this change we now always use `[NSString defaultCStringEncoding]` when reading strings files, unless the files has a BOM marker.

I’m not sure what the default encoding works out to be on different platforms, but since both ISO Latin 1 (the hardcoded fallback in Unicode.m) and UTF-8 can be seen as extensions of ASCII I am hoping that this change would not cause any issues with existing strings files.

The other commit here just fixes some code paths when using the Windows-bundled ICU installation.