### PR TITLE
Fix regex callback

### DIFF
--- a/Source/NSRegularExpression.m
+++ b/Source/NSRegularExpression.m
@@ -371,15 +371,18 @@ static UBool
 callback(const void *context, int32_t steps)
 {
   BOOL		stop = NO;
+  BOOL		keepGoing = YES;
   GSRegexBlock	block = (GSRegexBlock)context;
 
   if (NULL == context)
     {
-      return FALSE;
+      return TRUE; // keep going if there is no callback block
     }
   CALL_BLOCK(block, nil, NSMatchingProgress, &stop);
-  return stop;
+  keepGoing = !stop; // keep going if callback block didn't request a stop
+  return keepGoing;
 }
+
 
 
 #define DEFAULT_WORK_LIMIT 1500

--- a/Tests/base/NSRegularExpression/GNUmakefile.preamble
+++ b/Tests/base/NSRegularExpression/GNUmakefile.preamble
@@ -1,0 +1,2 @@
+
+ADDITIONAL_OBJCFLAGS += -fblocks

--- a/Tests/base/NSRegularExpression/bigSource.txt
+++ b/Tests/base/NSRegularExpression/bigSource.txt
@@ -1,0 +1,6000 @@
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -
++++ABC+++
+In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet sort of hole,
+filled with the ends of worms and an oozy smell. Nor yet a dry, bare, sandy hole
+with nothing in it to sit down on or to eat. It was a hobbit-hole, and that means
+comfort.
+- - - - - - - - - - - - - -

--- a/Tests/base/NSRegularExpression/callbacks.m
+++ b/Tests/base/NSRegularExpression/callbacks.m
@@ -1,0 +1,52 @@
+#import <Foundation/NSString.h>
+#import <Foundation/NSRegularExpression.h>
+#import <Foundation/NSTextCheckingResult.h>
+#import "ObjectTesting.h"
+
+int main(void)
+{
+	[NSAutoreleasePool new];
+	START_SET("NSRegularExpression + callbacks")
+
+#if !(__APPLE__ || GS_USE_ICU)
+		SKIP("NSRegularExpression not built, please install libicu")
+#else
+  // load source file containing some text repeated 1000 times
+  NSString *sourceText = [NSString stringWithContentsOfFile:@"bigSource.txt"];
+  NSRegularExpression *simpleRegex = [NSRegularExpression regularExpressionWithPattern: @"ABC"
+    options: 0 error: NULL];
+  NSRange sourceRange = NSMakeRange(0, [sourceText length] - 1);
+  
+  // matchesInString:... uses enumerateMatchesInString:... without any callbacks
+  NSArray *simpleMatches = [simpleRegex matchesInString: sourceText
+                   options: 0
+                     range: sourceRange];
+  NSLog(@"Simple matches: %ld", [simpleMatches count]);
+  PASS([simpleMatches count] == 1000, "1000 matches");
+  
+  // call enumerateMatchesInString:... directly, with callback
+  __block NSInteger matchCount = 0;
+  [simpleRegex enumerateMatchesInString:sourceText
+                              options:NSMatchingReportProgress
+                                range:NSMakeRange(0, [sourceText length] - 1)
+                           usingBlock:^(NSTextCheckingResult * result, NSMatchingFlags flags, BOOL * stop) {
+                               if (result) {
+                                   matchCount++;
+                               }
+							   else {
+							     NSLog(@"FLAGS: %d", flags);
+							   }
+                           }];
+
+  
+  NSLog(@"Number of matches: %ld", matchCount);
+  PASS(matchCount == 1000, "enumerate with callback has same count");
+  
+  NSMutableString *otherString;
+  
+  
+#endif
+
+	END_SET("NSRegularExpression + callbacks")
+	return 0;
+}


### PR DESCRIPTION
The Cocoa block uses a "stop" flag to allow a client to abort a long-running regex process. But the ICU library expects the callback function to return a flag with the opposite meaning -- "keepGoing". This change reverses the flag to fix the problem that any regex process that ran long enough to invoke the callback would be prematurely canceled.
