### PR TITLE
Various improvements (mainly) for Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-01-15 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSPathUtilities.m:
+	Fix NSTemporaryDirectory() returning path with backslashes on
+	Windows.
+
 2022-01-13 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSTimeZone.m:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-01-13 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSTimeZone.m:
+	Fix time zone lookup on Windows MSVC by converting Windows timezone
+	name to IANA identifier.
+
 2022-01-04 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSOperation.m:

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -233,11 +233,7 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
 {
   NSFileManager	*mgr = [NSFileManager defaultManager];
   NSDictionary	*att;
-#if defined(_WIN32)
-  const unichar	*thePath = 0;
-#else
-  const char	*thePath = 0;
-#endif
+  const GSNativeChar	*thePath = 0;
   FILE		*theFile = 0;
   void		*tmp = 0;
   int		c;
@@ -277,11 +273,7 @@ readContentsOfFile(NSString *path, void **buf, off_t *len, NSZone *zone)
     }
 #endif /* __ANDROID__ */
 
-#if defined(_WIN32)
-  thePath = (const unichar*)[path fileSystemRepresentation];
-#else
   thePath = [path fileSystemRepresentation];
-#endif
   if (thePath == 0)
     {
       NSWarnFLog(@"Open (%@) attempt failed - bad path", path);
@@ -1743,8 +1735,8 @@ failure:
 {
 #if defined(_WIN32)
   NSUInteger	length = [path length];
-  unichar	wthePath[length + 100];
-  unichar	wtheRealPath[length + 100];
+  GSNativeChar	wthePath[length + 100];
+  GSNativeChar	wtheRealPath[length + 100];
   int		c;
   FILE		*theFile;
   BOOL		useAuxiliaryFile = NO;
@@ -1858,7 +1850,7 @@ failure:
 	/* Windows 9x does not support MoveFileEx */
       else if (GetLastError() == ERROR_CALL_NOT_IMPLEMENTED)
 	{
-	  unichar	secondaryFile[length + 100];
+	  GSNativeChar	secondaryFile[length + 100];
 
 	  wcscpy(secondaryFile, wthePath);
 	  wcscat(secondaryFile, L"-delete");
@@ -3623,11 +3615,7 @@ getBytes(void* dst, void* src, unsigned len, unsigned limit, unsigned *pos)
   off_t		off;
   int		fd;
 
-#if defined(_WIN32)
-  const unichar	*thePath = (const unichar*)[path fileSystemRepresentation];
-#else
-  const char	*thePath = [path fileSystemRepresentation];
-#endif
+  const GSNativeChar	*thePath = [path fileSystemRepresentation];
 
   if (thePath == 0)
     {

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -237,9 +237,6 @@
 
 #endif
 
-#define	_CHAR		GSNativeChar
-#define	_CCP		const _CHAR*
-
 
 
 
@@ -252,7 +249,7 @@
 {
 @public
   struct _STATB	statbuf;
-  _CHAR		_path[0];
+  GSNativeChar	_path[0];
 }
 + (NSDictionary*) attributesAt: (NSString *)path
 		  traverseLink: (BOOL)traverse;
@@ -382,7 +379,7 @@ static NSStringEncoding	defaultEncoding;
 - (BOOL) changeCurrentDirectoryPath: (NSString*)path
 {
   static Class	bundleClass = 0;
-  const _CHAR	*lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar	*lpath = [self fileSystemRepresentationWithPath: path];
 
   /*
    * On some systems the only way NSBundle can determine the path to the
@@ -410,7 +407,7 @@ static NSStringEncoding	defaultEncoding;
 - (BOOL) changeFileAttributes: (NSDictionary*)attributes atPath: (NSString*)path
 {
   NSDictionary  *old;
-  const _CHAR	*lpath = 0;
+  const GSNativeChar	*lpath = 0;
   NSUInteger	num;
   NSString	*str;
   NSDate	*date;
@@ -571,7 +568,7 @@ static NSStringEncoding	defaultEncoding;
     {
       BOOL		ok = NO;
       struct _STATB	sb;
-      const _CHAR *lpath;
+      const GSNativeChar *lpath;
 
       lpath = [self fileSystemRepresentationWithPath: path];
       if (_STAT(lpath, &sb) != 0)
@@ -1058,7 +1055,7 @@ static NSStringEncoding	defaultEncoding;
     }
   else
     {
-      const _CHAR   *lpath;
+      const GSNativeChar   *lpath;
       lpath = [self fileSystemRepresentationWithPath: path];
 #if defined(_WIN32)
       isDir = (CreateDirectoryW(lpath, 0) != FALSE) ? YES : NO;
@@ -1115,13 +1112,12 @@ static NSStringEncoding	defaultEncoding;
 		 contents: (NSData*)contents
 	       attributes: (NSDictionary*)attributes
 {
+  const GSNativeChar	*lpath;
 #if	defined(_WIN32)
-  const _CHAR	*lpath = [self fileSystemRepresentationWithPath: path];
   HANDLE fh;
   DWORD	written = 0;
   DWORD	len = [contents length];
 #else
-  const _CHAR	*lpath;
   int	fd;
   int	len;
   int	written;
@@ -1133,6 +1129,8 @@ static NSStringEncoding	defaultEncoding;
       ASSIGN(_lastError, @"no path given");
       return NO;
     }
+
+  lpath = [self fileSystemRepresentationWithPath: path];
 
 #if	defined(_WIN32)
   fh = CreateFileW(lpath, GENERIC_WRITE, 0, 0, CREATE_ALWAYS,
@@ -1156,8 +1154,6 @@ static NSStringEncoding	defaultEncoding;
       return YES;
     }
 #else
-  lpath = [self fileSystemRepresentationWithPath: path];
-
   fd = open(lpath, GSBINIO|O_WRONLY|O_TRUNC|O_CREAT, 0644);
   if (fd < 0)
     {
@@ -1214,7 +1210,8 @@ static NSStringEncoding	defaultEncoding;
   int len = GetCurrentDirectoryW(0, 0);
   if (len > 0)
     {
-      _CHAR *lpath = (_CHAR*)calloc(len+10,sizeof(_CHAR));
+      GSNativeChar *lpath = (GSNativeChar*)calloc(len + 10,
+        sizeof(GSNativeChar));
 
       if (lpath != 0)
 	{
@@ -1233,7 +1230,7 @@ static NSStringEncoding	defaultEncoding;
 	}
     }
 #else
-  _CHAR path[PATH_MAX];
+  GSNativeChar path[PATH_MAX];
 #ifdef HAVE_GETCWD
   if (getcwd(path, PATH_MAX-1) == 0)
     return nil;
@@ -1396,8 +1393,8 @@ static NSStringEncoding	defaultEncoding;
   NSString	*destinationParent;
   unsigned int	sourceDevice;
   unsigned int	destinationDevice;
-  const _CHAR	*sourcePath;
-  const _CHAR	*destPath;
+  const GSNativeChar	*sourcePath;
+  const GSNativeChar	*destPath;
 
   sourcePath = [self fileSystemRepresentationWithPath: source];
   destPath = [self fileSystemRepresentationWithPath: destination];
@@ -1606,7 +1603,7 @@ static NSStringEncoding	defaultEncoding;
 		  handler: handler
 {
   BOOL		is_dir;
-  const _CHAR	*lpath;
+  const GSNativeChar	*lpath;
 
   if ([path isEqualToString: @"."] || [path isEqualToString: @".."])
     {
@@ -1761,7 +1758,7 @@ static NSStringEncoding	defaultEncoding;
 
 - (BOOL) fileExistsAtPath: (NSString*)path isDirectory: (BOOL*)isDirectory
 {
-  const _CHAR *lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar *lpath = [self fileSystemRepresentationWithPath: path];
 
   if (isDirectory != 0)
     {
@@ -1844,7 +1841,7 @@ static NSStringEncoding	defaultEncoding;
  */
 - (BOOL) isReadableFileAtPath: (NSString*)path
 {
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
 
   if (lpath == 0 || *lpath == _NUL)
     {
@@ -1901,7 +1898,7 @@ static NSStringEncoding	defaultEncoding;
  */
 - (BOOL) isWritableFileAtPath: (NSString*)path
 {
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
 
   if (lpath == 0 || *lpath == _NUL)
     {
@@ -1943,7 +1940,7 @@ static NSStringEncoding	defaultEncoding;
  */
 - (BOOL) isExecutableFileAtPath: (NSString*)path
 {
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
 
   if (lpath == 0 || *lpath == _NUL)
     {
@@ -2002,7 +1999,7 @@ static NSStringEncoding	defaultEncoding;
  */
 - (BOOL) isDeletableFileAtPath: (NSString*)path
 {
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
 
   if (lpath == 0 || *lpath == _NUL)
     {
@@ -2230,8 +2227,8 @@ static NSStringEncoding	defaultEncoding;
   DWORD SectorsPerCluster, BytesPerSector, NumberFreeClusters;
   DWORD TotalNumberClusters;
   DWORD volumeSerialNumber = 0;
-  const _CHAR *lpath = [self fileSystemRepresentationWithPath: path];
-  _CHAR volumePathName[128];
+  const GSNativeChar *lpath = [self fileSystemRepresentationWithPath: path];
+  GSNativeChar volumePathName[128];
 
   if (!GetVolumePathNameW(lpath, volumePathName, 128))
     {
@@ -2280,7 +2277,7 @@ static NSStringEncoding	defaultEncoding;
 #endif
   unsigned long long totalsize, freesize;
   unsigned long blocksize;
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
 
   id  values[5];
   id	keys[5] = {
@@ -2487,8 +2484,11 @@ static NSStringEncoding	defaultEncoding;
 		      pathContent: (NSString*)otherPath
 {
 #ifdef HAVE_SYMLINK
-  const _CHAR* newpath = [self fileSystemRepresentationWithPath: path];
-  const _CHAR* oldpath = [self fileSystemRepresentationWithPath: otherPath];
+  const GSNativeChar* oldpath;
+  const GSNativeChar* newpath;
+
+  newpath = [self fileSystemRepresentationWithPath: path];
+  oldpath = [self fileSystemRepresentationWithPath: otherPath];
 
   return (symlink(oldpath, newpath) == 0);
 #else
@@ -2505,7 +2505,7 @@ static NSStringEncoding	defaultEncoding;
 {
 #ifdef HAVE_READLINK
   char  buf[PATH_MAX];
-  const _CHAR* lpath = [self fileSystemRepresentationWithPath: path];
+  const GSNativeChar* lpath = [self fileSystemRepresentationWithPath: path];
   int   llen = readlink(lpath, buf, PATH_MAX-1);
 
   if (llen > 0)
@@ -2630,7 +2630,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
     //TODO: the justContents flag is currently basically useless and should be
     //      removed
       _DIR		*dir_pointer;
-      const _CHAR	*localPath;
+      const GSNativeChar	*localPath;
 
       _mgr = RETAIN(mgr);
       _stack = NSZoneMalloc([self zone], sizeof(GSIArray_t));
@@ -2779,7 +2779,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
     {
       GSEnumeratedDirectory dir = GSIArrayLastItem(_stack).ext;
       struct _STATB	statbuf;
-      const _CHAR *dirname = NULL;
+      const GSNativeChar *dirname = NULL;
 
 #ifdef __ANDROID__
       if (dir.assetDir)
@@ -3588,10 +3588,12 @@ static NSSet	*fileKeys = nil;
   GSAttrDictionary	*d;
   unsigned		l = 0;
   unsigned		i;
-  const _CHAR *lpath = [defaultManager fileSystemRepresentationWithPath: path];
+  const GSNativeChar *lpath;
 #ifdef __ANDROID__
   AAsset *asset = NULL;
 #endif
+
+  lpath = [defaultManager fileSystemRepresentationWithPath: path];
 
   if (lpath == 0 || *lpath == 0)
     {
@@ -3601,7 +3603,7 @@ static NSSet	*fileKeys = nil;
     {
       l++;
     }
-  d = (GSAttrDictionary*)NSAllocateObject(self, (l+1)*sizeof(_CHAR),
+  d = (GSAttrDictionary*)NSAllocateObject(self, (l+1)*sizeof(GSNativeChar),
     NSDefaultMallocZone());
 
 #if defined(S_IFLNK) && !defined(_WIN32)
@@ -3726,8 +3728,8 @@ static NSSet	*fileKeys = nil;
   DWORD		returnCode = 0;
   PSID		sidOwner;
   int		result = TRUE;
-  _CHAR		account[BUFSIZ];
-  _CHAR		domain[BUFSIZ];
+  GSNativeChar		account[BUFSIZ];
+  GSNativeChar		domain[BUFSIZ];
   DWORD		accountSize = 1024;
   DWORD		domainSize = 1024;
   SID_NAME_USE	eUse = SidTypeUnknown;
@@ -3893,8 +3895,8 @@ static NSSet	*fileKeys = nil;
   DWORD		returnCode = 0;
   PSID		sidOwner;
   int		result = TRUE;
-  _CHAR		account[BUFSIZ];
-  _CHAR		domain[BUFSIZ];
+  GSNativeChar		account[BUFSIZ];
+  GSNativeChar		domain[BUFSIZ];
   DWORD		accountSize = 1024;
   DWORD		domainSize = 1024;
   SID_NAME_USE	eUse = SidTypeUnknown;
@@ -4023,7 +4025,7 @@ static NSSet	*fileKeys = nil;
 {
 #if defined(_WIN32)
   DWORD volumeSerialNumber = 0;
-  _CHAR volumePathName[128];
+  GSNativeChar volumePathName[128];
   if (GetVolumePathNameW(_path,volumePathName,128))
   {
     GetVolumeInformationW(volumePathName,NULL,0,&volumeSerialNumber,NULL,NULL,NULL,0);

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -1162,8 +1162,8 @@ static void InitialisePathUtilities(void)
 	  char	dummy[1024];
 	} s;
 	LPTSTR	str;
-	unichar buf[1024];
-	unichar dom[1024];
+	GSNativeChar buf[1024];
+	GSNativeChar dom[1024];
 	SID_NAME_USE use;
 	DWORD bsize = 1024;
 	DWORD ssize = 1024;
@@ -1650,7 +1650,7 @@ NSUserName(void)
       else
 	{
 	  /* The GetUserName function returns the current user name */
-	  unichar buf[1024];
+	  GSNativeChar buf[1024];
 	  DWORD n = 1024;
 
 	  if (GetUserNameW(buf, &n) != 0 && buf[0] != '\0')
@@ -1829,8 +1829,9 @@ NSFullUserName(void)
 #if defined(_WIN32)
       struct _USER_INFO_2	*userInfo;
 
-      if (NetUserGetInfo(NULL, (unichar*)[userName cStringUsingEncoding:
-	NSUnicodeStringEncoding], 2, (LPBYTE*)&userInfo) == 0)
+      if (NetUserGetInfo(NULL, (const GSNativeChar*)[userName
+        cStringUsingEncoding: NSUnicodeStringEncoding], 2,
+        (LPBYTE*)&userInfo) == 0)
 	{
 	  int	length = wcslen(userInfo->usri2_full_name);
 
@@ -1957,7 +1958,7 @@ NSTemporaryDirectory(void)
 #endif
 
 #if defined(_WIN32)
-  unichar buffer[1024];
+  GSNativeChar buffer[1024];
   if (GetTempPathW(1024, buffer))
     {
       baseTempDirName = [NSString stringWithCharacters: buffer

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -1962,6 +1962,9 @@ NSTemporaryDirectory(void)
     {
       baseTempDirName = [NSString stringWithCharacters: buffer
 						length: wcslen(buffer)];
+      // convert path to use forward slashes, which we use internally
+      baseTempDirName = [baseTempDirName stringByReplacingString: @"\\"
+        withString: @"/"];
     }
 #elif defined(__ANDROID__)
   /*

--- a/Source/win32/GSFileHandle.m
+++ b/Source/win32/GSFileHandle.m
@@ -984,7 +984,7 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 - (id) initForReadingAtPath: (NSString*)path
 {
   int	d = _wopen(
-    (unichar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
+    (const GSNativeChar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
     O_RDONLY|O_BINARY);
 
   if (d < 0)
@@ -1008,7 +1008,7 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 - (id) initForWritingAtPath: (NSString*)path
 {
   int	d = _wopen(
-    (unichar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
+    (const GSNativeChar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
     O_WRONLY|O_BINARY);
 
   if (d < 0)
@@ -1032,7 +1032,7 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 - (id) initForUpdatingAtPath: (NSString*)path
 {
   int	d = _wopen(
-    (unichar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
+    (const GSNativeChar*)[path cStringUsingEncoding: NSUnicodeStringEncoding],
     O_RDWR|O_BINARY);
 
   if (d < 0)


### PR DESCRIPTION
This comprise a couple of improvements mainly targeting Windows:

- Fix NSTimeZone lookup on Windows MSVC, by converting the Windows time zone names to IANA names used in the NSTimeZone resources ([more info](https://devblogs.microsoft.com/oldnewthing/20210527-00/?p=105255)).
- Fix `NSTemporaryDirectory()` returning a path with backslashes on Windows, even though we use forward slashes for all internal path handling (with -fileSystemRepresentation converting forward to backward slashes to pass paths to system APIs).
- Non-functional: use `GSNativeChar` in various places handling paths instead of #ifdefs and `unichar` (which is defined as `uint16_t` like `GSNativeChar`).