### PR TITLE
Add unit tests for GSFFIInvocation

### DIFF
--- a/Tests/base/GSFFIInvocation/basic.m
+++ b/Tests/base/GSFFIInvocation/basic.m
@@ -1,0 +1,114 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+@protocol NSMenuItem <NSObject>
+- (NSString*) keyEquivalent;
+- (void) setKeyEquivalent: (NSString*)aKeyEquivalent;
+@end
+
+@interface NSMenuItem : NSObject <NSMenuItem>
+{
+  NSString *_keyEquivalent;
+}
+@end
+
+@implementation NSMenuItem
+- (void) setKeyEquivalent: (NSString*)aKeyEquivalent
+{
+  ASSIGNCOPY(_keyEquivalent,  aKeyEquivalent);
+}
+
+- (NSString*) keyEquivalent
+{
+  return _keyEquivalent;
+}
+@end
+
+@interface GSFakeNSMenuItem : NSObject
+{
+  NSMenuItem* _originalItem;
+}
+
+- (id) initWithItem: (NSMenuItem*)item;
+- (NSMenuItem*) originalItem;
+- (id) target;
+- (SEL)action;
+- (void) action: (id)sender;
+@end
+
+@implementation GSFakeNSMenuItem
+- (id) initWithItem: (NSMenuItem*)item
+{
+  self = [super init];
+  if (self)
+  {
+    _originalItem = item;
+  }
+  return self;
+}
+
+- (NSMenuItem*) originalItem
+{
+  return _originalItem;
+}
+
+- (id)target
+{
+  return self;
+}
+
+- (SEL)action
+{
+  return @selector(action:);
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector
+{
+  if ([_originalItem respondsToSelector:selector])
+    return _originalItem;
+  return nil;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL selector = [invocation selector];
+
+  // Forward any invocation to the original item if it supports it...
+  if ([_originalItem respondsToSelector:selector])
+    [invocation invokeWithTarget:_originalItem];
+}
+
+-(NSMethodSignature*)methodSignatureForSelector:(SEL)selector
+{
+	NSMethodSignature *signature = [[_originalItem class] instanceMethodSignatureForSelector:selector];
+	if(signature == nil)
+	{
+		signature = [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
+	}
+	return(signature);
+}
+
+- (void)doesNotRecognizeSelector:(SEL)selector
+{
+  NSLog(@"%s:selector not recognized: %@", __PRETTY_FUNCTION__, NSStringFromSelector(selector));
+}
+@end
+
+int main(int argc,char **argv)
+{
+  START_SET("GSFFIInvocation")
+
+  NSMenuItem *item = [NSMenuItem alloc];
+  [item setKeyEquivalent:@"Hello, World!"];
+
+  GSFakeNSMenuItem *fakeItem = [[GSFakeNSMenuItem alloc] initWithItem:item];
+
+  NSString *itemKeyEquivalent = [item keyEquivalent];
+  NSString *fakeItemKeyEquivalent = [fakeItem keyEquivalent];
+
+  NSLog(@"Item key equivalent: %@, fake item key equivalent: %@", itemKeyEquivalent, fakeItemKeyEquivalent);
+
+  END_SET("GSFFIInvocation")
+  return 0;
+}

--- a/Tests/base/GSFFIInvocation/string.m
+++ b/Tests/base/GSFFIInvocation/string.m
@@ -2,43 +2,20 @@
 #import "Testing.h"
 #import "ObjectTesting.h"
 
-@protocol NSMenuItem <NSObject>
-- (NSString*) keyEquivalent;
-- (void) setKeyEquivalent: (NSString*)aKeyEquivalent;
-@end
-
-@interface NSMenuItem : NSObject <NSMenuItem>
+@interface GSFakeNSString : NSObject
 {
-  NSString *_keyEquivalent;
-}
-@end
-
-@implementation NSMenuItem
-- (void) setKeyEquivalent: (NSString*)aKeyEquivalent
-{
-  ASSIGNCOPY(_keyEquivalent,  aKeyEquivalent);
+  NSString* _originalItem;
 }
 
-- (NSString*) keyEquivalent
-{
-  return _keyEquivalent;
-}
-@end
-
-@interface GSFakeNSMenuItem : NSObject
-{
-  NSMenuItem* _originalItem;
-}
-
-- (id) initWithItem: (NSMenuItem*)item;
-- (NSMenuItem*) originalItem;
+- (id) initWithItem: (NSString*)item;
+- (NSString*) originalItem;
 - (id) target;
 - (SEL)action;
 - (void) action: (id)sender;
 @end
 
-@implementation GSFakeNSMenuItem
-- (id) initWithItem: (NSMenuItem*)item
+@implementation GSFakeNSString
+- (id) initWithItem: (NSString*)item
 {
   self = [super init];
   if (self)
@@ -48,7 +25,7 @@
   return self;
 }
 
-- (NSMenuItem*) originalItem
+- (NSString*) originalItem
 {
   return _originalItem;
 }
@@ -99,16 +76,15 @@ int main(int argc,char **argv)
 {
   START_SET("GSFFIInvocation")
 
-  NSMenuItem *item = [NSMenuItem alloc];
-  [item setKeyEquivalent:@"Hello, World!"];
+  NSString *string = @"Hello, World!";
 
-  GSFakeNSMenuItem *fakeItem = [[GSFakeNSMenuItem alloc] initWithItem:item];
+  GSFakeNSString *fakeString = [[GSFakeNSString alloc] initWithItem:string];
 
-  NSString *itemKeyEquivalent = [item keyEquivalent];
-  NSString *fakeItemKeyEquivalent = [fakeItem keyEquivalent];
+  NSString *upperCaseString = [string uppercaseString];
+  NSString *fakeUpperCaseString = [fakeString uppercaseString];
 
-  PASS_EQUAL(itemKeyEquivalent, fakeItemKeyEquivalent, "keyEquivalent selector is forwarded from the fake item to the actual item");
-  NSLog(@"Item key equivalent: %@, fake item key equivalent: %@", itemKeyEquivalent, fakeItemKeyEquivalent);
+  PASS_EQUAL(upperCaseString, fakeUpperCaseString, "uppercaseString selector is forwarded from the fake string to the actual NSString object");
+  NSLog(@"Upper case string: %@, fake upper case string: %@", upperCaseString, fakeUpperCaseString);
 
   END_SET("GSFFIInvocation")
   return 0;


### PR DESCRIPTION
Selector forwarding from one object to another seems to be broken when using libobjc2 on Windows (see also: https://github.com/gnustep/plugins-themes-WinUXTheme/pull/7#issuecomment-2480839795).

This PR contains two tests which both pass on Linux, pass on Windows when using the GCC runtime, and fail on Windows when using libobjc2 to demonstrate the problem (and verify a fix).