### PR TITLE
use handle from the cache only if the caller asked

### DIFF
--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -1577,7 +1577,7 @@ static NSUInteger	urlAlign;
 - (void) loadResourceDataNotifyingClient: (id)client
 			      usingCache: (BOOL)shouldUseCache
 {
-  NSURLHandle	*handle = [self URLHandleUsingCache: YES];
+  NSURLHandle	*handle = [self URLHandleUsingCache: shouldUseCache];
   NSData	*d;
 
   if (shouldUseCache == YES && (d = [handle availableResourceData]) != nil)


### PR DESCRIPTION
The method description of **-[NSURL loadResourceDataNotifyingClient: (id)client   usingCache:(BOOL)shouldUseCache  ]** states:

_If **shouldUseCache** is YES then an attempt will be made to locate a cached NSURLHandle to provide the resource data, otherwise a new handle will be created and cached._

The current implementation doesn't follow that and always use the handle from the cache regardless of the **shouldUseCache**.
It is the source of the following bug in Grr [https://savannah.nongnu.org/bugs/index.php?56712](url). 

If the user subscribed to several feeds from the same site (e.g. yotube channels) the action "Fetch all" calls the -**[NSURL loadResourceDataNotifyingClient: usingCache: NO ]** consequently.  The libs-base disregards the **usingCache** and uses the same cached handle for those feed URLs ('siblings', with the same tuple schema/host/port but different path/query parts). These URLs are registered as clients in the internal NSURLHandle' registry and therefore all of them receive data in **-[NSURLHandle didLoadBytes:loadComplete:]**. That is a feed is populated by "foreign" articles from another feed.