### PR TITLE
Add missing includes for 

### DIFF
--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -35,6 +35,7 @@
 
 #import "common.h"
 #include <objc/Protocol.h>
+#include <objc/message.h>
 #import "Foundation/NSMethodSignature.h"
 #import "Foundation/NSInvocation.h"
 #import "Foundation/NSLock.h"

--- a/Source/NSProxy.m
+++ b/Source/NSProxy.m
@@ -34,6 +34,7 @@
 #import "Foundation/NSHashTable.h"
 #import "Foundation/NSDistantObject.h"
 #import "Foundation/NSPortCoder.h"
+#include <objc/message.h>
 
 // Get objc_delete_weak_refs(), if it is present in the runtime.
 #ifdef __GNUSTEP_RUNTIME__


### PR DESCRIPTION
`NSObject.m` and `NSProxy.m` both reference `objc_msg_lookup`, but don't include `objc/message.h`.  This may cause an undefined reference to `objc_msg_lookup` in some configurations.