### PR TITLE
NSRegularExpression: Improved Error and Exception handling to match macOS behaviour

### DIFF
--- a/Source/NSRegularExpression.m
+++ b/Source/NSRegularExpression.m
@@ -116,7 +116,14 @@ NSRegularExpressionOptionsToURegexpFlags(NSRegularExpressionOptions opts)
 	       options: (NSRegularExpressionOptions)opts
 		 error: (NSError**)e
 {
-  NSAssert(nil != aPattern, @"nil argument");
+  // Raise an NSInvalidArgumentException to match macOS behaviour.
+  if (!aPattern) {
+    NSException *exp;
+
+    exp = [NSException exceptionWithName: NSInvalidArgumentException
+          reason: @"nil argument"];
+    [exp raise];
+  }
 
   uint32_t	flags = NSRegularExpressionOptionsToURegexpFlags(opts);
   UText		p = UTEXT_INITIALIZER;

--- a/Tests/base/NSRegularExpression/basic.m
+++ b/Tests/base/NSRegularExpression/basic.m
@@ -9,6 +9,8 @@
 #import <Foundation/NSRunLoop.h>
 #import <Foundation/NSThread.h>
 #import <Foundation/NSValue.h>
+#import <Foundation/NSError.h>
+#import <Foundation/FoundationErrors.h>
 
 @interface DegeneratePatternTest : NSObject
 {
@@ -169,6 +171,31 @@ int main()
        beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.01]];
     }
   PASS(NO == [thread isExecuting], "Faulty regular expression terminated");
+
+  /* Testing the error handling when an invalid pattern is passed
+   * The error should look like this:
+   *
+   * Error Domain=NSCocoaErrorDomain Code=2048 "The value “(abc” is
+   * invalid." UserInfo={NSInvalidValue=(abc}
+   */
+
+  NSError *error = nil;
+  NSRegularExpression *testObj3 =
+    [[NSRegularExpression alloc] initWithPattern: @"(abc"
+           options: 0
+             error: &error];
+  PASS(testObj3 == nil, "Invalid pattern: returns nil");
+  PASS(error != nil, "Invalid pattern: error is set");
+  PASS_EQUAL([error domain], NSCocoaErrorDomain,
+             "Invalid pattern: error domain is NSCocoaErrorDomain");
+  PASS_EQUAL([error code], NSFormattingError, 
+             "Invalid pattern: error code is NSFormattingError");
+  PASS_EQUAL([[error userInfo] objectForKey: @"NSInvalidValue"],
+             @"(abc", "Invalid pattern: error message is correct");
+  PASS_EQUAL([[error userInfo] objectForKey: NSLocalizedDescriptionKey],
+             @"The value “(abc” is invalid.",
+             "Invalid pattern: localized description is correct");
+
 #endif
 
   END_SET("NSRegularExpression")

--- a/Tests/base/NSRegularExpression/basic.m
+++ b/Tests/base/NSRegularExpression/basic.m
@@ -196,6 +196,13 @@ int main()
              @"The value “(abc” is invalid.",
              "Invalid pattern: localized description is correct");
 
+  /* Testing exception handling when nil is passed as pattern */
+  PASS_EXCEPTION([NSRegularExpression regularExpressionWithPattern: nil
+                                                           options: 0
+                                                             error: NULL],
+                 NSInvalidArgumentException,
+                 "nil pattern: throws NSInvalidArgumentException");
+
 #endif
 
   END_SET("NSRegularExpression")


### PR DESCRIPTION
When creating a NSRegularExpression object on macOS, the following error message is created.

```objective-c
NSRegularExpression *exp;
exp = [NSRegularExpression regularExpressionWithPattern:@"(abc" options:0 error:&error];
if (!exp) {
  NSLog(@"%@", error);
}
```

## Output macOS 14.0
```sh
2023-11-11 19:43:08.886 objc-boilerplate[7287:328207] Error Domain=NSCocoaErrorDomain Code=2048 "The value “(abc” is invalid." UserInfo={NSInvalidValue=(abc}
```

On GNUstep we did not populate the error value.

Additionally, we did not check nil values:

```objective-c
NSRegularExpression *exp;
exp = [NSRegularExpression regularExpressionWithPattern:nil options:0 error:&error];
```

## Output macOS 14.0
```sh
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSRegularExpression initWithPattern:options:error:]: nil argument'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000018f4a88c0 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000018efa1eb4 objc_exception_throw + 60
        2   Foundation                          0x0000000190535ce0 -[NSRegularExpression initWithPattern:options:error:] + 664
        3   Foundation                          0x0000000190535a28 +[NSRegularExpression regularExpressionWithPattern:options:error:] + 52
        4   objc-boilerplate                    0x0000000102113df0 main + 928
        5   dyld                                0x000000018efdd058 start + 2224
```

This PR aligns the GNUstep implementation with Apple's Foundation framework, and supplies test cases for testing correct behaviour.