### PR TITLE
Mark notANumber test case as hopeful

### DIFF
--- a/Tests/base/NSNumberFormatter/basic10_4.m
+++ b/Tests/base/NSNumberFormatter/basic10_4.m
@@ -52,9 +52,6 @@ int main()
     PASS(NSNumberFormatterBehaviorDefault == [fmt formatterBehavior],
      "a new formatter can have the default behavior set")
 
-    str = [fmt stringFromNumber: [NSDecimalNumber notANumber]];
-    PASS_EQUAL(str, @"NaN", "notANumber special case")
-
     START_SET("NSLocale")
       NSLocale  *sys;
       NSLocale  *en;

--- a/Tests/base/NSNumberFormatter/basic10_4.m
+++ b/Tests/base/NSNumberFormatter/basic10_4.m
@@ -52,6 +52,14 @@ int main()
     PASS(NSNumberFormatterBehaviorDefault == [fmt formatterBehavior],
      "a new formatter can have the default behavior set")
 
+    /* It is not guaranteed by ICU that UNUM_NAN_SYMBOL is "NaN".
+     * On Windows, NaN has a negative signum and returns "-NaN".
+     */
+    testHopeful = YES;
+    str = [fmt stringFromNumber: [NSDecimalNumber notANumber]];
+    PASS_EQUAL(str, @"NaN", "notANumber special case")
+    testHopeful = NO;
+
     START_SET("NSLocale")
       NSLocale  *sys;
       NSLocale  *en;


### PR DESCRIPTION
It is not guaranteed by ICU that UNUM_NAN_SYMBOL is "NaN". On Windows, NaN has a negative signum and returns "-NaN".