### PR TITLE
ICU specifies a NULL is passed for default locale

### DIFF
--- a/Source/NSLocale.m
+++ b/Source/NSLocale.m
@@ -536,7 +536,7 @@ static NSRecursiveLock *classLock = nil;
   if (nil == systemLocale)
     {
 #if	GS_USE_ICU == 1
-      systemLocale = [[NSLocale alloc] initWithLocaleIdentifier: @""];
+      systemLocale = [[NSLocale alloc] initWithLocaleIdentifier: nil];
 #endif
     }
 


### PR DESCRIPTION
From https://unicode-org.github.io/icu/userguide/locale/#locales-and-services:

"Using the ICU C functions, NULL can be passed for a locale parameter to specify the default locale."

On my systems, passing an empty string either results in the systemLocale being set to "en_US_POSIX" (when using ICU ver50.0), or an empty string (when using ICU ver67.0).

Passing 'nil' results in the system locale being read correctly. On Centos/7 and AlmaLinux9.0, this matches the value set for 'LANG' in the /etc/locale.conf file.

Thanks!