### PR TITLE
Add CI leg for msys2/mingw64 using libobjc2 + gnustep-2.0 ABI

### DIFF
--- a/.github/scripts/dependencies.sh
+++ b/.github/scripts/dependencies.sh
@@ -64,8 +64,9 @@ install_libdispatch() {
 
 mkdir -p $DEPS_PATH
 
-# Windows MSVC toolchain uses tools-windows-msvc scripts to install non-GNUstep dependencies
-if [ "$LIBRARY_COMBO" = "ng-gnu-gnu" -a "$IS_WINDOWS_MSVC" != "true" ]; then
+# Windows MSVC toolchain uses tools-windows-msvc scripts to install non-GNUstep dependencies;
+# the MSYS2 toolchain uses Pacman to install non-GNUstep dependencies.
+if [ "$LIBRARY_COMBO" = "ng-gnu-gnu" -a "$IS_WINDOWS_MSVC" != "true" -a "$IS_WINDOWS_MINGW" != "true" ]; then
     install_libobjc2
     install_libdispatch
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,15 @@ jobs:
             CC: gcc
             CXX: g++
 
+          - name: Windows x64 MinGW Clang gnustep-2.0
+            arch: x86_64
+            msystem: MINGW64
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-2.0
+            CC: clang
+            CXX: clang
+            LDFLAGS: -fuse-ld=lld -lstdc++ -lgcc_s
+
           - name: Windows x86 MSVC Clang gnustep-2.0
             allow-test-failures: true
             arch: x86
@@ -223,13 +232,31 @@ jobs:
             libffi-devel
             libgnutls-devel
             icu-devel
-            mingw-w64-${{matrix.arch}}-gcc-objc
             mingw-w64-${{matrix.arch}}-pkg-config
             mingw-w64-${{matrix.arch}}-libxml2
             mingw-w64-${{matrix.arch}}-libxslt
             mingw-w64-${{matrix.arch}}-libffi
             mingw-w64-${{matrix.arch}}-gnutls
             mingw-w64-${{matrix.arch}}-icu
+
+      - name: Set up MSYS2 (gcc)
+        uses: msys2/setup-msys2@v2
+        if: env.CC == 'gcc'
+        with:
+          msystem: ${{ matrix.msystem }}
+          install: >
+            mingw-w64-${{matrix.arch}}-gcc-objc
+
+      - name: Set up MSYS2 (clang)
+        uses: msys2/setup-msys2@v2
+        if: env.CC == 'clang'
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >
+            mingw-w64-${{matrix.arch}}-libobjc2
+            mingw-w64-${{matrix.arch}}-clang
+            mingw-w64-${{matrix.arch}}-lld
 
       - name: Set up MSYS2 (MSVC)
         uses: msys2/setup-msys2@v2

--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -65,7 +65,7 @@ check::
 	GNUSTEP_LOCAL_ADDITIONAL_MAKEFILES="$(TOP_DIR)/base.make";\
 	ADDITIONAL_INCLUDE_DIRS="-I$(TOP_DIR)/Headers -I$(TOP_DIR)/Source/$(GNUSTEP_TARGET_DIR)";\
 	ADDITIONAL_LIB_DIRS="-L$(TOP_DIR)/Source/$(GNUSTEP_OBJ_DIR)";\
-	if [ "$(GNUSTEP_TARGET_OS)" != "windows" ]; then \
+	if [ "$(GNUSTEP_TARGET_OS)" != "windows" -a "$(GNUSTEP_TARGET_OS)" != "mingw32" ]; then \
 		PATH="$(TOP_DIR)/Tools/$(GNUSTEP_OBJ_DIR):${PATH}";\
 		ADDITIONAL_LDFLAGS="-Wl,-rpath,$(TOP_DIR)/Source/$(GNUSTEP_OBJ_DIR)";\
 		LD_LIBRARY_PATH="$(TOP_DIR)/Source/$(GNUSTEP_OBJ_DIR):${LD_LIBRARY_PATH}";\


### PR DESCRIPTION
libobjc2 now supports msys2/mingw64 and is part of the msys2 package repositories, so it's easier to add a CI job which uses that environment.

I had to make one minor change in `Tests/GNUMakefile` to avoid passing a `-rpath` flag on mingw.
The check for thread-safe +initialize in runtime will fail, but I believe #373 fixes that.