### PR TITLE
Map `CURLE_COULDNT_CONNECT` to `NSURLErrorCannotConnectToHost`

### DIFF
--- a/Source/GSEasyHandle.m
+++ b/Source/GSEasyHandle.m
@@ -325,6 +325,10 @@ curl_socket_function(void *userdata, curl_socket_t fd, curlsocktype type)
       {
         return NSURLErrorTimedOut;
       }
+    else if (easyCode == CURLE_COULDNT_CONNECT) 
+      {
+        return NSURLErrorCannotConnectToHost;
+      }
     else if (easyCode == CURLE_OPERATION_TIMEDOUT) 
       {
         return NSURLErrorTimedOut;

--- a/Source/GSMultiHandle.m
+++ b/Source/GSMultiHandle.m
@@ -8,6 +8,7 @@
 #import "Foundation/NSException.h"
 #import "Foundation/NSURLError.h"
 #import "Foundation/NSURLSession.h"
+#import "Foundation/NSValue.h"
 
 @interface GSMultiHandle ()
 - (void) readAndWriteAvailableDataOnSocket: (curl_socket_t)socket;
@@ -287,7 +288,7 @@ static int curl_timer_function(CURL *easyHandle, int timeout, void *userdata) {
         }
       err = [NSError errorWithDomain: NSURLErrorDomain 
                                 code: errCode 
-                            userInfo: @{NSLocalizedDescriptionKey : d}];
+                            userInfo: @{NSLocalizedDescriptionKey : d, NSUnderlyingErrorKey: [NSNumber numberWithInt:easyCode]}];
       RELEASE(d);
     }
 


### PR DESCRIPTION
When connecting to an IPv6 socket fails, curl easy will return `CURLE_COULDNT_CONNECT`.  GNUstep currently maps `easyCode == CURLE_COULDNT_CONNECT && failureErrno == ETIMEDOUT` to `NSURLErrorTimedOut`, in all other scenarios `CURLE_COULDNT_CONNECT` is not handled.

This would cause the `NSURLSession/test01` to fail on (certain) systems with IPv6 enabled.

This PR maps all other values of `CURLE_COULDNT_CONNECT` to `NSURLErrorCannotConnectToHost`.
Additionally, it also stores the value of `easyCode` in the `NSUnderlyingErrorKey` to make troubleshooting (slightly) easier.