### PR TITLE
Remove Ubuntu x64 Clang gnustep-1.9 build leg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,12 +66,6 @@ jobs:
             CC: gcc
             CXX: g++
 
-          - name: Ubuntu x64 Clang gnustep-1.9
-            library-combo: ng-gnu-gnu
-            runtime-version: gnustep-1.9
-            CC: clang
-            CXX: clang++
-
           - name: Ubuntu x64 Clang gnustep-2.0
             library-combo: ng-gnu-gnu
             runtime-version: gnustep-2.0


### PR DESCRIPTION
This build has been broken for a while, and I'm going to assume most users are on the 2.0 ABI by now.