### PR TITLE
`[NSData initWithBase64EncodedString]`: Fix decoding of an empty string

### DIFF
--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -804,6 +804,13 @@ failure:
 	}
     }
   length = dst - result;
+
+  if (length == 0)
+    {
+      NSZoneFree(zone, result);
+      return [self initWithBytesNoCopy: 0 length: 0 freeWhenDone: YES];
+    }
+
   if (options & NSDataBase64DecodingIgnoreUnknownCharacters)
     {
       /* If the decoded length is a lot shorter than expected (because we

--- a/Tests/base/NSData/base64.m
+++ b/Tests/base/NSData/base64.m
@@ -127,6 +127,12 @@ int main()
   PASS_EQUAL(data, ref, "base64 decoding Yml0bWFya2V0cyB1c2VyIGluZGVudGl0eQ==")
   [data release];
 
+  data = [[NSData alloc] initWithBase64EncodedString: @"\n"
+    options: NSDataBase64DecodingIgnoreUnknownCharacters];
+  ref = [NSData dataWithBytes: "" length: 0];
+  PASS_EQUAL(data, ref, "base64 decoding empty string")
+  [data release];
+
   [arp release]; arp = nil;
   return 0;
 }


### PR DESCRIPTION
Don't call `NSZoneRealloc` with a length of 0, but free the zone and return an empty `NSData` buffer instead.

This pattern was observed when unarchiving Xib files.