### PR TITLE
Fix compiler warning when compling NSFontAssetRequest.m in libs-gui

### DIFF
--- a/Headers/GNUstepBase/GSBlocks.h
+++ b/Headers/GNUstepBase/GSBlocks.h
@@ -107,8 +107,8 @@ typedef retTy(^name)()
 
 #endif /* __has_feature(blocks) */
 
-#define CALL_BLOCK(block, args...) ((NULL != block) ? CALL_NON_NULL_BLOCK(block, args) : nil)
-#define CALL_BLOCK_NO_ARGS(block) ((NULL != block) ? CALL_NON_NULL_BLOCK_NO_ARGS(block) : nil)
+#define CALL_BLOCK(block, args...) ((NULL != block) ? (void*)CALL_NON_NULL_BLOCK(block, args) : (void*)nil)
+#define CALL_BLOCK_NO_ARGS(block) ((NULL != block) ? (void*)CALL_NON_NULL_BLOCK_NO_ARGS(block) : (void*)nil)
 
 #if __has_include(<objc/blocks_runtime.h>)
 #  include <objc/blocks_runtime.h>


### PR DESCRIPTION
Cast the result type of CALL_NON_NULL_BLOCK to void to satisfy the ? operator.

If not, compiling on clang on msys2/ucrt64 fails with this error:

```
NSFontAssetRequest.m:48:3: error: incompatible operand types ('int' and 'id')
    48 |   CALL_BLOCK(completionHandler, error);
        |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/tools/msys64/ucrt64/include/GNUstepBase/GSBlocks.h:110:53: note: expanded from macro 'CALL_BLOCK'
    110 | #define CALL_BLOCK(block, args...) ((NULL != block) ? CALL_NON_NULL_BLOCK(block, args) : nil)
        |                                                     ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~~~
1 error generated.
```