### PR TITLE
Add some missing NSSearchPathDirectory enum types

### DIFF
--- a/Headers/Foundation/NSPathUtilities.h
+++ b/Headers/Foundation/NSPathUtilities.h
@@ -131,9 +131,16 @@ enum
   NSDownloadsDirectory = 15,	        /** location of downloaded files */
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+  NSInputMethodsDirectory = 16,         /** location of Library/Input methods */
   NSMoviesDirectory = 17,	        /** location of video/movie files */
   NSMusicDirectory = 18,	        /** location of music files */
   NSPicturesDirectory = 19,	        /** location of picture/images files */
+  NSPrinterDescriptionDirectory = 20,   /** location of system's PPDs directory */
+  NSSharedPublicDirectory = 21,		/** location of user's Public sharing directory */
+  NSPreferencePanesDirectory = 22,	/** location of the PreferencePanes directory for use with System Preferences */
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
+  NSApplicationScriptsDirectory = 23,	/** location of the user scripts folder for the calling application */
+#endif
   NSItemReplacementDirectory = 99,      /** pass to URLFirDirectory:inDomain:
                                             appropriateForURL:create:error to create a temporary directory */
 #endif  


### PR DESCRIPTION
As found here: https://web.archive.org/web/20131113010445/https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/Reference/reference.html