### PR TITLE
NSObject: Change return type of setVersion: from id to void

### DIFF
--- a/Headers/Foundation/NSObject.h
+++ b/Headers/Foundation/NSObject.h
@@ -363,7 +363,7 @@ GS_EXPORT_CLASS GS_ROOT_CLASS
 + (BOOL) isSubclassOfClass: (Class)aClass;
 + (id) new;
 + (void) poseAsClass: (Class)aClassObject;
-+ (id) setVersion: (NSInteger)aVersion;
++ (void) setVersion: (NSInteger)aVersion;
 + (NSInteger) version;
 
 - (id) awakeAfterUsingCoder: (NSCoder*)aDecoder;

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -2220,14 +2220,13 @@ static id gs_weak_load(id obj)
 /**
  * Sets the version number of the receiving class.  Should be nonnegative.
  */
-+ (id) setVersion: (NSInteger)aVersion
++ (void) setVersion: (NSInteger)aVersion
 {
   if (aVersion < 0)
     [NSException raise: NSInvalidArgumentException
 	        format: @"%s +setVersion: may not set a negative version",
 			GSClassNameFromObject(self)];
   class_setVersion(self, aVersion);
-  return self;
 }
 
 /**


### PR DESCRIPTION
I have check libs-base and found no code that expects a return value from setVersion:

As the GNUstep implementation diverges from Foundation, we treat this as a bug.