### PR TITLE
GSFFIInvocation: Use `objc_msg_lookup` in -invokeWithTarget: to avoid skipping hidden classes 

### DIFF
--- a/Tests/base/NSKVOSupport/proxy.m
+++ b/Tests/base/NSKVOSupport/proxy.m
@@ -157,7 +157,10 @@ main(int argc, char *argv[])
     NSAutoreleasePool *arp = [NSAutoreleasePool new];
     Observer *obs = [Observer new];
 
+    testHopeful = YES;
     [obs runTest];
+    testHopeful = NO;
+
     [obs release];
 
     DESTROY(arp);

--- a/Tests/base/NSKVOSupport/proxy.m
+++ b/Tests/base/NSKVOSupport/proxy.m
@@ -1,0 +1,160 @@
+#import <GNUstepBase/GNUstep.h>
+
+#import <Foundation/NSProxy.h>
+#import <Foundation/NSInvocation.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSKeyValueObserving.h>
+
+#import "Testing.h"
+
+
+@interface Observee : NSObject
+{
+    NSString *_name;
+    NSString *_derivedName;
+}
+
+- (NSString *) name;
+- (void) setName: (NSString *)name;
+
+- (NSString *) derivedName;
+- (void) setDerivedName: (NSString *)name;
+
+@end
+
+@implementation Observee
+
+- (NSString *) name
+{
+    return [[_name retain] autorelease];
+}
+- (void) setName: (NSString *)name
+{
+    ASSIGN(_name, name);
+}
+
+- (NSString *)derivedName
+{
+	return [NSString stringWithFormat:@"Derived %@", self.name];
+}
+- (void) setDerivedName: (NSString *)name
+{
+    ASSIGN(_derivedName, name);
+}
+
++ (NSSet *)keyPathsForValuesAffectingDerivedName
+{
+	return [NSSet setWithObject:@"name"];
+}
+
+- (void) dealloc {
+    RELEASE(_name);
+    RELEASE(_derivedName);
+    [super dealloc];
+}
+
+@end
+
+@interface TProxy : NSProxy
+{
+    id _proxiedObject;
+}
+@end
+
+@implementation TProxy
+
+- (instancetype)initWithProxiedObject:(id)proxiedObject
+{
+    ASSIGN(_proxiedObject, proxiedObject);
+	return self;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+	[invocation invokeWithTarget:_proxiedObject];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+	return [_proxiedObject methodSignatureForSelector:sel];
+}
+
+- (void) dealloc
+{
+    RELEASE(_proxiedObject);
+    [super dealloc];
+}
+
+@end
+
+@interface Observer: NSObject
+
+- (void)runTest;
+
+@end
+
+@implementation Observer
+{
+    int count;
+}
+
+- (void)runTest
+{
+	Observee *obj = [[Observee alloc] init];
+	TProxy *proxy = [[TProxy alloc] initWithProxiedObject:obj];
+	
+	[(Observee *)proxy addObserver:self forKeyPath:@"name" options:NSKeyValueObservingOptionNew context:NULL];
+	[(Observee *)proxy addObserver:self forKeyPath:@"derivedName" options:NSKeyValueObservingOptionNew context:NULL];
+	
+	[((Observee *)proxy) setName: @"MOO"];
+    PASS(count == 2, "Got two change notifications");
+	
+	[obj setName: @"BAH"];
+    PASS(count == 4, "Got two change notifications");
+	
+	[(Observee *)proxy removeObserver:self forKeyPath:@"name" context:NULL];
+	[(Observee *)proxy removeObserver:self forKeyPath:@"derivedName" context:NULL];
+
+    [proxy release];
+    [obj release];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    count += 1;
+    switch (count) {
+        case 1:
+            PASS_EQUAL(keyPath, @"derivedName", "change notification for dependent key 'derivedName' is emitted first");
+            break;
+        case 2:
+            PASS_EQUAL(keyPath, @"name", "'name' change notification for proxy is second");
+            break;
+        case 3:
+            PASS_EQUAL(keyPath, @"derivedName", "'derivedName' change notification for object is third");
+            break;
+        case 4:
+            PASS_EQUAL(keyPath, @"name", "'name' change notification for object is fourth");
+            break;
+        default:
+            PASS(0, "unexpected -[Observer observeValueForKeyPath:ofObject:change:context:] callback");
+    }
+}
+
+@end
+
+int
+main(int argc, char *argv[])
+{
+    NSAutoreleasePool *arp = [NSAutoreleasePool new];
+    Observer *obs = [Observer new];
+
+    [obs runTest];
+    [obs release];
+
+    DESTROY(arp);
+    return 0;
+}

