### PR TITLE
Fix handling of concurrent NSOperations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-12-21 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSOperation.m: fix handling of concurrent NSOperations
+	if isFinished KVO is triggered without the operation being finished,
+	and call completion block for concurrent operations. Also fixes
+	removing dependency observers more than once.
+
 2021-12-14 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSBundle.m:


### PR DESCRIPTION
- Concurrent operations never called the completion block.
- In the "isFinished", the observer code in both NSOperation and NSOperationQueue assumed that isFinished was YES when the KVO notification was triggered, but this doesn’t have to be the case.
- The "isFinished" observer for a dependency was removed both when the notification triggered and when the dependency was removed. This assumes an implementation detail of our current KVO implementation, which doesn’t throw an exception if an observer is not actually registered (Apple platforms do). (We previously fixed the same issue for the operation itself in https://github.com/gnustep/libs-base/commit/ae10f58dc456a954d06ecc57376c8e77e9b243ae).

I also added tests for the first two issues (which [failed](https://github.com/gnustep/libs-base/runs/4593591523?check_suite_focus=true) without the changes).