### PR TITLE
Fix LD_LIBRARY_PATH in Documentation GNUmakefile

### DIFF
--- a/Documentation/GNUmakefile
+++ b/Documentation/GNUmakefile
@@ -100,7 +100,7 @@ ReleaseNotes.gsdoc
 ReleaseNotes_AGSDOC_FLAGS = -DTDs ../Tools
 
 # Use local version of autogsdoc in case it is not installed
-LD_LIBRARY_PATH := $(dir $(CURDIR))/Source/$(GNUSTEP_OBJ_DIR_NAME):$(LD_LIBRARY_PATH)
+LD_LIBRARY_PATH := $(dir $(CURDIR))/../Source/$(GNUSTEP_OBJ_DIR_NAME):$(LD_LIBRARY_PATH)
 AUTOGSDOC=../Tools/$(GNUSTEP_OBJ_DIR_NAME)/autogsdoc
 BASE_MAKE_LOADED=yes
 


### PR DESCRIPTION
When building the gnustep-base documentation (Documentation/GNUmakefile) without installing the base library into a standard library load path, compilation with 'autogsdoc' fails, as it requires libgnustep-base.

The modified LD_LIBRARY_PATH in the GNUmakefile to address this problem is incorrect, thus preventing autogsdoc to find the shared library.