### PR TITLE
Win64: Only use `__builtin_setjmp`/`__builtin_longjmp` when compiling with GCC

### DIFF
--- a/Headers/Foundation/NSException.h
+++ b/Headers/Foundation/NSException.h
@@ -54,17 +54,6 @@
 #include <setjmp.h>
 #include <stdarg.h>
 
-#if	defined(__WIN64__)
-/* This hack is to deal with the fact that currently (June 2016) the
- * implementation of longjmp in mingw-w64  sometimes crashes in msvcrt.dll
- * but the builtin version provided by gcc seems to work.
- */
-#undef	setjmp
-#define	setjmp(X)	__builtin_setjmp(X)
-#undef	longjmp
-#define	longjmp(X,Y)	__builtin_longjmp(X,Y)
-#endif
-
 #if	defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
Using `__builtin_setjmp` when compiling with Clang on MSYS2 will result in compiler warnings and runtime crashes.  It seems to work on GCC, though.

Compiler warning on Clang:

```
warning: incompatible pointer types passing 'jmp_buf' (aka 'struct _SETJMP_FLOAT128[16]') to parameter of type 'void **' [-Wincompatible-pointer-types]
                NS_DURING
                ^~~~~~~~~
note: expanded from macro 'NS_DURING'
                    if (!setjmp(NSLocalHandler.jumpState)) {
                                ^~~~~~~~~~~~~~~~~~~~~~~~
note: expanded from macro 'setjmp'
#define setjmp(X)       __builtin_setjmp(X)
                                         ^
1 warning generated.
```