### PR TITLE
GSTLS, NSData, NSString Unit Test Fixes on Windows MSVC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,9 +4,6 @@
 	Disable test completly if gnutls is not present.
 	* Tests/base/NSData/additions.m:
 	Check if dataWithContentsOfFile: returns an instance.
-	* Tests/base/NSProgress/basic.m:
-	Replace Objective-C strings with cstrings in PASS_EQUAL macros
-	and fix UserInfo test case.
 	* Tests/base/NSString/tilde.m:
 	Skip tilde abbreviation test on Windows.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,17 @@
 2022-08-04 Hugo Melder <contact@hugomelder.com>
 
+	* Tests/base/GSTLS/basic.m:
+	Disable test completly if gnutls is not present.
+	* Tests/base/NSData/additions.m:
+	Check if dataWithContentsOfFile: returns an instance.
+	* Tests/base/NSProgress/basic.m:
+	Replace Objective-C strings with cstrings in PASS_EQUAL macros
+	and fix UserInfo test case.
+	* Tests/base/NSString/tilde.m:
+	Skip tilde abbreviation test on Windows.
+
+2022-08-04 Hugo Melder <contact@hugomelder.com>
+
 	* Tests/base/coding/basictypes.m:
 	Fetch the generated .type file directly to avoid size mismatches.
 	* .gitignore:

--- a/Tests/base/GSTLS/basic.m
+++ b/Tests/base/GSTLS/basic.m
@@ -36,16 +36,15 @@ START_SET("TLS support")
 #endif
   [dateFormatter release];
   PASS_EQUAL([c expiresAt], expiresAt,
-    "Expiration for entire list is that of the single item")
-#else
-  SKIP("TLS support disabled");
-#endif
-
+    "Expiration for entire list is that of the single item");
   
   cred = [GSTLSCredentials selfSigned: YES];
   NSLog(@"%@", cred);
   PASS(cred != nil, "generates self signed certificate");
-
+#else
+  SKIP("TLS support disabled");
+#endif
+  
   END_SET("TLS support");
   DESTROY(arp);
   return 0;

--- a/Tests/base/NSData/additions.m
+++ b/Tests/base/NSData/additions.m
@@ -15,6 +15,7 @@ int main()
   NSUInteger    length;
 
   ref = [NSData dataWithContentsOfFile: @"Lorum"];
+  PASS(ref != nil, "dataWithContentsOfFile: is not nil");
   PASS(NO == [ref isGzipped], "Reference data is not gzipped");
 
   data = [ref gzipped: 0];

--- a/Tests/base/NSData/additions.m
+++ b/Tests/base/NSData/additions.m
@@ -8,6 +8,8 @@
 int main()
 {
   NSAutoreleasePool   *arp = [NSAutoreleasePool new];
+  
+  START_SET("NSData Additions")
 #if USE_ZLIB
   NSData        *data;
   NSData        *ref;
@@ -15,7 +17,6 @@ int main()
   NSUInteger    length;
 
   ref = [NSData dataWithContentsOfFile: @"Lorum"];
-  PASS(ref != nil, "dataWithContentsOfFile: is not nil");
   PASS(NO == [ref isGzipped], "Reference data is not gzipped");
 
   data = [ref gzipped: 0];
@@ -68,6 +69,7 @@ int main()
 #else
   SKIP("zlib support disabled");
 #endif
+  END_SET("NSData Additions")
 
   [arp release]; arp = nil;
   return 0;

--- a/Tests/base/NSProgress/basic.m
+++ b/Tests/base/NSProgress/basic.m
@@ -12,10 +12,10 @@ int main()
                                                    userInfo: dict];
   PASS(progress != nil, "[NSProgress initWithParent:userInfo:] returns instance");
   
-  PASS_EQUAL([progress userInfo], dict, @"[NSProgress userInfo] returns correct user info");
+  PASS_EQUAL([progress userInfo], dict, "[NSProgress userInfo] returns correct user info");
   
   [progress setUserInfoObject:@"new value" forKey:@"key"];
-  PASS_EQUAL([[progress userInfo] objectForKey:@"key"], @"new value", @"[NSProgress setUserInfoObject:forKey:] updates user info");
+  PASS_EQUAL([[progress userInfo] objectForKey:@"key"], "new value", "[NSProgress setUserInfoObject:forKey:] updates user info");
   
   progress = [NSProgress discreteProgressWithTotalUnitCount:100];
   PASS(progress != nil, "[NSProgress discreteProgressWithTotalUnitCount:] returns instance");

--- a/Tests/base/NSProgress/basic.m
+++ b/Tests/base/NSProgress/basic.m
@@ -15,7 +15,7 @@ int main()
   PASS_EQUAL([progress userInfo], dict, "[NSProgress userInfo] returns correct user info");
   
   [progress setUserInfoObject:@"new value" forKey:@"key"];
-  PASS_EQUAL([[progress userInfo] objectForKey:@"key"], "new value", "[NSProgress setUserInfoObject:forKey:] updates user info");
+  PASS_EQUAL([[[progress userInfo] objectForKey:@"key"] UTF8String], "new value", "[NSProgress setUserInfoObject:forKey:] updates user info");
   
   progress = [NSProgress discreteProgressWithTotalUnitCount:100];
   PASS(progress != nil, "[NSProgress discreteProgressWithTotalUnitCount:] returns instance");

--- a/Tests/base/NSString/tilde.m
+++ b/Tests/base/NSString/tilde.m
@@ -32,8 +32,10 @@ int main()
   PASS_EQUAL([tmp stringByAbbreviatingWithTildeInPath], @"~/Documents/./..",
     "dot directory reference retained");
 
-#ifndef	_WIN32
-  /* This test can't work on windows, because the ome directory of a
+#if defined(_WIN32)
+  SKIP("multiple slashes can't be removed on Windows")
+#else
+  /* This test can't work on windows, because the home directory of a
    * user doesn't start with a slash... don't run it on _WIN32
    */
   tmp = [NSString stringWithFormat: @"////%@//Documents///", home];
@@ -52,9 +54,12 @@ int main()
   END_SET("tilde")
 
   START_SET("tilde abbreviation for other home")
+
+#if defined(_WIN32)
+  SKIP("tilde abbreviation test not implemented on Windows")
+#else
   NSString      *home = NSHomeDirectory();
   NSString      *tmp;
-
   /* The idea here is to use a home directory for a user other than the
    * current one.  We pick root as a user which will exist on most systems.
    * If the current user is root then this will not work, so we skip the
@@ -71,6 +76,7 @@ int main()
     }
   PASS_EQUAL([tmp stringByAbbreviatingWithTildeInPath], tmp,
     "tilde does nothing for root's home");
+#endif
 
   END_SET("tilde abbreviation for other home")
   return 0;


### PR DESCRIPTION
- Fix GSTLS unit test
- NSData unit test
   - Check for nil in NSData
- NSString unit test
- Fix NSProgress unit test
   - Replace Objective-C string with cstring in PASS_EQUAL macros
   - Fix UserInfo check by retrieving UTF8String