### PR TITLE
fix missing links in generated documentation

### DIFF
--- a/Documentation/HtmlNav/index.html
+++ b/Documentation/HtmlNav/index.html
@@ -104,7 +104,7 @@ notice and this notice are preserved.
                <td><a href="Developer/Base/General/OpenStepCompliance.html">OpenStep and OS X Compliance</a></td>
              </tr>
              <tr>
-               <td><a href="Developer/CodingStandards/coding-standards_toc.html">GNUstep Coding Standards</a></td>
+               <td><a href="Developer/CodingStandards/gs-standards/Introduction.html">GNUstep Coding Standards</a></td>
                <td><a href="Developer/CodingStandards/gs-standards.pdf">(PDF)</a></td>
              </tr>
              <tr>

--- a/Documentation/coding-standards.texi
+++ b/Documentation/coding-standards.texi
@@ -51,7 +51,7 @@ Permission is granted to copy and distribute translations of this manual
 into another language, under the above conditions for modified versions.
 @end titlepage
 
-@node Top, Introduction, (dir), (dir)
+@node Top
 @top Coding Standards
 
 @menu
@@ -71,7 +71,7 @@ into another language, under the above conditions for modified versions.
 
 @c ******************************************************************
 @node Introduction, ChangeLog Entries, Top, Top
-@section Introduction
+@chapter Introduction
 
 This document explains the official coding standards which developers
 for GNUstep should follow. Note that these standards are in addition

--- a/Documentation/manual/WorkingWithObjects.texi
+++ b/Documentation/manual/WorkingWithObjects.texi
@@ -180,6 +180,8 @@ pools which provide a degree of automated memory management.  This gives
 a good degree of control over memory management, but requires some care
 in following simple rules.  It's pretty efficient.
 
+@end itemize
+
 The recommended approach is to use some standard macros defined in
 @code{NSObject.h} which encapsulate the retain/release/autorelease mechanism,
 but which permit efficient use of Automated reference Counts (ARC) if you build


### PR DESCRIPTION
The offline documentation is missing links to the manual and coding standards. 
This is due to errors in the texi files which prevent the make file to generate HTML versions and a broken link.