### PR TITLE
Fix NSURL path on Windows for UNC paths

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-07-26 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSURL.m:
+	* Tests/base/NSURL/basic.m:
+	Fix NSURL path on Windows for UNC paths.
+
 2023-07-25 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSFileManager.h:

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -1497,24 +1497,24 @@ static NSUInteger	urlAlign;
     }
 
 #if	defined(_WIN32)
-  /* On windows a file URL path may be of the form C:\xxx (ie we should
-   * not insert the leading slash).
+  /* On Windows a file URL path may be of the form C:\xxx or \\xxx,
+   * and in both cases we should not insert the leading slash.
    * Also the vertical bar symbol may have been used instead of the
    * colon, so we need to convert that.
    */
   if (myData->isFile == YES)
     {
-      if (ptr[1] && isalpha(ptr[1]))
-	{
-	  if (ptr[2] == ':' || ptr[2] == '|')
-	    {
-	      if (ptr[3] == '\0' || ptr[3] == '/' || ptr[3] == '\\')
-		{
-		  ptr[2] = ':';
-		  ptr++;
-		}
-	    }
-	}
+      if ((ptr[1] && isalpha(ptr[1]))
+          && (ptr[2] == ':' || ptr[2] == '|')
+          && (ptr[3] == '\0' || ptr[3] == '/' || ptr[3] == '\\'))
+        {
+          ptr[2] = ':';
+          ptr++; // remove leading slash
+        }
+      else if (ptr[1] == '\\' && ptr[2] == '\\')
+        {
+          ptr++; // remove leading slash
+        }
     }
 #endif
   return ptr;

--- a/Tests/base/NSURL/basic.m
+++ b/Tests/base/NSURL/basic.m
@@ -105,6 +105,16 @@ int main()
     "File URL C:\\WINDOWS is file:///C:%%5CWINDOWS/");
   PASS_EQUAL([url resourceSpecifier], @"/C:%5CWINDOWS/",
     "resourceSpecifier of C:\\WINDOWS is /C:%5CWINDOWS/");
+
+  // UNC path
+  url = [NSURL fileURLWithPath: @"\\\\SERVER\\SHARE\\"];
+  str = [url path];
+  PASS_EQUAL(str, @"\\\\SERVER\\SHARE\\",
+    "Path of file URL \\\\SERVER\\SHARE\\ is \\\\SERVER\\SHARE\\");
+  PASS_EQUAL([url description], @"file:///%5C%5CSERVER%5CSHARE%5C",
+    "File URL \\\\SERVER\\SHARE\\ is file:///%5C%5CSERVER%5CSHARE%5C");
+  PASS_EQUAL([url resourceSpecifier], @"/%5C%5CSERVER%5CSHARE%5C",
+    "resourceSpecifier of \\\\SERVER\\SHARE\\ is /%5C%5CSERVER%5CSHARE%5C");
 #else
   url = [NSURL fileURLWithPath: @"/usr"];
   str = [url path];


### PR DESCRIPTION
Fixes issue on Windows where initializing NSURL with an [UNC path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths) like `\\server\path\xxx\` and getting back its path adds an extra leading forward slash:

```objc
NSURL *url = [NSURL fileURLWithPath:@"\\\\path\\to\\test.txt"];
NSLog(@"url: %@", url); // => file:///%5C%5Cpath%5Cto%5Ctest.txt
NSLog(@"path: %@", url.path); // => /\\path\to\test.txt (extra forward slash)
```
