### PR TITLE
./configure thread-safe +initialize check: include unistd everywhere except msvc

### DIFF
--- a/config/config.initialize.m
+++ b/config/config.initialize.m
@@ -4,6 +4,10 @@
 #include "objc-common.g"
 #include <stdio.h>
 
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#endif
+
 #if defined(_WIN32)
 
 #include <process.h>


### PR DESCRIPTION
The config check for thread-safe +initialize was failing to build on msys2/mingw64, and it seemed reasonable to force it to use pthread.h since that's what it did [a long time ago](https://github.com/gnustep/libs-base/blob/gnustep_testplant_branch/config/config.initialize.m#L5), before msvc support was introduced