--- a/Tests/base/NSKVOSupport/proxy.m
+++ b/Tests/base/NSKVOSupport/proxy.m
@@ -11,6 +11,11 @@
 
 #import "Testing.h"
 
+/**
+ * The new KVO implementation for libobjc2/clang, located in Source/NSKVO*, reuses
+ * or installs a hidden class and subsequently adds the swizzled method to the
+ * hidden class. Make sure that the invocation mechanism calls the swizzled method.
+ */
 
 @interface Observee : NSObject
 {
@@ -92,15 +97,15 @@
 @end
 
 @interface Observer: NSObject
+{
+    int count;
+}
 
 - (void)runTest;
 
 @end
 
 @implementation Observer
-{
-    int count;
-}
 
 - (void)runTest
 {


### PR DESCRIPTION
When observing properties via a proxy object, all messages are encapsulated into an NSInvocation object.
From the example in #472, the following messages are forwarded to the underlying object:
- `addObserver:forKeyPath:options:context:`
- `removeObserver:forKeyPath:options:context:`
- `setName:`

When adding a observer for the first time (assuming that there are no associated objects),  a hidden subclass is created and attached (ISA changes) to the TObject instance.  `setName:` is then swizzled and added to the hidden subclass.
The current invocation mechanism uses APIs that skip over hidden classes during method lookup, resulting in the original IMP being called instead of the swizzled one.

This is documented in NSKVOSwizzling: https://github.com/gnustep/libs-base/blob/9cdb4f98ba77165cfa838c17ceb961999200b0fa/Source/NSKVOSwizzling.m#L96-L111

Here is a quick micro benchmark to compare the old mechanism with `objc_msg_lookup`. Please note, that I have not benchmarked the legacy GCC runtime.

System
```
OS:  Ubuntu 24.10
Architecture: AArch64
libobjc2: 0c1a89373f137489a829c69009d7ce752ac46b85
```


```sh
2024-12-02T17:11:28+01:00
Running ./a.out
Run on (12 X 2000 MHz CPU s)
Load Average: 1.49, 1.20, 1.06
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------
Benchmark                   Time             CPU   Iterations
-------------------------------------------------------------
BM_objc_msg_lookup       7.86 ns         7.86 ns     89906353
BM_GSGetMethod           12.5 ns         12.4 ns     56523293
```

```objc++
#include <benchmark/benchmark.h>
#include <Foundation/Foundation.h>

struct objc_method *
GSGetMethod(Class cls, SEL sel,
  BOOL searchInstanceMethods,
  BOOL searchSuperClasses)
{
  if (cls == 0 || sel == 0)
    {
      return 0;
    }

  if (searchSuperClasses == NO)
    {
      unsigned int	count;
      Method		method = NULL;
      Method		*methods;

      if (searchInstanceMethods == NO)
	{
	  methods = class_copyMethodList(object_getClass(cls), &count);
	}
      else
	{
	  methods = class_copyMethodList(cls, &count);
	}
      if (methods != NULL)
	{
	  unsigned int	index = 0;

	  while ((method = methods[index++]) != NULL)
	    {
	      if (sel_isEqual(sel, method_getName(method)))
		{
		  break;
		}
	    }
	  free(methods);
	}
      return method;
    }
  else
    {
      if (searchInstanceMethods == NO)
	{
	  return class_getClassMethod(cls, sel);
	}
      else
	{
	  return class_getInstanceMethod(cls, sel);
	}
    }
}

static void BM_objc_msg_lookup(benchmark::State& state) {
  NSObject *target = [NSObject new];
  SEL sel = @selector(description);
  IMP imp;

  for (auto _ : state) {
    benchmark::DoNotOptimize(imp = objc_msg_lookup(target, sel));
  }
}

static void BM_GSGetMethod(benchmark::State& state) {
  Class cls = [NSObject class];
  SEL sel = @selector(description);
  IMP imp;

  for (auto _ : state) {
    benchmark::DoNotOptimize(imp = method_getImplementation(GSGetMethod(cls, sel, YES, YES)));
  }
}

BENCHMARK(BM_objc_msg_lookup);
BENCHMARK(BM_GSGetMethod);
BENCHMARK_MAIN();
```
