### PR TITLE
NSDistributedNotificationCenter: Throw a descriptive exception when gdnc could not be found

### DIFF
--- a/Source/NSDistributedNotificationCenter.m
+++ b/Source/NSDistributedNotificationCenter.m
@@ -699,6 +699,12 @@ static NSDistributedNotificationCenter	*netCenter = nil;
 
 	  cmd = [NSTask launchPathForTool: @"gdnc"];
 	
+	  if (cmd == nil)
+	    {
+	      [NSException raise: NSInternalInconsistencyException
+		format: @"Unable to find the gdnc tool.\n"];
+	    }
+	
 	  NSDebugMLLog(@"NSDistributedNotificationCenter",
 @"\nI couldn't contact the notification server for %@ -\n"
 @"so I'm attempting to to start one - which will take a few seconds.\n"


### PR DESCRIPTION
`NSTask launchPathForTool: @"gdnc"];` can return `nil` when the tool is not found.  In this case, `[NSTask launchedTaskWithLaunchPath]` would raise a `NSInvalidArgumentException` with error message "NSTask - no launch path set" which is not very descriptive.