### PR TITLE
Fix some checks when using ICU DLL from Windows 10

### DIFF
--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -447,7 +447,8 @@ do \
                           options: (NSUInteger) opts
 {
 #if GS_USE_ICU == 1 && (U_ICU_VERSION_MAJOR_NUM > 4 \
-  || (U_ICU_VERSION_MAJOR_NUM == 4 && U_ICU_VERSION_MINOR_NUM >= 8))
+  || (U_ICU_VERSION_MAJOR_NUM == 4 && U_ICU_VERSION_MINOR_NUM >= 8) \
+  || defined(HAVE_ICU_H))
 
   NSDateComponents *comps = nil;
   UErrorCode err = U_ZERO_ERROR;

--- a/Source/NSDateFormatter.m
+++ b/Source/NSDateFormatter.m
@@ -946,7 +946,7 @@ static NSDateFormatterBehavior _defaultBehavior = 0;
       pat = malloc(sizeof(UChar) * patLength);
       [self->_dateFormat getCharacters: pat];
     }
-#if U_ICU_VERSION_MAJOR_NUM >= 50
+#if U_ICU_VERSION_MAJOR_NUM >= 50 || defined(HAVE_ICU_H)
   timeStyle = pat ? UDAT_PATTERN : NSToUDateFormatStyle (internal->_timeStyle);
   dateStyle = pat ? UDAT_PATTERN : NSToUDateFormatStyle (internal->_dateStyle);
 #else

--- a/Source/NSRegularExpression.m
+++ b/Source/NSRegularExpression.m
@@ -38,7 +38,7 @@
  * won't work because libicu internally renames all entry points with some cpp
  * magic.
  */
-#if (U_ICU_VERSION_MAJOR_NUM > 4 || (U_ICU_VERSION_MAJOR_NUM == 4 && U_ICU_VERSION_MINOR_NUM >= 4))
+#if U_ICU_VERSION_MAJOR_NUM > 4 || (U_ICU_VERSION_MAJOR_NUM == 4 && U_ICU_VERSION_MINOR_NUM >= 4) || defined(HAVE_ICU_H)
 #define HAVE_UREGEX_OPENUTEXT 1
 #endif
 


### PR DESCRIPTION
[`icu.h` from Windows 10](https://docs.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-) doesn’t define `U_ICU_VERSION_MAJOR_NUM`, but is a recent ICU version providing various functionality we need.