### PR TITLE
Fix runtime initialize config check on Windows

### DIFF
--- a/config/config.initialize.m
+++ b/config/config.initialize.m
@@ -66,7 +66,12 @@ static volatile BOOL		may_proceed = NO;
 
 @end
 
-static void *
+static
+#if defined(_WIN32)
+unsigned int __stdcall
+#else
+void *
+#endif
 test(void *arg)
 {
   [MyClass class];


### PR DESCRIPTION
Was failing due to:
```
In file included from conftest.c:97:
././config/config.initialize.m:83:25: error: incompatible function pointer types passing 'void *(void *)' to parameter of type '_beginthreadex_proc_type' (aka 'unsigned int (*)(void *)') [-Wincompatible-function-pointer-types]
  if (CREATE_THREAD(t1, test, 0))
                        ^~~~
././config/config.initialize.m:12:27: note: expanded from macro 'CREATE_THREAD'
  _beginthreadex(NULL, 0, start, arg, 0, &threadId) != 0
                          ^~~~~
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\process.h:99:40: note: passing argument to parameter '_StartAddress' here
    _In_      _beginthreadex_proc_type _StartAddress,
                                       ^
```

This was causing the following incorrect configure output building with libobjc2 on Windows:
```
configure: WARNING: Your ObjectiveC runtime does not support thread-safe class initialisation.  Please use a different runtime if you intend to use threads.
checking for thread-safe +initialize in runtime... no
```

We do the same thing here, which also uses `_beginthreadex()`:
https://github.com/gnustep/libs-base/blob/7a76635360ecab13f130174abbfeb0eacfaeeaf3/Tests/base/NSThread/lazy_thread.m#L12-L17