### PR TITLE
NotificationCenter removeObserver

### DIFF
--- a/Headers/Foundation/NSNotification.h
+++ b/Headers/Foundation/NSNotification.h
@@ -42,6 +42,7 @@ extern "C" {
 @class NSDictionary;
 @class NSLock;
 @class NSOperationQueue;
+@class NSMutableArray;
 
 typedef NSString* NSNotificationName;
 

--- a/Headers/Foundation/NSNotification.h
+++ b/Headers/Foundation/NSNotification.h
@@ -74,7 +74,8 @@ GS_EXPORT_CLASS
 {
 #if	GS_EXPOSE(NSNotificationCenter)
 @private
-  void	*_table;
+  void	         *_table;
+  NSMutableArray *retainedObserverList;
 #endif
 }
 

--- a/Headers/Foundation/NSNotification.h
+++ b/Headers/Foundation/NSNotification.h
@@ -75,7 +75,7 @@ GS_EXPORT_CLASS
 #if	GS_EXPOSE(NSNotificationCenter)
 @private
   void	         *_table;
-  NSMutableArray *retainedObserverList;
+  NSMutableArray *_retainedObserverArray;
 #endif
 }
 

--- a/Headers/Foundation/NSNotification.h
+++ b/Headers/Foundation/NSNotification.h
@@ -42,7 +42,6 @@ extern "C" {
 @class NSDictionary;
 @class NSLock;
 @class NSOperationQueue;
-@class NSMutableArray;
 
 typedef NSString* NSNotificationName;
 
@@ -76,7 +75,6 @@ GS_EXPORT_CLASS
 #if	GS_EXPOSE(NSNotificationCenter)
 @private
   void	         *_table;
-  NSMutableArray *_retainedObserverArray;
 #endif
 }
 

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -1052,13 +1052,6 @@ static NSNotificationCenter *default_center = nil;
     }
   unlockNCTable(TABLE);
 
-  /* As a special case GSNotificationObserver instances are owned by the
-   * notification center and are released when they are removed.
-   */
-  if (object_getClass(observer) == GSNotificationObserverClass)
-    {
-      RELEASE(observer);
-    }
 }
 
 /**

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -36,6 +36,7 @@
 #import "Foundation/NSLock.h"
 #import "Foundation/NSOperation.h"
 #import "Foundation/NSThread.h"
+#import "Foundation/NSArray.h"
 #import "GNUstepBase/GSLock.h"
 
 static NSZone	*_zone = 0;

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -720,7 +720,6 @@ static NSNotificationCenter *default_center = nil;
   if ((self = [super init]) != nil)
     {
       _table = newNCTable();
-      _retainedObserverArray = [[NSMutableArray alloc] init];
     }
   return self;
 }

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -738,7 +738,7 @@ static NSNotificationCenter *default_center = nil;
    * Release all memory used to store Observations etc.
    */
   endNCTable(TABLE);
-  [_retainedObserverArray release];
+  RELEASE(_retainedObserverArray);
 }
 
 
@@ -1078,7 +1078,7 @@ static NSNotificationCenter *default_center = nil;
   if (needToRelease)
     {
       [_retainedObserverArray removeObject:observer];
-      [observer release];
+      RELEASE(observer);
     }
     
   unlockNCTable(TABLE);


### PR DESCRIPTION
This modifies the NotificationCenter class to do the following:
  - add an ivar to the class for an array to hold observers that need to be released when they are removed
  - adds an observer to that array if the observer is of class GSNotificationObserver
  - upon removing an observer, check if it is in that array, if so remove it from the array and release it.
 
This replaces the previous implementation which checked the class of the observer as it was being removed, which would cause a crash if the observer had been deallocated.