### PR TITLE
Refactor +[NSTimeZone timeZoneArray] to use NSString instead of raw FDs

### DIFF
--- a/Source/NSTimeZone.m
+++ b/Source/NSTimeZone.m
@@ -1779,7 +1779,7 @@ localZoneString, [zone name], sign, s/3600, (s/60)%60);
  * Each element contains an array of NSStrings which are
  * the region names.
  */
-+ (NSArray*) timeZoneArray
++ (NSArray *)timeZoneArray
 {
   static NSArray *regionsArray = nil;
 
@@ -1791,56 +1791,59 @@ localZoneString, [zone name], sign, s/3600, (s/60)%60);
   GS_MUTEX_LOCK(zone_mutex);
   if (regionsArray == nil)
     {
-      NSAutoreleasePool	*pool = [NSAutoreleasePool new];
+      NSAutoreleasePool *pool = [NSAutoreleasePool new];
       NSMutableArray	*temp_array[24];
-      NSInteger index;
-      NSInteger i;
-	    NSString *name;
-      NSString *path;
-	    NSString *contents;
-	    NSScanner *scanner;
-	    NSCharacterSet *newLineSet;
-      NSError *error = nil;
+      NSInteger		 index;
+      NSInteger		 i;
+      NSString		*name;
+      NSString		*path;
+      NSString		*contents;
+      NSScanner		*scanner;
+      NSCharacterSet	*newLineSet;
+      NSError		*error = nil;
 
       for (i = 0; i < 24; i++)
-	      {
-	        temp_array[i] = [NSMutableArray array];
-	      }
+	{
+	  temp_array[i] = [NSMutableArray array];
+	}
 
-      path = _time_zone_path (REGIONS_FILE, nil);
+      path = _time_zone_path(REGIONS_FILE, nil);
       if (path != nil)
-	      {
-          contents = [NSString stringWithContentsOfFile: path
-                                               encoding: NSUTF8StringEncoding
-                                                  error: &error];
-          if (!contents)
-            {
-              NSException *exp;
-              NSDictionary *userInfo;
-              GS_MUTEX_UNLOCK(zone_mutex);
+	{
+	  contents = [NSString stringWithContentsOfFile: path
+					       encoding: NSUTF8StringEncoding
+						  error: &error];
+	  if (!contents)
+	    {
+	      NSException  *exp;
+	      NSDictionary *userInfo;
+	      GS_MUTEX_UNLOCK(zone_mutex);
 
-              userInfo = [NSDictionary dictionaryWithObjectsAndKeys: error, @"underlyingError"];
-              exp = [NSException exceptionWithName: NSInternalInconsistencyException
-                                            reason:@"Failed to open time zone regions array file."
-                                          userInfo:userInfo];
-              [exp raise];
-            }
-          newLineSet = [NSCharacterSet newlineCharacterSet];
-          scanner = [NSScanner scannerWithString: contents];
-
-          while ([scanner scanInteger: &index]
-            && [scanner scanUpToCharactersFromSet: newLineSet intoString: &name])
-            {
-              NSLog(@"Index: %ld Name: %@", index, name);
-              if (index < 0)
-                index = 0;
-              else
-                index %= 24;
-              
-              [temp_array[index] addObject: name];
-            }
+	      userInfo = [NSDictionary
+		dictionaryWithObjectsAndKeys: error, @"underlyingError"];
+	      exp = [NSException
+		exceptionWithName: NSInternalInconsistencyException
+			   reason:
+			     @"Failed to open time zone regions array file."
+			 userInfo: userInfo];
+	      [exp raise];
 	    }
-  else
+	  newLineSet = [NSCharacterSet newlineCharacterSet];
+	  scanner = [NSScanner scannerWithString: contents];
+
+	  while ([scanner scanInteger: &index] &&
+		 [scanner scanUpToCharactersFromSet: newLineSet
+					 intoString: &name])
+	    {
+	      if (index < 0)
+		index = 0;
+	      else
+		index %= 24;
+
+	      [temp_array[index] addObject: name];
+	    }
+	}
+      else
 	  {
 	  NSString	*zonedir = [NSTimeZone _getTimeZoneFile: @"WET"]; 
 

--- a/Source/NSTimeZone.m
+++ b/Source/NSTimeZone.m
@@ -106,6 +106,7 @@
 #import "Foundation/NSTimeZone.h"
 #import "Foundation/NSByteOrder.h"
 #import "Foundation/NSLocale.h"
+#import "Foundation/NSScanner.h"
 #import "GNUstepBase/NSString+GNUstepBase.h"
 #import "GSPrivate.h"
 #import "GSPThread.h"

--- a/Tests/base/NSTimeZone/use.m
+++ b/Tests/base/NSTimeZone/use.m
@@ -13,9 +13,13 @@ int main()
   NSLocale *locale;
   NSString *str;
   NSDate *date;
+  NSArray *zones;
   id current;
   id localh = [NSTimeZone defaultTimeZone];
   int offset = [localh secondsFromGMT];
+
+  zones = [NSTimeZone knownTimeZoneNames];
+  PASS(zones != nil, "+knownTimeZoneNames returns valid array");
 
   current = [NSTimeZone timeZoneForSecondsFromGMT: 900];
   PASS(current != nil && [current isKindOfClass: [NSTimeZone class]]


### PR DESCRIPTION
We cannot use raw fopen, fscanf, etc. to access Assets on Android.
A higher-level API like +[NSString stringWithContentsOfFile:encoding:error:] should be used instead.