### PR TITLE
Use AC_SEARCH_LIBS instead of AC_CHECK_LIB for sframe

### DIFF
--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -412,6 +412,9 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #undef HAVE_LIBZ
 
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+#undef HAVE_LIBZSTD
+
 /* Define to 1 if you have the <limits.h> header file. */
 #undef HAVE_LIMITS_H
 

--- a/configure
+++ b/configure
@@ -9505,13 +9505,12 @@ _ACEOF
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for sframe_decode in -lsframe" >&5
-$as_echo_n "checking for sframe_decode in -lsframe... " >&6; }
-if ${ac_cv_lib_sframe_sframe_decode+:} false; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sframe" >&5
+$as_echo_n "checking for library containing sframe... " >&6; }
+if ${ac_cv_search_sframe+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsframe  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9521,32 +9520,44 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char sframe_decode ();
+char sframe ();
 int
 main ()
 {
-return sframe_decode ();
+return sframe ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_sframe_sframe_decode=yes
-else
-  ac_cv_lib_sframe_sframe_decode=no
+for ac_lib in '' sframe_decode; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_sframe=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_sframe+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_sframe_sframe_decode" >&5
-$as_echo "$ac_cv_lib_sframe_sframe_decode" >&6; }
-if test "x$ac_cv_lib_sframe_sframe_decode" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBSFRAME 1
-_ACEOF
+done
+if ${ac_cv_search_sframe+:} false; then :
 
-  LIBS="-lsframe $LIBS"
+else
+  ac_cv_search_sframe=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sframe" >&5
+$as_echo "$ac_cv_search_sframe" >&6; }
+ac_res=$ac_cv_search_sframe
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2454,7 +2454,7 @@ AC_CHECK_LIB(intl, libintl_fprintf)
 AC_CHECK_LIB(zstd, ZSTD_compress)
 AC_CHECK_LIB(iberty, dyn_string_append)
 AC_CHECK_LIB(z, gzseek)
-AC_CHECK_LIB(sframe, sframe_decode)
+AC_SEARCH_LIBS(sframe, sframe_decode)
 AC_CHECK_LIB(bfd, bfd_openr)
 
 AC_TRY_COMPILE([


### PR DESCRIPTION
Commit 4515e4a28b63ccd3e715cb21736e95242d671843 introduced a `AC_CHECK_LIB(sframe, sframe_decode)` in `configure.ac`. 

This causes libs-base to take a hard dependency on `libsframe`; `AC_CHECK_LIB` will prepend `lsframe` to LIBS even if the library is not found.  This results in a build failure on systems that don't have libsframe installed (and on which libsframe isn't available).  For example, libsframe is not available on Enterprise Linux (e.g. Rocky Linux).

This PR slightly modifies the original commit by using `AC_SEARCH_LIBS` making the library optional.