### PR TITLE
Support deleting NSMutableURLRequest headers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-11-14 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSURLRequest.m: Support deleting NSMutableURLRequest headers by
+	calling setValue:forHTTPHeaderField: with nil value.
+	* Headers/Foundation/NSURLRequest.h: Update method documentation.
+	* Tests/base/NSURLRequest/basic.m: Extended NSMutableURLRequest tests.
+
 2023-11-14 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSFileManager.m: Fix issue #292

--- a/Headers/Foundation/NSURLRequest.h
+++ b/Headers/Foundation/NSURLRequest.h
@@ -321,8 +321,9 @@ GS_EXPORT_CLASS
 - (void) setHTTPShouldHandleCookies: (BOOL)should;
 
 /**
- * Sets the value for the sapecified header field, replacing any
- * previously set value.
+ * Sets the value for the specified header field, replacing any
+ * previously set value. Setting a nil value deletes a previously set
+ * header field.
  */
 - (void) setValue: (NSString *)value forHTTPHeaderField: (NSString *)field;
 

--- a/Source/NSURLRequest.m
+++ b/Source/NSURLRequest.m
@@ -403,8 +403,8 @@ typedef struct {
 
       if ([value isKindOfClass: [NSString class]] == YES)
         {
-	  [self setValue: (NSString*)value forHTTPHeaderField: field];
-	}
+          [self setValue: (NSString*)value forHTTPHeaderField: field];
+        }
     }
 }
 
@@ -444,7 +444,14 @@ typedef struct {
     {
       this->headers = [_GSMutableInsensitiveDictionary new];
     }
-  [this->headers setObject: value forKey: field];
+  if (value != nil)
+    {
+      [this->headers setObject: value forKey: field];
+    }
+  else
+    {
+      [this->headers removeObjectForKey: field];
+    }
 }
 
 @end

--- a/Tests/base/NSURLRequest/basic.m
+++ b/Tests/base/NSURLRequest/basic.m
@@ -43,6 +43,18 @@ int main()
   [mutable addValue: @"value2" forHTTPHeaderField: @"gnustep"];
   PASS_EQUAL([mutable valueForHTTPHeaderField: @"gnustep"], (@"value1,value2"),
     "Handle multiple values for an HTTP header field");
+  [mutable setAllHTTPHeaderFields: [NSDictionary dictionaryWithObject: @"object" forKey: @"key"]];
+  PASS_EQUAL([mutable allHTTPHeaderFields],
+    [NSDictionary dictionaryWithObjectsAndKeys:@"object", @"key", @"value1,value2", @"gnustep", nil],
+    "setAllHTTPHeaderFields adds header");
+  [mutable setValue: @"value3" forHTTPHeaderField: @"gnustep"];
+  PASS_EQUAL([mutable allHTTPHeaderFields],
+    [NSDictionary dictionaryWithObjectsAndKeys:@"object", @"key", @"value3", @"gnustep", nil],
+    "Update header field");
+  [mutable setValue: nil forHTTPHeaderField: @"gnustep"];
+  PASS_EQUAL([mutable allHTTPHeaderFields],
+    [NSDictionary dictionaryWithObjectsAndKeys:@"object", @"key", nil],
+    "Remove header field");
   [mutable release];
 
   mutable = [NSMutableURLRequest new];


### PR DESCRIPTION
Calling `setValue:forHTTPHeaderField:` with a nil value deletes the header on Apple platforms.