### PR TITLE
Use `__has_include` to choose between <Block.h> and <objc/blocks_runtime.h>

### DIFF
--- a/Headers/GNUstepBase/GSVersionMacros.h
+++ b/Headers/GNUstepBase/GSVersionMacros.h
@@ -358,7 +358,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
  */
 #if __has_feature(blocks)
 #  if	OBJC2RUNTIME
-#    if defined(__APPLE__)
+#    if __has_include(<Block.h>)
 #      include <Block.h>
 #    else
 #      include <objc/blocks_runtime.h>


### PR DESCRIPTION
Most Linux distributions and MSYS2 include a version of BlocksRuntime which includes the `Block.h` header, e.g.:
- https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-libblocksruntime?repo=ucrt64
- https://packages.ubuntu.com/kinetic/amd64/libblocksruntime-dev/filelist

So it's likely you will want to include `Block.h` when compiling libs-base using clang on these platforms (assuming you're still on the GNU objc runtime).

Alternatively, I can update the ifdef to be `defined(__APPLE__) && defined(__clang__)` or `defined(__llvm__)`, or reverse the order of #if statments so that `objc/blocks_runtime.h` gets preference