### PR TITLE
Add typedef NSKeyValueChangeKey to NSKeyValueObserving.h

### DIFF
--- a/Headers/Foundation/NSKeyValueObserving.h
+++ b/Headers/Foundation/NSKeyValueObserving.h
@@ -72,6 +72,9 @@ GS_EXPORT NSString *const NSKeyValueChangeOldKey;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5,GS_API_LATEST)
 GS_EXPORT NSString *const NSKeyValueChangeNotificationIsPriorKey;
 #endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12,GS_API_LATEST)
+typedef NSString *NSKeyValueChangeKey;
+#endif
 
 /* Given that the receiver has been registered as an observer
  * of the value at a key path relative to an object,


### PR DESCRIPTION
tinkering with KVO, ChatGPT told me to implement observeValueForKeyPath: ... alike:

```
- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
```

Instead of replacing with NSString *, this tiny change allows me to do as advised.

Documented here:
https://developer.apple.com/documentation/foundation/nskeyvaluechangekey?language=objc
