### PR TITLE
Add support for -[NSThread setName:] on win32 and fix inconsistency in API behaviour

### DIFF
--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -394,6 +394,9 @@
 /* Define to 1 if you have the `rt' library (-lrt). */
 #undef HAVE_LIBRT
 
+/* Define to 1 if you have the `sframe' library (-lsframe). */
+#undef HAVE_LIBSFRAME
+
 /* Define to 1 if you have the `socket' library (-lsocket). */
 #undef HAVE_LIBSOCKET
 
@@ -411,6 +414,9 @@
 
 /* Define to 1 if you have the `z' library (-lz). */
 #undef HAVE_LIBZ
+
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+#undef HAVE_LIBZSTD
 
 /* Define to 1 if you have the <limits.h> header file. */
 #undef HAVE_LIMITS_H
@@ -874,6 +880,10 @@
 
 /* Define as the link to exe of process in /proc filesystem. */
 #undef PROCFS_EXE_LINK
+
+/* Description: Define getname function for pthread with two args (generic
+   style) */
+#undef PTHREAD_GETNAME
 
 /* Description: Define setname function for pthread with three args */
 #undef PTHREAD_SETNAME

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -200,7 +200,7 @@ GSPrivateThreadID()
 #endif
 
 #ifndef PTHREAD_GETNAME
-#define PTHREAD_GETNAME() -1
+#define PTHREAD_GETNAME(a, b) -1
 #endif
 
 

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -31,6 +31,7 @@
 */
 
 #import "common.h"
+#include <processthreadsapi.h>
 
 #import "GSPThread.h"
 
@@ -191,56 +192,12 @@ GSPrivateThreadID()
 #endif
 }
 
-#if 0
-/*
- * NSThread setName: method for windows.
- * FIXME ... This is code for the microsoft compiler;
- * how do we make it work for gcc/clang?
- */
-#if defined(_WIN32) && defined(HAVE_WINDOWS_H)
-// Usage: SetThreadName (-1, "MainThread");
-#include <windows.h>
-const DWORD MS_VC_EXCEPTION=0x406D1388;
-
-#pragma pack(push,8)
-typedef struct tagTHREADNAME_INFO
-{
-  DWORD dwType; // Must be 0x1000.
-  LPCSTR szName; // Pointer to name (in user addr space).
-  DWORD dwThreadID; // Thread ID (-1=caller thread).
-  DWORD dwFlags; // Reserved for future use, must be zero.
-} THREADNAME_INFO;
-#pragma pack(pop)
-
-static int SetThreadName(DWORD dwThreadID, const char *threadName)
-{
-  THREADNAME_INFO info;
-  int result;
-
-  info.dwType = 0x1000;
-  info.szName = threadName;
-  info.dwThreadID = dwThreadID;
-  info.dwFlags = 0;
-
-  __try
-  {
-    RaiseException(MS_VC_EXCEPTION, 0,
-      sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info);
-    result = 0;
-  }
-  __except(EXCEPTION_EXECUTE_HANDLER)
-  {
-    result = -1;
-  }
-}
-
-#define PTHREAD_SETNAME(a)  SetThreadName(-1, a)
-
-#endif
-#endif
-
 #ifndef PTHREAD_SETNAME
 #define PTHREAD_SETNAME(a) -1
+#endif
+
+#ifndef PTHREAD_GETNAME
+#define PTHREAD_GETNAME() -1
 #endif
 
 
