### PR TITLE
Tests/base/NSCalendar/era.m: Fix testing with non-English locale

### DIFF
--- a/Tests/base/NSCalendar/era.m
+++ b/Tests/base/NSCalendar/era.m
@@ -32,6 +32,8 @@ int main()
   /* Test getEra:year:month:day:fromDate:
    */
   dateFormatter = [[NSDateFormatter alloc] init];
+  [dateFormatter setLocale: [[NSLocale alloc] initWithLocaleIdentifier:
+	[NSLocale canonicalLocaleIdentifierFromString: @"en_US"]]];
   cal = [NSCalendar currentCalendar];
   [cal setTimeZone:[NSTimeZone timeZoneWithName: @"America/New_York"]];
   [dateFormatter setDateFormat: @"d MMM yyyy HH:mm:ss Z"];


### PR DESCRIPTION
Currently, the `NSCalendar` tests fail (at least on musl-based Alpine Linux v3.18) in the file _Tests/NSCalendar/era.m_ if the locale is set to any non-English locale. For example, with
```
$ export LANG=sr_RS.UTF-8
```
the ICU function `udat_parse` used by `NSDateFormatter` returns 9 (`U_PARSE_ERROR`) when passed the string containing English language month name (`@"22 Nov 1969 08:15:00 Z"`), which makes the tests fail.

This patch explicitly sets the `NSDateFormatter` locale in _Tests/NSCalendar/era.m_ to `en_US`.

Solves part of the issues in https://github.com/gnustep/libs-base/issues/356.