### PR TITLE
Update `-[NSMutableArray removeLastObject]`

### DIFF
--- a/Source/GSArray.m
+++ b/Source/GSArray.m
@@ -669,8 +669,7 @@ static Class	GSInlineArrayClass;
   _version++;
   if (_count == 0)
     {
-      [NSException raise: NSRangeException
-		  format: @"Trying to remove from an empty array."];
+      return;
     }
   _count--;
   RELEASE(_contents_array[_count]);

--- a/Source/NSArray.m
+++ b/Source/NSArray.m
@@ -2187,16 +2187,14 @@ compare(id elem1, id elem2, void* context)
 }
 
 /**
- * Removes the last object in the array.  Raises an exception if the array
- * is already empty.
+ * Removes the last object in the array if one exists (otherwise it just returns).
  */
 - (void) removeLastObject
 {
   NSUInteger	count = [self count];
 
   if (count == 0)
-    [NSException raise: NSRangeException
-		 format: @"Trying to remove from an empty array."];
+    return;
   [self removeObjectAtIndex: count-1];
 }
 

--- a/Source/NSKeyValueMutableArray.m
+++ b/Source/NSKeyValueMutableArray.m
@@ -158,7 +158,12 @@
 
 - (void) removeLastObject
 {
-  [self removeObjectAtIndex: ([self count] - 1)];
+  NSUInteger count = [self count];
+  if (0 == count)
+    {
+      return;
+    }
+  [self removeObjectAtIndex: (count - 1)];
 }
 
 @end
@@ -521,10 +526,15 @@
 - (void) removeLastObject
 {
   NSIndexSet *indexes =  nil;
+  NSUInteger count = [array count];
+  if (0 == count)
+    {
+      return;
+    }
 
   if (notifiesObservers)
     {
-      indexes = [NSIndexSet indexSetWithIndex: [array count] - 1];
+      indexes = [NSIndexSet indexSetWithIndex: count - 1];
       [object willChange: NSKeyValueChangeRemoval
          valuesAtIndexes: indexes
                   forKey: key];

--- a/Tests/base/NSMutableArray/general.m
+++ b/Tests/base/NSMutableArray/general.m
@@ -116,6 +116,13 @@ int main()
     [ma release];
     PASS(5 == before && 0 == after, "-removeObjectsInArray: works for self")
   }
+  {
+    NSMutableArray *ma = [NSMutableArray new];
+      
+    PASS_RUNS([ma removeLastObject],
+              "-removeLastObject does not raise exceptions on empty array")
+    [ma release];
+  }
   [arp release]; arp = nil;
   return 0;
 }


### PR DESCRIPTION
Updates the `-[NSMutableArray removeLastObject]` implementation to avoid raising an exception if the array is already empty. 

This brings the behavior of `-[NSMutableArray removeLastObject]` inline with the Apple implementation, improving compatibility for code bases which use both GNUStep and Apple objc/Foundation implementations.

RE: https://github.com/gnustep/libs-base/issues/432