@@ -1253,6 +1210,34 @@ unregisterActiveThread(NSThread *thread)
 
 - (id) init
 {
+// SetThreadDescription() was added in Windows 10 1607 (Redstone 1)
+#if defined(_WIN32) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
+  HANDLE current;
+  HRESULT hr;
+  PWSTR name;
+  NSString *threadName;
+
+  current = GetCurrentThread();
+  hr = GetThreadDescription(current, &name);
+  if (SUCCEEDED(hr))
+    {
+      threadName = [NSString stringWithCharacters: (const void *) name length: wcslen(name)];
+      ASSIGN(_name, threadName);
+      LocalFree(name);
+    }
+#elif defined(PTHREAD_GETNAME)
+  NSString *threadName;
+  char name[16];
+  int status;
+
+  status = PTHREAD_GETNAME(name, 16);
+  if (status == 0)
+    {
+      threadName = [NSString stringWithCString: name encoding: NSUTF8StringEncoding];
+      ASSIGN(_name, threadName);
+    }
+#endif
+
   GS_CREATE_INTERNAL(NSThread);
   pthread_spin_init(&lockInfo.spin, 0);
   lockInfo.held = NSCreateHashTable(NSNonOwnedPointerHashCallBacks, 10);
@@ -1316,11 +1301,20 @@ unregisterActiveThread(NSThread *thread)
 {
   if ([aName isKindOfClass: [NSString class]])
     {
+// SetThreadDescription() was added in Windows 10 1607 (Redstone 1)
+#if defined(_WIN32) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
+      HANDLE current;
+      const void *utf16String;
+
+      current = GetCurrentThread();
+      utf16String = [aName cStringUsingEncoding: NSUnicodeStringEncoding];
+      SetThreadDescription(current, utf16String);
+#elif defined(PTHREAD_SETNAME)
       int       i;
       char      buf[200];
 
       if (YES == [aName getCString: buf
-                         maxLength: sizeof(buf)
+                        maxLength: sizeof(buf)
                           encoding: NSUTF8StringEncoding])
         {
           i = strlen(buf);
@@ -1328,7 +1322,7 @@ unregisterActiveThread(NSThread *thread)
       else
         {
           /* Too much for buffer ... truncate on a character boundary.
-           */
+          */
           i = sizeof(buf) - 1;
           if (buf[i] & 0x80)
             {
@@ -1347,7 +1341,7 @@ unregisterActiveThread(NSThread *thread)
           if (PTHREAD_SETNAME(buf) == ERANGE)
             {
               /* Name must be too long ... gnu/linux uses 15 characters
-               */
+              */
               if (i > 15)
                 {
                   i = 15;
@@ -1357,7 +1351,7 @@ unregisterActiveThread(NSThread *thread)
                   i--;
                 }
               /* too long a name ... truncate on a character boundary.
-               */
+              */
               if (buf[i] & 0x80)
                 {
                   while (i > 0 && (buf[i] & 0x80))
@@ -1375,13 +1369,14 @@ unregisterActiveThread(NSThread *thread)
               break;    // Success or some other error
             }
         }
-    }
+#endif
+  }
 }
 
 - (void) setName: (NSString*)aName
 {
   ASSIGN(_name, aName);
-#ifdef PTHREAD_SETNAME
+  
   if (YES == _active)
     {
       [self performSelector: @selector(_setName:)
@@ -1389,7 +1384,6 @@ unregisterActiveThread(NSThread *thread)
                  withObject: aName
               waitUntilDone: NO];
     }
-#endif
 }
 
 - (void) setStackSize: (NSUInteger)stackSize

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -31,9 +31,12 @@
 */
 
 #import "common.h"
-#include <processthreadsapi.h>
 
 #import "GSPThread.h"
+
+#ifdef _WIN32
+#import <processthreadsapi.h>
+#endif
 
 // Dummy implementatation
 // cleaner than IFDEF'ing the code everywhere

--- a/Tests/base/NSThread/name.m
+++ b/Tests/base/NSThread/name.m
@@ -1,0 +1,44 @@
+#import "ObjectTesting.h"
+#include <winerror.h>
+#import <Foundation/NSThread.h>
+
+#if defined(_WIN32) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
+#include <processthreadsapi.h>
+#else
+#include <pthread.h>
+#endif
+
+
+int main(void)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+// SetThreadDescription() was added in Windows 10 1607 (Redstone 1)
+#if defined(_WIN32) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
+    PWSTR nativeThreadName = NULL;
+    HANDLE current = GetCurrentThread();
+    HRESULT hr = SetThreadDescription(current, L"Test");
+    PASS(SUCCEEDED(hr), "SetThreadDescription was successful");
+
+    NSString *name = [[[NSThread alloc] init] name];
+    PASS(name != nil, "-[NSThread name] returns a valid string");
+    NSLog(@"Name: %@", name);
+    PASS([name isEqualToString: @"Test"], "Thread name is correct");
+    [name release];
+
+    [[NSThread currentThread] setName: @"Test2"];
+    name = [[NSThread currentThread] name];
+    PASS(name != nil, "-[NSThread name] returns a valid string");
+    PASS([name isEqualToString: @"Test2"], "-[NSThread name] returns a valid string after setName");
+
+    
+    hr = GetThreadDescription(current, &nativeThreadName);
+    PASS(SUCCEEDED(hr), "SetThreadDescription was successful");
+
+    name = [NSString stringWithCharacters: (void *)nativeThreadName length: wcslen(nativeThreadName)];
+    PASS([name isEqualToString: @"Test2"], "-[NSThread setName] successfully updated thread name");
+    LocalFree(nativeThreadName);
+#else
+#endif
+
+  return 0;
+}

--- a/Tests/base/NSThread/name.m
+++ b/Tests/base/NSThread/name.m
@@ -1,5 +1,4 @@
 #import "ObjectTesting.h"
-#include <winerror.h>
 #import <Foundation/NSThread.h>
 
 #if defined(_WIN32) && (NTDDI_VERSION >= NTDDI_WIN10_RS1)
@@ -19,11 +18,12 @@ int main(void)
     HRESULT hr = SetThreadDescription(current, L"Test");
     PASS(SUCCEEDED(hr), "SetThreadDescription was successful");
 
-    NSString *name = [[[NSThread alloc] init] name];
+    NSThread *thread = [[NSThread alloc] init];
+    NSString *name = [thread name];
     PASS(name != nil, "-[NSThread name] returns a valid string");
     NSLog(@"Name: %@", name);
     PASS([name isEqualToString: @"Test"], "Thread name is correct");
-    [name release];
+    [thread release];
 
     [[NSThread currentThread] setName: @"Test2"];
     name = [[NSThread currentThread] name];

--- a/configure
+++ b/configure
@@ -772,7 +772,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -896,7 +895,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1149,15 +1147,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1295,7 +1284,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1448,7 +1437,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7867,6 +7855,39 @@ $as_echo "#define PTHREAD_SETNAME(a) pthread_setname_np(pthread_self(),\"%s\",a)
 
       ;;
   esac
+
+# Check if we can get names of pthreads
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_getname_np()" >&5
+$as_echo_n "checking for pthread_getname_np()... " >&6; }
+if ${gs_cv_pthread_getname_np+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <pthread.h>
+int
+main ()
+{
+char name16; pthread_getname_np(pthread_self(), name, 16);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  gs_cv_pthread_getname_np=generic
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $gs_cv_pthread_getname_np" >&5
+$as_echo "$gs_cv_pthread_getname_np" >&6; }
+case $gs_cv_pthread_getname_np in
+  generic)
+
+$as_echo "#define PTHREAD_GETNAME(b,c) pthread_getname_np(pthread_self(),b,c)" >>confdefs.h
+
+    ;;
+esac
 
   # Check if we have spinlock support
   for ac_func in pthread_spin_lock

--- a/configure.ac
+++ b/configure.ac
@@ -1849,7 +1849,20 @@ if test $HAVE_WIN32_THREADS_AND_LOCKS = 0; then
         [Description: Define setname function for pthread with three args])
       ;;
   esac
