### PR TITLE
Add userInfo accessor to NSProgress

### DIFF
--- a/Headers/Foundation/NSProgress.h
+++ b/Headers/Foundation/NSProgress.h
@@ -118,6 +118,7 @@ GS_NSProgress_IVARS;
 - (void) setKind: (NSProgressKind)k;
 - (void) setUserInfoObject: (id)obj
                     forKey: (NSProgressUserInfoKey)key;
+- (GS_GENERIC_CLASS(NSDictionary,NSProgressUserInfoKey,id) *)userInfo;
 
 // Instance property accessors...
 - (void) setFileOperationKind: (NSProgressFileOperationKind)k;

--- a/Source/NSProgress.m
+++ b/Source/NSProgress.m
@@ -116,7 +116,6 @@ static NSMutableDictionary *__subscribers = nil;
 
 - (void) dealloc
 {
-  RELEASE(internal->_userInfo);
   RELEASE(internal->_fileOperationKind);
   RELEASE(internal->_kind);
   RELEASE(internal->_estimatedTimeRemaining);
@@ -343,6 +342,11 @@ static NSMutableDictionary *__subscribers = nil;
                    forKey: (NSProgressUserInfoKey)key
 {
   [internal->_userInfo setObject: obj forKey: key];
+}
+
+- (GS_GENERIC_CLASS(NSDictionary,NSProgressUserInfoKey,id) *)userInfo
+{
+  return AUTORELEASE([internal->_userInfo copy]);
 }
 
 // Instance property accessors...

--- a/Tests/base/NSProgress/basic.m
+++ b/Tests/base/NSProgress/basic.m
@@ -6,10 +6,16 @@
 int main()
 {
   NSAutoreleasePool     *arp = [NSAutoreleasePool new];
-  NSDictionary *dict = [NSDictionary dictionary];
+  NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+  [dict setObject:@"value" forKey:@"key"];
   NSProgress *progress = [[NSProgress alloc] initWithParent: nil
                                                    userInfo: dict];
   PASS(progress != nil, "[NSProgress initWithParent:userInfo:] returns instance");
+  
+  PASS_EQUAL([progress userInfo], dict, @"[NSProgress userInfo] returns correct user info");
+  
+  [progress setUserInfoObject:@"new value" forKey:@"key"];
+  PASS_EQUAL([[progress userInfo] objectForKey:@"key"], @"new value", @"[NSProgress setUserInfoObject:forKey:] updates user info");
   
   progress = [NSProgress discreteProgressWithTotalUnitCount:100];
   PASS(progress != nil, "[NSProgress discreteProgressWithTotalUnitCount:] returns instance");


### PR DESCRIPTION
Matches Apple implementation.

Also removes duplicate release of `_userInfo` in dealloc, and extends NSProgress test to check user info.