### PR TITLE
Add +[NSObject _TrivialAllocInit] to enable fast-path alloc / init methods with libobjc2 2.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-04-15 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSObject.m: add +[NSObject _TrivialAllocInit] to enable
+	fast-path alloc / init methods with libobjc2 2.2.
+
 2024-04-02 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSURLSession.m: fix for #385

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -949,8 +949,9 @@ NSShouldRetainWithZone (NSObject *anObject, NSZone *requestedZone)
  * </p>
  */
 @implementation NSObject
-#if  defined(GS_ARC_COMPATIBLE)
-- (void)_ARCCompliantRetainRelease {}
+#ifdef OBJC_CAP_ARC
++ (void) _TrivialAllocInit {}
+- (void) _ARCCompliantRetainRelease {}
 #endif
 
 /**

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -209,20 +209,6 @@ static void GSLogZombie(id o, SEL sel)
 #undef	GSATOMICREAD
 #endif
 
-
-/* Traditionally, GNUstep has been using a 32bit reference count in front
- * of the object. The automatic reference counting implementation in
- * libobjc2 uses an intptr_t instead, so NSObject will only be compatible
- * with ARC if either of the following apply:
- *
- * a) sizeof(intptr_t) == sizeof(int32_t)
- * b) we can provide atomic operations on pointer sized values, allowing
- *    us to extend the refcount to intptr_t.
- */
-#ifdef GS_ARC_COMPATIBLE
-#undef GS_ARC_COMPATIBLE
-#endif
-
 #if defined(__llvm__) || (defined(USE_ATOMIC_BUILTINS) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)))
 /* Use the GCC atomic operations with recent GCC versions */
 
@@ -231,7 +217,6 @@ typedef intptr_t gsrefcount_t;
 #define GSATOMICREAD(X) (*(X))
 #define GSAtomicIncrement(X)    __sync_add_and_fetch(X, 1)
 #define GSAtomicDecrement(X)    __sync_sub_and_fetch(X, 1)
-#define GS_ARC_COMPATIBLE 1
 
 #elif	defined(_WIN32)
 
@@ -425,16 +410,6 @@ static inline pthread_mutex_t   *GSAllocationLockForObject(id p)
 
 #endif
 
-#ifndef GS_ARC_COMPATIBLE
-/*
- * If we haven't previously declared that we can work in fast-ARC mode,
- * check whether a point is 32bit (4 bytes) wide, which also enables ARC
- * integration.
- */
-#  if __SIZEOF_POINTER__ == 4
-#    define GS_ARC_COMPATIBLE 1
-#  endif
-#endif
 
 #if defined(__GNUC__) && __GNUC__ < 4
 #define __builtin_offsetof(s, f) (uintptr_t)(&(((s*)0)->f))


### PR DESCRIPTION
See https://github.com/gnustep/libobjc2/pull/268, requires the upcoming Clang 18 (but doesn't hurt when using older releases).

It’s not clear to me why `_ARCCompliantRetainRelease` was guarded by `GS_ARC_COMPATIBLE` instead of the more fine-grained `OBJC_CAP_ARC`. The latter seems to also be used in other places (like in `NSAllocateObject`) as a kind of general check for libobjc2 availability, so I used it here as well and removed the former as it’s no longer used. Let me know if that doesn’t make sense.

We should probably also update Make to default to libobjc2 2.2 instead of 2.0.