### PR TITLE
Fix NSString ICU includes for Windows

### DIFF
--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -750,6 +750,9 @@
 /* Define if libobjc has the _objc_unexpected_exception callback */
 #undef HAVE_UNEXPECTED
 
+/* Define to 1 if you have the <unicode/ubrk.h> header file. */
+#undef HAVE_UNICODE_UBRK_H
+
 /* Define to 1 if you have the <unicode/ucal.h> header file. */
 #undef HAVE_UNICODE_UCAL_H
 
@@ -791,6 +794,9 @@
 
 /* Define to 1 if you have the <unicode/utext.h> header file. */
 #undef HAVE_UNICODE_UTEXT_H
+
+/* Define to 1 if you have the <unicode/utypes.h> header file. */
+#undef HAVE_UNICODE_UTYPES_H
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -66,11 +66,13 @@
 #import "Foundation/NSLocale.h"
 #import "Foundation/NSLock.h"
 #import "Foundation/NSNotification.h"
+#import "Foundation/NSObjCRuntime.h"
 #import "Foundation/NSScanner.h"
 #import "Foundation/NSUserDefaults.h"
 #import "Foundation/FoundationErrors.h"
 // For private method _decodePropertyListForKey:
 #import "Foundation/NSKeyedArchiver.h"
+#import "GNUstepBase/GSBlocks.h"
 #import "GNUstepBase/GSMime.h"
 #import "GNUstepBase/NSString+GNUstepBase.h"
 #import "GNUstepBase/NSMutableString+GNUstepBase.h"
@@ -102,23 +104,21 @@
 #if	defined(HAVE_UNICODE_UNORM2_H)
 # include <unicode/unorm2.h>
 #endif
-#if     defined(HAVE_UNICODE_USTRING_H)
+#if	defined(HAVE_UNICODE_USTRING_H)
 # include <unicode/ustring.h>
 #endif
-#if     defined(HAVE_UNICODE_USEARCH_H)
+#if	defined(HAVE_UNICODE_USEARCH_H)
 # include <unicode/usearch.h>
 #endif
-#if     defined(HAVE_ICU_H)
+#if	defined(HAVE_UNICODE_UBRK_H)
+# include <unicode/ubrk.h>
+#endif
+#if	defined(HAVE_UNICODE_UTYPES_H)
+# include <unicode/utypes.h>
+#endif
+#if	defined(HAVE_ICU_H)
 # include <icu.h>
 #endif
-
-#import "Foundation/NSObjCRuntime.h"
-#import "GNUstepBase/GSBlocks.h"
-#if GS_USE_ICU
-#include <unicode/ubrk.h>
-#include <unicode/utypes.h>
-#endif
-
 
 /* Create local inline versions of key functions for case-insensitive operations
  */

--- a/Tests/base/NSURLConnection/test02.m
+++ b/Tests/base/NSURLConnection/test02.m
@@ -15,7 +15,7 @@ int main(int argc, char **argv, char **env)
   NSString *helperPath;
 
 #if defined(_WIN64) && defined(_MSC_VER)
-  NSLog(@"Marking tests as hopeful because they are known to fail on 64-bit Windows with Clang/MSVC.")
+  NSLog(@"Marking tests as hopeful because they are known to fail on 64-bit Windows with Clang/MSVC.");
   testHopeful = YES;
 #endif
 

--- a/configure
+++ b/configure
@@ -13601,7 +13601,7 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-      for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h
+      for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h unicode/ubrk.h unicode/utypes.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -3571,7 +3571,7 @@ AS_IF([test "x$enable_icu" = "xyes"], [
   esac
   if test $HAVE_ICU = 0; then
     PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0], [
-      AC_CHECK_HEADERS([unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h],
+      AC_CHECK_HEADERS([unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h unicode/ubrk.h unicode/utypes.h],
         HAVE_ICU=1)], [HAVE_ICU=0])
   fi
   if test $HAVE_ICU = 0; then


### PR DESCRIPTION
Fixes building with the Windows-bundled ICU libraries (was broken with #370).

This wasn’t caught by CI because it’s still using Windows 2019 agents which don’t have the ICU library. I’ll open a separate PR to update this.