### PR TITLE
Implement -[NSFileManager URLsForDirectory:inDomains:]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-06-10 Marco Rebhan <me@dblsaiko.net>
+
+  * Headers/Foundation/NSFileManager.h:
+  * Source/NSFileManager.m:
+  Implement -[NSFileManager URLsForDirectory:inDomains:].
+
 2024-06-10 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/GSFileHandle.m: debug log of closing a closed file handle

--- a/Headers/Foundation/NSFileManager.h
+++ b/Headers/Foundation/NSFileManager.h
@@ -357,6 +357,21 @@ GS_EXPORT_CLASS
                      error: (NSError **)error;
 
 /**
+ * Returns an array of search paths to look at for resources.<br/ >
+ * The paths are returned in domain order:
+ * USER, LOCAL, NETWORK then SYSTEM.<br />
+ * The presence of a path in this list does <em>not</em> mean that the
+ * path actually exists in the filesystem.<br />
+ * If you are wanting to locate an existing resource, you should normally
+ * call this method with NSAllDomainsMask, but if you wish to find the
+ * path in which you should create a new file, you would generally
+ * specify a particular domain, and then create the path in the file
+ * system if it does not already exist.
+ */
+- (GS_GENERIC_CLASS(NSArray, NSURL *) *)URLsForDirectory: (NSSearchPathDirectory)directory
+                                               inDomains: (NSSearchPathDomainMask)domain;
+
+/**
  * Enumerate over the contents of a directory.
  */
 - (NSDirectoryEnumerator *)enumeratorAtURL: (NSURL *)url

--- a/MISSING
+++ b/MISSING
@@ -200,7 +200,6 @@ NSFileManager:
 
 	- mountedVolumeURLsIncludingResourceValuesForKeys:options:
 	- contentsOfDirectoryAtURL:includingPropertiesForKeys:options:error:
-	- URLsForDirectory:inDomains:
 	- createDirectoryAtURL:withIntermediateDirectories:attributes:error:
 	- createSymbolicLinkAtURL:withDestinationURL:error:
 	- setDelegate:

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -59,6 +59,7 @@
 #import "Foundation/NSSet.h"
 #import "Foundation/NSURL.h"
 #import "Foundation/NSValue.h"
+#import "GSFastEnumeration.h"
 #import "GSPrivate.h"
 #import "GSPThread.h"
 #import "GNUstepBase/NSString+GNUstepBase.h"
@@ -923,6 +924,20 @@ static gs_mutex_t       classLock = GS_MUTEX_INIT_STATIC;
       }
   
   return [NSURL fileURLWithPath: path];
+}
+
+- (GS_GENERIC_CLASS(NSArray, NSURL *) *)URLsForDirectory: (NSSearchPathDirectory)directory
+                                               inDomains: (NSSearchPathDomainMask)domain
+{
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(directory, domain, YES);
+  NSMutableArray *urls = [[NSMutableArray alloc] initWithCapacity: paths.count];
+
+  FOR_IN(NSString *, path, paths)
+    [urls addObject: [NSURL fileURLWithPath: path]];
+  END_FOR_IN(paths)
+
+  RELEASE(paths);
+  return urls;
 }
 
 - (NSDirectoryEnumerator*) enumeratorAtURL: (NSURL*)url


### PR DESCRIPTION
This behaves like NSSearchPathForDirectoriesInDomains (at least, superficially. Not sure if Apple's implementation has some special behavior on top that their documentation doesn't mention.)

The documentation comment is copied from NSSearchPathForDirectoriesInDomains.