### PR TITLE
Add getOffset:error: implementation to base

### DIFF
--- a/Headers/Foundation/NSFileHandle.h
+++ b/Headers/Foundation/NSFileHandle.h
@@ -76,6 +76,9 @@ GS_EXPORT_CLASS
 - (NSData*) readDataToEndOfFile;
 - (NSData*) readDataOfLength: (unsigned int)len;
 - (void) writeData: (NSData*)item;
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
+- (BOOL) getOffset: (unsigned long long *)offsetInFile error: (NSError **)error;
+#endif
 
 // Asynchronous I/O operations
 

--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -1439,7 +1439,6 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
     }
 }
 
-
 // Asynchronous I/O operations
 
 - (void) acceptConnectionInBackgroundAndNotifyForModes: (NSArray*)modes

--- a/Source/NSFileHandle.m
+++ b/Source/NSFileHandle.m
@@ -320,6 +320,25 @@ static Class NSFileHandle_ssl_class = nil;
   [self subclassResponsibility: _cmd];
 }
 
+/**
+ * Get the current position in the file.
+ */
+- (BOOL) getOffset: (unsigned long long *)offsetInFile error: (NSError **)error
+{
+  BOOL result = YES;
+
+  // We can do the concrete implementation here since the method relies on
+  // offsetInFile to get the offset.
+  *error = nil;
+  *offsetInFile = [self offsetInFile];
+  if (*offsetInFile == -1)
+    {
+      *offsetInFile = 0;
+      result = NO;
+    }
+
+  return result;
+}
 
 // Asynchronous I/O operations
 


### PR DESCRIPTION
This PR adds the 10.15 method getOffset:error: to NSFileHandle.