### PR TITLE
Change NSNumberFormatter minimum/maximum properties type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-08-10 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Headers/Foundation/NSNumberFormatter.h:
+	* Source/NSNumberFormatter.m:
+	Change NSNumberFormatter minimum/maximum properties from
+	NSDecimalNumber to NSNumber to match Apple platforms.
+
 2023-07-30  Yavor Doganov  <yavor@gnu.org>
 
 	* Tools/HTMLLinker.1: Fix a groff warning.

--- a/Headers/Foundation/NSNumberFormatter.h
+++ b/Headers/Foundation/NSNumberFormatter.h
@@ -129,8 +129,8 @@ GS_EXPORT_CLASS
   unichar _thousandSeparator;
   unichar _decimalSeparator;
   NSDecimalNumberHandler *_roundingBehavior;
-  NSDecimalNumber *_maximum;
-  NSDecimalNumber *_minimum;
+  NSNumber *_maximum;
+  NSNumber *_minimum;
   NSAttributedString *_attributedStringForNil;
   NSAttributedString *_attributedStringForNotANumber;
   NSAttributedString *_attributedStringForZero;
@@ -337,25 +337,25 @@ GS_NSNumberFormatter_IVARS;
  * Returns maximum value that will be accepted as valid in number parsing.
  * Default is none.
  */
-- (NSDecimalNumber*) maximum;
+- (NSNumber*) maximum;
 
 /**
  * Sets maximum value that will be accepted as valid in number parsing.
  * Default is none.
  */
-- (void) setMaximum: (NSDecimalNumber*)aMaximum;
+- (void) setMaximum: (NSNumber*)aMaximum;
 
 /**
  * Returns minimum value that will be accepted as valid in number parsing.
  * Default is none.
  */
-- (NSDecimalNumber*) minimum;
+- (NSNumber*) minimum;
 
 /**
  * Sets minimum value that will be accepted as valid in number parsing.
  * Default is none.
  */
-- (void) setMinimum: (NSDecimalNumber*)aMinimum;
+- (void) setMinimum: (NSNumber*)aMinimum;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 /** Sets the behavior of the formatter.<br />

--- a/Source/NSNumberFormatter.m
+++ b/Source/NSNumberFormatter.m
@@ -900,12 +900,12 @@ static NSUInteger _defaultBehavior = NSNumberFormatterBehavior10_4;
   return _localizesFormat;
 }
 
-- (NSDecimalNumber*) maximum
+- (NSNumber*) maximum
 {
   return _maximum;
 }
 
-- (NSDecimalNumber*) minimum
+- (NSNumber*) minimum
 {
   return _minimum;
 }
@@ -1002,13 +1002,13 @@ static NSUInteger _defaultBehavior = NSNumberFormatterBehavior10_4;
   _localizesFormat = flag;
 }
 
-- (void) setMaximum: (NSDecimalNumber*)aMaximum
+- (void) setMaximum: (NSNumber*)aMaximum
 {
   // FIXME: NSNumberFormatterBehavior10_4
   ASSIGN(_maximum, aMaximum);
 }
 
-- (void) setMinimum: (NSDecimalNumber*)aMinimum
+- (void) setMinimum: (NSNumber*)aMinimum
 {
   // FIXME: NSNumberFormatterBehavior10_4
   ASSIGN(_minimum, aMinimum);


### PR DESCRIPTION
Not sure why they were defined as NSDecimalNumber, but in current Apple headers they are [defined as NSNumber](https://developer.apple.com/documentation/foundation/nsnumberformatter/1417228-minimum).

As far as I can tell these properties are not currently used in any implementations.