### PR TITLE
Fix NSPredicate test using GCC

### DIFF
--- a/Tests/base/NSPredicate/basic.m
+++ b/Tests/base/NSPredicate/basic.m
@@ -250,8 +250,10 @@ int main()
   p = [NSPredicate predicateWithFormat: @"sum(a) == 3"]; 
   PASS([p evaluateWithObject: a], "aggregate sum works");
 
-  p = [NSPredicate predicateWithFormat: @"self IN %@", @[@"yes"]];
-  a = [@[@"yes", @"no"] filteredArrayUsingPredicate: p];
+  p = [NSPredicate predicateWithFormat: @"self IN %@",
+    [NSArray arrayWithObject:@"yes"]];
+  a = [[NSArray arrayWithObjects:@"yes", @"no", nil]
+    filteredArrayUsingPredicate: p];
   PASS_EQUAL([a description], @"(yes)",
     "predicate created with format can filter an array")
 


### PR DESCRIPTION
Not sure why this didn’t cause a failure in recent builds, do failed builds not count as test failures?

```
--- Running tests in base/NSPredicate ---
Building basic
Building base/NSPredicate/basic.m
make debug=yes basic
Making all for test_tool basic...
 Compiling file basic.m ...
basic.m: In function ‘main’:
basic.m:253:56: error: stray ‘@’ in program
  253 |   p = [NSPredicate predicateWithFormat: @"self IN %@", @[@"yes"]];
      |                                                        ^
basic.m:253:59: error: expected ‘:’ before ‘]’ token
  253 |   p = [NSPredicate predicateWithFormat: @"self IN %@", @[@"yes"]];
      |                                                           ^    ~
      |                                                           :
basic.m:254:8: error: stray ‘@’ in program
  254 |   a = [@[@"yes", @"no"] filteredArrayUsingPredicate: p];
      |        ^
basic.m:254:16: warning: left-hand operand of comma expression has no effect [-Wunused-value]
  254 |   a = [@[@"yes", @"no"] filteredArrayUsingPredicate: p];
      |                ^
basic.m:254:19: error: expected ‘:’ before ‘]’ token
  254 |   a = [@[@"yes", @"no"] filteredArrayUsingPredicate: p];
      |                   ^   ~
      |                   :
make[5]: *** [/home/runner/work/libs-base/libs-base/build/share/GNUstep/Makefiles/rules.make:521: obj/basic.obj/basic.m.o] Error 1
make[4]: *** [/home/runner/work/libs-base/libs-base/build/share/GNUstep/Makefiles/Instance/tool.make:74: internal-tool-all_] Error 2
make[3]: *** [/home/runner/work/libs-base/libs-base/build/share/GNUstep/Makefiles/Master/rules.make:297: basic.all.test-tool.variables] Error 2
make[2]: *** [/home/runner/work/libs-base/libs-base/build/share/GNUstep/Makefiles/Master/test-tool.make:60: basic] Error 2
Failed build:     basic.m
```