### PR TITLE
NSThread: Fix `threadPriority` and `setThreadPriority:` on Android by using `setpriority` instead of pthread

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-12-08 Hugo Melder <hugo@algoriddim.com>
+	* Source/NSThread.m:
+	Fix threadPriority and setThreadPriority: on Android.
+
 2024-08-08 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Tools/AGSHtml.m:


### PR DESCRIPTION
Android's pthread_setschedparam is currently broken, as it checks if the priority is in the range of the system's min and max priorities. The interval bounds are queried with `sched_get_priority_min`, and `sched_get_priority_max` which just return 0, regardless of the specified scheduling policy.
  
   The solution is to use `setpriority` to set the thread priority. This is possible because on Linux, it is not a per-process setting as specified by POSIX but a per-thread setting (See the `Bugs` section in `setpriority`).
