### PR TITLE
Key-Value Observing: Add support for observing through a proxy

### DIFF
--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -123,6 +123,7 @@ _NSKVOEnsureKeyWillNotify(id object, NSString *key);
  */
 @interface
 NSObject (NSKeyValueObservingPrivate)
+- (Class)_underlyingClass;
 - (void)_notifyObserversOfChangeForKey:(NSString *)key
                               oldValue:(id)oldValue
                               newValue:(id)newValue;

--- a/Source/NSKVOSwizzling.m
+++ b/Source/NSKVOSwizzling.m
@@ -666,6 +666,8 @@ void
 _NSKVOEnsureKeyWillNotify(id object, NSString *key)
 {
   char *rawKey;
+  Class cls;
+  Class underlyingCls;
 
   // Since we cannot replace the isa of tagged pointer objects, we can't swizzle
   // them.
@@ -674,8 +676,17 @@ _NSKVOEnsureKeyWillNotify(id object, NSString *key)
       return;
     }
 
+  cls = [object class];
+  underlyingCls = [object _underlyingClass];
+  // If cls differs from underlyingCls, object is actually a proxy.
+  // Retrieve the underlying object with KVC.
+  if (cls != underlyingCls)
+  {
+    object = [object valueForKey: @"self"];
+  }
+
   // A class is allowed to decline automatic swizzling for any/all of its keys.
-  if (![[object class] automaticallyNotifiesObserversForKey: key])
+  if (![underlyingCls automaticallyNotifiesObserversForKey: key])
     {
       return;
     }

--- a/Tests/base/NSKVOSupport/proxy.m
+++ b/Tests/base/NSKVOSupport/proxy.m
@@ -197,16 +197,16 @@
     count += 1;
     switch (count) {
         case 1:
-            PASS_EQUAL(keyPath, keys[0], "change notification for dependent key 'derivedName' is emitted first");
+            PASS_EQUAL(keyPath, [keys objectAtIndex: 0], "change notification for dependent key 'derivedName' is emitted first");
             break;
         case 2:
-            PASS_EQUAL(keyPath, keys[1], "'name' change notification for proxy is second");
+            PASS_EQUAL(keyPath, [keys objectAtIndex: 1], "'name' change notification for proxy is second");
             break;
         case 3:
-            PASS_EQUAL(keyPath, keys[0], "'derivedName' change notification for object is third");
+            PASS_EQUAL(keyPath, [keys objectAtIndex: 0], "'derivedName' change notification for object is third");
             break;
         case 4:
-            PASS_EQUAL(keyPath, keys[1], "'name' change notification for object is fourth");
+            PASS_EQUAL(keyPath, [keys objectAtIndex: 1], "'name' change notification for object is fourth");
             break;
         default:
             PASS(0, "unexpected -[Observer observeValueForKeyPath:ofObject:change:context:] callback");


### PR DESCRIPTION
While not explicitly allowed, observing an object from a stand-in, a NSProxy subclass, works on macOS.
As outlined in #472, we are currently facing two issues preventing this to work:
1. Class methods are not forwarded by design
2. KVO currently tries to swizzle the stand-in, and not the underlying object

I've tried not to introduce additional overhead, and implemented `- _underlyingClass` in a NSObject and NSProxy category.
The implementation in NSObject simply returns `[self class]`, while -[NSProxy _underlyingClass] calls `[self valueForKey: @"class"]` to retrieve the underlying class.

When swizzling, we check for a mismatch between `-class` and `-_underlyingClass`.