### PR TITLE
Fix NSData initWithContentsOfURL: caching data of file URLs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2023-07-26 Frederik Seiffert <frederik@algoriddim.com>
 
+	* Source/NSData.m:
+	Fix NSData initWithContentsOfURL: caching data of file URLs.
+
+2023-07-26 Frederik Seiffert <frederik@algoriddim.com>
+
 	* Source/NSURL.m:
 	* Tests/base/NSURL/basic.m:
 	Fix NSURL path on Windows for UNC paths.

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -643,7 +643,15 @@ failure:
 {
   NSData	*d;
 
-  d = [url resourceDataUsingCache: YES];
+  if ([url isFileURL])
+    {
+      d = [dataMalloc allocWithZone: NSDefaultMallocZone()];
+      d = AUTORELEASE([d initWithContentsOfFile: [url path]]);
+    }
+  else
+    {
+      d = [url resourceDataUsingCache: YES];
+    }
   return d;
 }
 
@@ -955,9 +963,15 @@ failure:
  */
 - (id) initWithContentsOfURL: (NSURL*)url
 {
-  NSData	*data = [url resourceDataUsingCache: YES];
-
-  return [self initWithData: data];
+  if ([url isFileURL])
+    {
+      return [self initWithContentsOfFile: [url path]];
+    }
+  else
+    {
+      NSData *data = [url resourceDataUsingCache: YES];
+      return [self initWithData: data];
+    }
 }
 
 /**
@@ -2359,11 +2373,18 @@ failure:
 + (id) dataWithContentsOfURL: (NSURL*)url
 {
   NSMutableData	*d;
-  NSData	*data;
 
   d = [mutableDataMalloc allocWithZone: NSDefaultMallocZone()];
-  data = [url resourceDataUsingCache: YES];
-  d = [d initWithBytes: [data bytes] length: [data length]];
+
+  if ([url isFileURL])
+    {
+      d = [d initWithContentsOfFile: [url path]];
+    }
+  else
+    {
+      NSData *data = [url resourceDataUsingCache: YES];
+      d = [d initWithBytes: [data bytes] length: [data length]];
+    }
   return AUTORELEASE(d);
 }
 


### PR DESCRIPTION
Initializing NSData with a file URL was using `-[NSURL resourceDataUsingCache:]` to load the file, which as a side effect caused the file data to be cached in memory. This is probably not desired behavior and caused very large memory growths in our application, and doesn’t match the behavior on Apple platforms.