### PR TITLE
Generate pkg-config configuration file for libs-base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Tests/base/*/GNUmakefile
 *.log
 *.sum
 Tools/BaseTools/dependencies
+Source/gnustep-base.pc
 
 # Unit test byproducts
 *.err

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -639,6 +639,7 @@ libbase-resources_RESOURCE_FILES = Info-gnustep.plist
 
 libgnustep-base_NEEDS_GUI = NO
 libgnustep-baseadd_NEEDS_GUI = NO
+libgnustep-base_PKGCONFIG_FILES = "gnustep-base.pc"
 
 # Build the Additions subproject first.  It can then be used in by
 # both gnustep-base and gnustep-baseadd (otherwise, if we ever build

--- a/Source/gnustep-base.pc.in
+++ b/Source/gnustep-base.pc.in
@@ -1,0 +1,6 @@
+Name: gnustep-base
+Description: The GNUstep Base Library is a library of general-purpose, non-graphical Objective C objects.
+Version: @VERSION@
+URL: https://github.com/gnustep/libs-base/
+Libs: @BASELIBS@
+Cflags: @BASEFLAGS@

--- a/configure
+++ b/configure
@@ -750,6 +750,8 @@ build_os
 build_vendor
 build_cpu
 build
+BASELIBS
+BASEFLAGS
 BASE_NONFRAGILE_ABI
 target_alias
 host_alias
@@ -2800,6 +2802,11 @@ else
 $as_echo "$as_me: WARNING: You are running configure with the link options ($LDFLAGS) set to a different value from that used by gnustep-make ($MAKELDFLAGS).  To avoid conflicts/problems, reconfigure/reinstall gnustep-make to use LDFLAGS=$LDFLAGS or run the gnustep-base configure again with your LDFLAGS environment variable set to $MAKELDFLAGS" >&2;}
   fi
 fi
+
+BASEFLAGS=`gnustep-config --objc-flags`
+
+BASELIBS=`gnustep-config --base-libs`
+
 
 # We shouldn't be loading GNUstep.sh here.  It would load in a lot of
 # variables which might get confused with the ones that will be used
@@ -14161,7 +14168,7 @@ $as_echo "$VERSION" >&6; }
 #--------------------------------------------------------------------
 # Write the Makefiles
 #--------------------------------------------------------------------
-ac_config_files="$ac_config_files config.mak base.make Headers/GNUstepBase/GSConfig.h"
+ac_config_files="$ac_config_files config.mak base.make Source/gnustep-base.pc Headers/GNUstepBase/GSConfig.h"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -14856,6 +14863,7 @@ do
     "Headers/GNUstepBase/config.h") CONFIG_HEADERS="$CONFIG_HEADERS Headers/GNUstepBase/config.h" ;;
     "config.mak") CONFIG_FILES="$CONFIG_FILES config.mak" ;;
     "base.make") CONFIG_FILES="$CONFIG_FILES base.make" ;;
+    "Source/gnustep-base.pc") CONFIG_FILES="$CONFIG_FILES Source/gnustep-base.pc" ;;
     "Headers/GNUstepBase/GSConfig.h") CONFIG_FILES="$CONFIG_FILES Headers/GNUstepBase/GSConfig.h" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,9 @@ else
   fi
 fi
 
+AC_SUBST(BASEFLAGS, `gnustep-config --objc-flags`)
+AC_SUBST(BASELIBS, `gnustep-config --base-libs`)
+
 # We shouldn't be loading GNUstep.sh here.  It would load in a lot of
 # variables which might get confused with the ones that will be used
 # at runtime.  We will load it later once we have determined (and
@@ -3868,5 +3871,5 @@ AC_SUBST(GCC_VERSION)
 #--------------------------------------------------------------------
 # Write the Makefiles
 #--------------------------------------------------------------------
-AC_CONFIG_FILES([config.mak base.make Headers/GNUstepBase/GSConfig.h])
+AC_CONFIG_FILES([config.mak base.make Source/gnustep-base.pc Headers/GNUstepBase/GSConfig.h])
 AC_OUTPUT


### PR DESCRIPTION
This PR updates the libs-base build process to generate a `gnustep-base.pc` file which is installed in `/lib/pkgconfig` and contains the GNUstep base version number, the libraries to link (equivalent to `gnustep-config --base-libs`) with and the C flags to use (equivalent to `gnustep-config --objc-flags`).

This can be useful when linking with libs-base in projects which don't use the GNUstep build system.

Sample output is:

```
Name: gnustep-base
Description: The GNUstep Base Library is a library of general-purpose, non-graphical Objective C objects.
Version: 1.29.0
Libs: -fuse-ld=lld -L/usr/local/lib64 -lstdc++ -pthread -fexceptions -rdynamic -fobjc-runtime=gnustep-2.0 -fblocks -L/home/vagrant/GNUstep/Library/Libraries -L/usr/local/lib -lgnustep-base -lpthread -lobjc -lm
Cflags:  -MMD -MP -DGNUSTEP -DGNUSTEP_BASE_LIBRARY=1 -DGNU_GUI_LIBRARY=1 -DGNUSTEP_RUNTIME=1 -D_NONFRAGILE_ABI=1 -DGNUSTEP_BASE_LIBRARY=1 -fno-strict-aliasing -fexceptions -fobjc-exceptions -D_NATIVE_OBJC_EXCEPTIONS -pthread -fPIC -Wall -DGSWARN -DGSDIAGNOSE -Wno-import -g -O2 -fobjc-runtime=gnustep-2.0 -fblocks -fconstant-string-class=NSConstantString -I. -I/home/vagrant/GNUstep/Library/Headers -I/usr/local/include
```