### PR TITLE
INSTALL: Add libavahi and zlib as requirements

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,9 @@ higher.
    * libxml2 (RECOMMENDED)
    * libcurl (RECOMMENDED)
    * libdispatch (RECOMMENDED)
-   * libxslt (OPTIONAL)
+   * libavahi (RECOMMENDED for NSNetServices)
+   * libxslt (RECOMMENDED)
+   * zlib (RECOMMENDED)
    * iconv (OPTIONAL, not needed if you have glibc)
    * openssl (OPTIONAL, not needed if you have gnutls)
 


### PR DESCRIPTION
This is only a small patch that lifts libxslt, which is used in NSXMLDocument for xslt parsing, from OPTIONAL to RECOMMENDED, as a gnustep-base installation without libxslt would introduce inconsistency. The method objectByApplyingXSLT:arguments:error: (Available since Mac OS X 10.4) would just return nil if gnustep-base was compiled without libxslt support.

Additionally, libavahi for mDNS discovery, used in NSNetService (https://developer.apple.com/documentation/foundation/nsnetservice), and zlib, used in GSFileHandle for file compression should be listed and marked as RECOMMENDED.