### PR TITLE
fix: wrap aFormat with NSNumber

### DIFF
--- a/Source/Additions/NSPropertyList+GNUstepBase.m
+++ b/Source/Additions/NSPropertyList+GNUstepBase.m
@@ -642,7 +642,7 @@ OAppend(id obj, NSDictionary *loc, unsigned lev, unsigned step,
       return dest;
     }
   return (*(id(*)(id,SEL,id,id,id))originalImp)
-    (self, _cmd, aPropertyList, aFormat, anErrorString);
+    (self, _cmd, aPropertyList, [NSNumber numberWithInt:aFormat], anErrorString);
 }
 
 + (void) load


### PR DESCRIPTION
seeing build failure as below:

```
  NSPropertyList+GNUstepBase.m:645:33: error: incompatible integer to pointer conversion passing 'NSPropertyListFormat' (aka 'enum NSPropertyListFormat') to parameter of type 'id' [-Wint-conversion]
      (self, _cmd, aPropertyList, aFormat, anErrorString);
                                  ^~~~~~~
  1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/173267