### PR TITLE
Add a CI job for Rocky Linux 9

### DIFF
--- a/.github/scripts/dependencies.sh
+++ b/.github/scripts/dependencies.sh
@@ -14,7 +14,7 @@ install_gnustep_make() {
     if [ -n "$RUNTIME_VERSION" ]; then
       MAKE_OPTS="$MAKE_OPTS --with-runtime-abi=$RUNTIME_VERSION"
     fi
-    ./configure --prefix=$INSTALL_PATH --with-library-combo=$LIBRARY_COMBO $MAKE_OPTS || cat config.log
+    ./configure --prefix=$INSTALL_PATH --with-library-combo=$LIBRARY_COMBO --with-libdir=$LIBDIR $MAKE_OPTS || cat config.log
     make install
 
     echo Objective-C build flags:
@@ -49,14 +49,15 @@ install_libdispatch() {
     mkdir libdispatch/build
     cd libdispatch/build
     # -Wno-error=void-pointer-to-int-cast to work around build error in queue.c due to -Werror
+    # -Wno-error=unused-but-set-variable to work around build error in shims/yield.c due to -Werror
     cmake \
       -DBUILD_TESTING=off \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH \
-      -DCMAKE_C_FLAGS="-Wno-error=void-pointer-to-int-cast" \
+      -DCMAKE_C_FLAGS="-Wno-error=void-pointer-to-int-cast -Wno-error=unused-but-set-variable" \
       -DINSTALL_PRIVATE_HEADERS=1 \
       -DBlocksRuntime_INCLUDE_DIR=$INSTALL_PATH/include \
-      -DBlocksRuntime_LIBRARIES=$INSTALL_PATH/lib/libobjc.so \
+      -DBlocksRuntime_LIBRARIES=$INSTALL_PATH/$LIBDIR/libobjc.so \
       ../
     make install
     echo "::endgroup::"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ on:
 
 env:
   APT_PACKAGES: >-
+    git
+    cmake
+    clang
     pkg-config
     libgnutls28-dev
     libffi-dev
@@ -53,6 +56,7 @@ jobs:
   ########### Linux ###########
   linux:
     name: ${{ matrix.name }}
+    container: ${{ matrix.container }}
     runs-on: ubuntu-latest
     # don't run pull requests from local branches twice
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
@@ -62,11 +66,13 @@ jobs:
       matrix:
         include:
           - name: Ubuntu x64 GCC
+            container: ubuntu:22.04
             library-combo: gnu-gnu-gnu
             CC: gcc
             CXX: g++
 
           - name: Ubuntu x64 Clang gnustep-2.0
+            container: ubuntu:22.04
             library-combo: ng-gnu-gnu
             runtime-version: gnustep-2.0
             CC: clang
@@ -92,12 +98,12 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt-get -q -y update
-          sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_${{ matrix.library-combo == 'ng-gnu-gnu' && 'clang' || 'gcc' }}
+          apt-get -q -y update
+          apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_${{ matrix.library-combo == 'ng-gnu-gnu' && 'clang' || 'gcc' }}
 
           # gnustep-2.0 runtime requires ld.gold or lld
           if [ "$RUNTIME_VERSION" = "gnustep-2.0" ]; then
-            sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
+            update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
           fi
 
       - name: Install dependencies
@@ -109,7 +115,7 @@ jobs:
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
           ./configure
-          make && make install
+          make -j$(nproc) && make install
 
       - name: Run tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,23 @@ env:
   APT_PACKAGES_clang: >-
     libpthread-workqueue-dev
 
+  RPM_PACKAGES: >-
+    which
+    gzip
+    git
+    cmake
+    clang
+    lld
+    pkg-config
+    gnutls-devel
+    gnutls-utils
+    libcurl-devel
+    libffi-devel
+    libicu-devel
+    libxml2-devel
+    libxslt-devel
+    glibc-gconv-extra
+
   # GNUstep Windows MSVC toolchain release tag to be used (keep up to date with latest release):
   # https://github.com/gnustep/tools-windows-msvc/releases
   TOOLS_WINDOWS_MSVC_RELEASE_TAG: release-20230104
@@ -70,6 +87,7 @@ jobs:
             library-combo: gnu-gnu-gnu
             CC: gcc
             CXX: g++
+            libdir: lib
 
           - name: Ubuntu x64 Clang gnustep-2.0
             container: ubuntu:22.04
@@ -77,6 +95,15 @@ jobs:
             runtime-version: gnustep-2.0
             CC: clang
             CXX: clang++
+            libdir: lib
+
+          - name: Rocky Linux x64 Clang gnustep-2.0
+            container: rockylinux:9
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-2.0
+            CC: clang
+            CXX: clang++
+            libdir: lib64
 
     env:
       SRC_PATH: ${{ github.workspace }}/source
@@ -86,6 +113,7 @@ jobs:
       CXX: ${{ matrix.CXX }}
       LIBRARY_COMBO: ${{ matrix.library-combo }}
       RUNTIME_VERSION: ${{ matrix.runtime-version }}
+      LIBDIR: ${{ matrix.libdir }}
 
     defaults:
       run:
@@ -96,7 +124,7 @@ jobs:
         with:
           path: ${{ env.SRC_PATH }}
 
-      - name: Install packages
+      - name: Install apt packages
         run: |
           apt-get -q -y update
           apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_${{ matrix.library-combo == 'ng-gnu-gnu' && 'clang' || 'gcc' }}
@@ -105,6 +133,17 @@ jobs:
           if [ "$RUNTIME_VERSION" = "gnustep-2.0" ]; then
             update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
           fi
+        if: ${{ startsWith(matrix.container, 'ubuntu') }}
+
+      - name: Install rpm packages
+        run: |
+          yum install -y $RPM_PACKAGES
+
+          # gnustep-2.0 runtime requires ld.gold or lld
+          if [ "$RUNTIME_VERSION" = "gnustep-2.0" ]; then
+            update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 10
+          fi
+        if: ${{ startsWith(matrix.container, 'rockylinux') }}
 
       - name: Install dependencies
         env:
@@ -207,6 +246,7 @@ jobs:
       MSYS2_ARG_CONV_EXCL: --prefix=
       # provide GitHub token to scripts to prevent rate limit errors when accessing GitHub
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LIBDIR: lib
 
     defaults:
       run:


### PR DESCRIPTION
4515e4a28b63ccd3e715cb21736e95242d671843 inadvertently broke building libs-base on Enterprise Linux (e.g. Rocky Linux).  #389 fixes the build, and this PR adds a CI job for Rocky Linux 9, hopefully helping us catch these errors when a PR for such changes gets raised.

It:
- Runs the Ubuntu 22.04 and Rocky Linux 9 jobs in a container
- Accounts for the lib/lib64 difference between Ubuntu & Rocky Linux

#389 and #388 are required to make this build succeed.