### PR TITLE
NSOrderedSet: Fix keyed encoding to match Apple platforms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-05-04 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSOrderedSet.m: Fix keyed encoding to match Apple platforms.
+
 2023-05-04 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/GSFileHandle.m: Ignore notificaton that a descriptor is

--- a/Source/NSOrderedSet.m
+++ b/Source/NSOrderedSet.m
@@ -179,30 +179,17 @@ static SEL	remSel;
 {
    if ([aCoder allowsKeyedCoding])
     {
-      if ([aCoder class] == [NSKeyedArchiver class])
-	{
-          /* HACK ... MacOS-X seems to code differently if the coder is an
-           * actual instance of NSKeyedArchiver
-           */
-          NSArray *array = [self array];
-
-	  [(NSKeyedArchiver*)aCoder _encodeArrayOfObjects: array
-						   forKey: @"NS.objects"];
-	}
-      else
-	{
-	  unsigned	i = 0;
-	  NSEnumerator	*e = [self objectEnumerator];
-	  id		o;
-
-	  while ((o = [e nextObject]) != nil)
-	    {
-	      NSString	*key;
-
-	      key = [NSString stringWithFormat: @"NS.object.%u", i++];
-	      [(NSKeyedArchiver*)aCoder encodeObject: o forKey: key];
-	    }
-	}
+      unsigned	i = 0;
+      NSEnumerator	*e = [self objectEnumerator];
+      id		o;
+    
+      while ((o = [e nextObject]) != nil)
+        {
+          NSString	*key;
+    
+          key = [NSString stringWithFormat: @"NS.object.%u", i++];
+          [(NSKeyedArchiver*)aCoder encodeObject: o forKey: key];
+        }
     }
   else
     {
@@ -212,9 +199,9 @@ static SEL	remSel;
 
       [aCoder encodeValueOfObjCType: @encode(unsigned) at: &count];
       while ((o = [e nextObject]) != nil)
-	{
-	  [aCoder encodeValueOfObjCType: @encode(id) at: &o];
-	}
+        {
+          [aCoder encodeValueOfObjCType: @encode(id) at: &o];
+        }
     }
 }
 


### PR DESCRIPTION
We found that the code marked as follows does not match the actual behavior on macOS:

> HACK ... MacOS-X seems to code differently if the coder is an actual instance of NSKeyedArchiver

This seems to have been copy-pasted from the NSSet implementation, but does not apply to NSOrderedSet, making NSOrderedSet instances encoded with GNUstep incompatible with Apple platforms.