### PR TITLE
-[NSFileHandle initWithFileDescriptor:] logs a message each time fstat() doesn't succeed on UNIX

### DIFF
--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -1108,11 +1108,6 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 	   */
 	  isStandardFile = NO;
 #else
-	  /* This should never happen on unix.  If it does, we have somehow
-	   * ended up with a bad descriptor.
-	   */
-          NSLog(@"unable to get status of descriptor %d - %@",
-	    desc, [NSError _last]);
 	  isStandardFile = NO;
 #endif
 	}


### PR DESCRIPTION
`fstat()` on UNIX isn't guaranteed to always succeed, even if the file handle is valid. Special files may or may not support `fstat()` in the kernel.

(For context, I'm working on a Vulkan application. Vulkan has facilities to send certain objects across processes by representing the objects as file descriptors. These file descriptors still need to be `close()`d, which makes them good candidates for wrapping an NSFileHandle around them, but they do not support `fstat()`. I'm creating multiple of these each frame in the application, which means the line "unable to get status of descriptor" appears very often in the terminal while my application is running.)