### PR TITLE
Fix incorrect formatting in NSISO8601DateFormatter

### DIFF
--- a/Source/NSISO8601DateFormatter.m
+++ b/Source/NSISO8601DateFormatter.m
@@ -122,7 +122,7 @@
     {
       if (_formatOptions & NSISO8601DateFormatWithColonSeparatorInTimeZone)
         {
-          result = [result stringByAppendingString: @"ZZ:ZZ"];
+          result = [result stringByAppendingString: @"ZZZZZ"];
         }
       else
         {


### PR DESCRIPTION
By default, the `NSISO8601DateFormatter` uses the
`NSISO8601DateFormatWithInternetDateTime` formatting:

https://github.com/gnustep/libs-base/blob/master/Headers/Foundation/NSISO8601DateFormatter.h#L57

This equates to these format options:
```
NSISO8601DateFormatWithYear |
NSISO8601DateFormatWithMonth |
NSISO8601DateFormatWithDay |
NSISO8601DateFormatWithDashSeparatorInDate |

NSISO8601DateFormatWithTime |
NSISO8601DateFormatWithColonSeparatorInTime |
NSISO8601DateFormatWithTimeZone |
NSISO8601DateFormatWithColonSeparatorInTimeZone
```

The last option (`NSISO8601DateFormatWithColonSeparatorInTimeZone`) causes the formatter to append "ZZ:ZZ" to the formatting string. But ZZ maps to a timezone like this: "-0800" according to the ICU documentation:
https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table

The full format string that GNUStep puts together with the above options is:

"yyyy-MM-dd'T'HH:mm:ssZZ:ZZ"

As a result, "ZZ:ZZ" will always translate to something like:

"-0800:-08:00"

"ZZ:ZZ" should be "ZZZZZ" which is would output the timezone offset once with the `:` separator between hours and minutes.

"yyyy-MM-dd'T'HH:mm:ssZZZZZ" is also the same format string used in Apple's implementation according to their documentation: https://developer.apple.com/documentation/foundation/nsiso8601dateformatter/1643114-init