### PR TITLE
Replace make check with gnustep-tests in CI to avoid edge-cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,15 +212,9 @@ jobs:
         continue-on-error: ${{ matrix.allow-test-failures || false }}
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
-          # MSVC: build tests for release to match CRT of DLLs
-          if [ "$IS_WINDOWS" = "true" ]; then
-            cd ${{ env.SRC_PATH }}\Tests
-          else
-            cd ${{ env.SRC_PATH }}/Tests
-          fi
           # Run 'gnustep-tests' instead of 'make check' to avoid edge-cases
           # on MSVC
-          gnustep-tests .
+          gnustep-tests Tests
 
       - name: Upload logs
         uses: actions/upload-artifact@v2
@@ -229,4 +223,4 @@ jobs:
           name: Logs - ${{ matrix.name }}
           path: |
             ${{ env.SRC_PATH }}/config.log
-            ${{ env.SRC_PATH }}/Tests/tests.log
+            ${{ env.SRC_PATH }}/tests.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
       INSTALL_PATH: ${{ github.workspace }}${{ startsWith(matrix.os, 'windows') && '\' || '/' }}build
       IS_WINDOWS_MINGW: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.msystem, 'MINGW') }}
       IS_WINDOWS_MSVC: ${{ startsWith(matrix.os, 'windows') && endsWith(matrix.host, '-pc-windows') }}
+      IS_WINDOWS: ${{ startsWith(matrix.os, 'windows')}}
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
       LDFLAGS: ${{ matrix.LDFLAGS }}
@@ -211,9 +212,14 @@ jobs:
         continue-on-error: ${{ matrix.allow-test-failures || false }}
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          # MSVC: build tests for release to match CRT of DLLs
+          if [ "$IS_WINDOWS" = "true" ]; then
+            cd ${{ env.SRC_PATH }}\Tests
+          else
+            cd ${{ env.SRC_PATH }}/Tests
+          fi
           # Run 'gnustep-tests' instead of 'make check' to avoid edge-cases
           # on MSVC
-          cd ${{ env.SRC_PATH }}/Tests
           gnustep-tests .
 
       - name: Upload logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,11 +211,10 @@ jobs:
         continue-on-error: ${{ matrix.allow-test-failures || false }}
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
-          # MSVC: build tests for release to match CRT of DLLs
-          if [ "$IS_WINDOWS_MSVC" = "true" ]; then
-            sed -i -e 's/ debug=yes//g' `which gnustep-tests`
-          fi
-          make check
+          # Run 'gnustep-tests' instead of 'make check' to avoid edge-cases
+          # on MSVC
+          cd ${{ env.SRC_PATH }}/Tests
+          gnustep-tests .
 
       - name: Upload logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,7 @@ jobs:
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
           # Run 'gnustep-tests' instead of 'make check' to avoid edge-cases
           # on MSVC
-          gnustep-tests Tests
+          gnustep-tests --verbose Tests
 
       - name: Upload logs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Running 'make check' on Windows environments has some quirks:

- Tests randomly fail or crash
- Time zones are broken
- Configuration errors:  general.m 25 ... it looks like GNUstep-base is not yet installed

Running 'gnustep-tests' directly is more reliable and works as expected.