### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,14 +162,13 @@ jobs:
           make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Logs - ${{ matrix.name }}
           path: |
-            ${{ env.SRC_PATH }}/config.log
-            ${{ env.SRC_PATH }}/Tests/tests.log
-
+            source/config.log
+            source/Tests/tests.log
 
   ########### Windows ###########
   windows:
@@ -386,10 +385,10 @@ jobs:
           make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Logs - ${{ matrix.name }}
           path: |
-            ${{ env.SRC_PATH }}/config.log
-            ${{ env.SRC_PATH }}/Tests/tests.log
+            source/config.log
+            source/Tests/tests.log


### PR DESCRIPTION
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024, so upgrade to v4.

Also hardcode the paths to `source/config.log` and `source/Tests/tests.log`, for some reason test logs weren't always captured and this fixes that.