### PR TITLE
Issue a warning instead of throwing an exception

### DIFF
--- a/Source/NSLock.m
+++ b/Source/NSLock.m
@@ -63,7 +63,6 @@ static Class    untracedLockClass = Nil;
 static Class    untracedRecursiveLockClass = Nil;
 
 static BOOL     traceLocks = NO;
-static BOOL     compatible = NO;
 
 @implementation NSObject (GSTraceLocks)
 
@@ -250,10 +249,15 @@ static BOOL     compatible = NO;
 {\
   if (0 != GS_MUTEX_UNLOCK(_mutex))\
     {\
-      if (compatible)\
+      if (GSPrivateDefaultsFlag(GSMacOSXCompatible))\
+	{\
+          NSLog(@"Failed to unlock mutex %@ at %@",\
+	    self, [NSThread callStackSymbols]);\
+	}\
+      else \
 	{\
           [NSException raise: NSLockException\
-  	        format: @"failed to unlock mutex"];\
+		      format: @"failed to unlock mutex %@", self];\
 	}\
     }\
   CHK(Drop) \
@@ -349,7 +353,6 @@ NSString *NSLockException = @"NSLockException";
       untracedConditionLockClass = [GSUntracedConditionLock class];
       untracedLockClass = [GSUntracedLock class];
       untracedRecursiveLockClass = [GSUntracedRecursiveLock class];
-      compatible = (strcmp(getenv("NSLOCK_COMPATIBLE"), "YES") == 0) ? YES : NO;
     }
 }
 

--- a/Source/NSLock.m
+++ b/Source/NSLock.m
@@ -42,6 +42,7 @@
 #import "Foundation/NSLock.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSThread.h"
+#import "Foundation/NSUserDefaults.h"
 
 #define class_createInstance(C,E) NSAllocateObject(C,E,NSDefaultMallocZone())
 
@@ -61,6 +62,7 @@ static Class    untracedLockClass = Nil;
 static Class    untracedRecursiveLockClass = Nil;
 
 static BOOL     traceLocks = NO;
+static BOOL     compatible = NO;
 
 @implementation NSObject (GSTraceLocks)
 
@@ -247,7 +249,11 @@ static BOOL     traceLocks = NO;
 {\
   if (0 != GS_MUTEX_UNLOCK(_mutex))\
     {\
-      NSLog(@"failed to unlock mutex");\
+      if (compatible)\
+	{\
+          [NSException raise: NSLockException\
+  	        format: @"failed to unlock mutex"];\
+	}\
     }\
   CHK(Drop) \
 }
@@ -342,6 +348,7 @@ NSString *NSLockException = @"NSLockException";
       untracedConditionLockClass = [GSUntracedConditionLock class];
       untracedLockClass = [GSUntracedLock class];
       untracedRecursiveLockClass = [GSUntracedRecursiveLock class];
+      compatible = [[NSUserDefaults standardUserDefaults] boolForKey: @"GSMacOSXCompatible"];
     }
 }
 

--- a/Source/NSLock.m
+++ b/Source/NSLock.m
@@ -247,8 +247,7 @@ static BOOL     traceLocks = NO;
 {\
   if (0 != GS_MUTEX_UNLOCK(_mutex))\
     {\
-      [NSException raise: NSLockException\
-	    format: @"failed to unlock mutex"];\
+      NSLog(@"failed to unlock mutex");\
     }\
   CHK(Drop) \
 }

--- a/Source/NSLock.m
+++ b/Source/NSLock.m
@@ -36,13 +36,14 @@
 #import "GSPrivate.h"
 #import "GSPThread.h"
 #include <math.h>
+#include <stdlib.h>
 
 #import "common.h"
 
 #import "Foundation/NSLock.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSThread.h"
-#import "Foundation/NSUserDefaults.h"
+// #import "Foundation/NSUserDefaults.h"
 
 #define class_createInstance(C,E) NSAllocateObject(C,E,NSDefaultMallocZone())
 
@@ -348,7 +349,7 @@ NSString *NSLockException = @"NSLockException";
       untracedConditionLockClass = [GSUntracedConditionLock class];
       untracedLockClass = [GSUntracedLock class];
       untracedRecursiveLockClass = [GSUntracedRecursiveLock class];
-      compatible = [[NSUserDefaults standardUserDefaults] boolForKey: @"GSMacOSXCompatible"];
+      compatible = (strcmp(getenv("NSLOCK_COMPATIBLE"), "YES") == 0) ? YES : NO;
     }
 }
 

--- a/Tests/base/NSLock/unbalancedUnlock.m
+++ b/Tests/base/NSLock/unbalancedUnlock.m
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+int main()
+{
+  START_SET("Unbalanced unlocking")
+
+  NSLock		*lock;
+
+  lock = [NSLock new];
+
+  PASS_EXCEPTION([lock unlock], @"NSLockException",
+    "unlocking an unlocked lock raises NSLockException")
+
+  [[NSUserDefaults standardUserDefaults] setBool: YES
+					  forKey: @"GSMacOSXCompatible"];
+
+  PASS_RUNS([lock unlock],
+    "unlocking an unlocked lock does not raise in MacOSX compatibility mode")
+
+  END_SET("Unbalanced unlocking")
+  return 0;
+}

--- a/Tests/base/NSLock/unbalancedUnlock.m
+++ b/Tests/base/NSLock/unbalancedUnlock.m
@@ -6,18 +6,19 @@ int main()
 {
   START_SET("Unbalanced unlocking")
 
-  NSLock		*lock;
+  NSLock		*lock = [NSLock new];
+  NSUserDefaults	*defs = [NSUserDefaults standardUserDefaults];
+  BOOL			mode = [defs boolForKey: @"GSMacOSXCompatible"]; 
 
-  lock = [NSLock new];
-
+  [defs setBool: NO forKey: @"GSMacOSXCompatible"];
   PASS_EXCEPTION([lock unlock], @"NSLockException",
     "unlocking an unlocked lock raises NSLockException")
 
-  [[NSUserDefaults standardUserDefaults] setBool: YES
-					  forKey: @"GSMacOSXCompatible"];
-
+  [defs setBool: YES forKey: @"GSMacOSXCompatible"];
   PASS_RUNS([lock unlock],
     "unlocking an unlocked lock does not raise in MacOSX compatibility mode")
+
+  [defs setBool: mode forKey: @"GSMacOSXCompatible"];
 
   END_SET("Unbalanced unlocking")
   return 0;


### PR DESCRIPTION
This is a basic solution to issue #316,  it is likely not the right one, but I am hoping this PR provides the right forum for discussing what is correct.   It is worth noting that macOS does not throw an exception when an unlock fails.