### PR TITLE
Fix CI

### DIFF
--- a/configure
+++ b/configure
@@ -5696,20 +5696,14 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler is clang" >&5
 printf %s "checking whether the compiler is clang... " >&6; }
-if test ! x"${GCC}" = x"yes" ; then
+if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+  CLANG_CC=yes
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else
   CLANG_CC=no
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-else
-  if "${CC}" -v 2>&1 | grep -q 'clang version'; then
-    CLANG_CC=yes
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-  else
-    CLANG_CC=no
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-  fi
 fi
 
 

--- a/configure
+++ b/configure
@@ -5696,7 +5696,9 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler is clang" >&5
 printf %s "checking whether the compiler is clang... " >&6; }
-if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+# CC may have flags appended to it, so we need to extract the actual
+# compiler name.
+if "$(echo "${CC}" | awk '{print $1}')" -v 2>&1 | grep -q 'clang version'; then
   CLANG_CC=yes
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }

--- a/configure
+++ b/configure
@@ -7624,29 +7624,31 @@ fi
 # Windows: check if we have native threading APIs and SRW locks
 #--------------------------------------------------------------------
 HAVE_WIN32_THREADS_AND_LOCKS=0
-case "$target_os" in
-  mingw*|windows)
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for native Windows threads and locks" >&5
+if test "$CLANG_CC" = "yes"; then
+  case "$target_os" in
+    mingw*|windows)
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for native Windows threads and locks" >&5
 printf %s "checking for native Windows threads and locks... " >&6; }
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-        #define GS_USE_WIN32_THREADS_AND_LOCKS 1
-        #include "$srcdir/Source/GSPThread.h"
+          #define GS_USE_WIN32_THREADS_AND_LOCKS 1
+          #include "$srcdir/Source/GSPThread.h"
 
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-      HAVE_WIN32_THREADS_AND_LOCKS=1
+        HAVE_WIN32_THREADS_AND_LOCKS=1
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    ;;
-esac
+      ;;
+  esac
+fi
 
 
 #--------------------------------------------------------------------
@@ -14511,16 +14513,12 @@ fi
     HAVE_LIBDISPATCH_RUNLOOP=1
   fi
   # Check for availability of functions in more recent libdispatch versions.
-  for ac_func in dispatch_cancel
-do :
   ac_fn_c_check_func "$LINENO" "dispatch_cancel" "ac_cv_func_dispatch_cancel"
-if test "x$ac_cv_func_dispatch_cancel" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_DISPATCH_CANCEL 1
-_ACEOF
+if test "x$ac_cv_func_dispatch_cancel" = xyes
+then :
+  printf "%s\n" "#define HAVE_DISPATCH_CANCEL 1" >>confdefs.h
 
 fi
-done
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1704,19 +1704,21 @@ AC_CHECK_FUNCS(getaddrinfo)
 # Windows: check if we have native threading APIs and SRW locks
 #--------------------------------------------------------------------
 HAVE_WIN32_THREADS_AND_LOCKS=0
-case "$target_os" in
-  mingw*|windows)
-    AC_MSG_CHECKING(for native Windows threads and locks)
-    AC_COMPILE_IFELSE(
-      [AC_LANG_SOURCE([
-        #define GS_USE_WIN32_THREADS_AND_LOCKS 1
-        #include "$srcdir/Source/GSPThread.h"
-      ])],
-      AC_MSG_RESULT([yes])
-      HAVE_WIN32_THREADS_AND_LOCKS=1,
-      AC_MSG_RESULT([no]))
-    ;;
-esac
+if test "$CLANG_CC" = "yes"; then
+  case "$target_os" in
+    mingw*|windows)
+      AC_MSG_CHECKING(for native Windows threads and locks)
+      AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([
+          #define GS_USE_WIN32_THREADS_AND_LOCKS 1
+          #include "$srcdir/Source/GSPThread.h"
+        ])],
+        AC_MSG_RESULT([yes])
+        HAVE_WIN32_THREADS_AND_LOCKS=1,
+        AC_MSG_RESULT([no]))
+      ;;
+  esac
+fi
 AC_SUBST(HAVE_WIN32_THREADS_AND_LOCKS)
 
 #--------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1120,7 +1120,9 @@ AC_PROG_CPP
 AC_USE_SYSTEM_EXTENSIONS
 
 AC_MSG_CHECKING(whether the compiler is clang)
-if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+# CC may have flags appended to it, so we need to extract the actual
+# compiler name.
+if "$(echo "${CC}" | awk '{print $1}')" -v 2>&1 | grep -q 'clang version'; then
   CLANG_CC=yes
   AC_MSG_RESULT(yes)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -1120,17 +1120,12 @@ AC_PROG_CPP
 AC_USE_SYSTEM_EXTENSIONS
 
 AC_MSG_CHECKING(whether the compiler is clang)
-if test ! x"${GCC}" = x"yes" ; then
+if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+  CLANG_CC=yes
+  AC_MSG_RESULT(yes)
+else
   CLANG_CC=no
   AC_MSG_RESULT(no)
-else
-  if "${CC}" -v 2>&1 | grep -q 'clang version'; then
-    CLANG_CC=yes
-    AC_MSG_RESULT(yes)
-  else
-    CLANG_CC=no
-    AC_MSG_RESULT(no)
-  fi
 fi
 AC_SUBST(CLANG_CC)
 


### PR DESCRIPTION
The build system is really fragile.

`if "${CC}" -v 2>&1 | grep -q 'clang version'` does not work when the `CC` variable consists of more than one word, as it is treated as the executable.