-  
+
+# Check if we can get names of pthreads
+AC_CACHE_CHECK([for pthread_getname_np()], gs_cv_pthread_getname_np,
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM([#include <pthread.h>],
+    [char name[16]; pthread_getname_np(pthread_self(), name, 16);])],
+  [gs_cv_pthread_getname_np=generic])])
+case $gs_cv_pthread_getname_np in
+  generic)
+    AC_DEFINE(PTHREAD_GETNAME(b,c), pthread_getname_np(pthread_self(),b,c),
+      [Description: Define getname function for pthread with two args (generic style)])
+    ;;
+esac
+
   # Check if we have spinlock support
   AC_CHECK_FUNCS(pthread_spin_lock)
 fi


### PR DESCRIPTION
Implements support for -[NSThread setName:] on win32. I am using `GetThreadDescription` and `SetThreadDescription` from `processthreadsapi.h`. This API was introduced in Windows 10 Redstone 1. Here is an overview of setting a thread name in native code: https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2022.

The test currently only checks correct behaviour on Windows, as I do not know how to reconfigure `configure.ac`. `autoreconf -vi` results in an erroneous `configure` script on Debian. @rfm how do you reconfigure autoconf in gnustep-base?

```objc
#import <Foundation/Foundation.h>
#import <pthread.h>

int main() {
				@autoreleasepool {
								pthread_setname_np("Hello World");
								NSLog(@"Current Thread: %@", [[NSThread currentThread] name]);
								[[NSThread currentThread] setName:@"Test"];
								NSLog(@"Current Thread: %@", [[NSThread currentThread] name]);
								pthread_setname_np("Hello World");
								NSLog(@"Current Thread: %@", [[NSThread currentThread] name]);
				}
				return 0;
}
```

Output on macOS:
```sh
hugo@w192-m-v4 ~ % ./a.out
hugo@w192-m-v4 ~ % ./a.out
2024-04-18 23:40:31.432 a.out[24036:1426738] Current Thread: Hello World
2024-04-18 23:40:31.432 a.out[24036:1426738] Current Thread: Test
2024-04-18 23:40:31.432 a.out[24036:1426738] Current Thread: Test
```

Foundation's NSThreads implementation seems to retrieve the current thread's name in the initialiser. -[NSThread name] returns nil, until a name is set with -[NSThread setName:].