### PR TITLE
Look for locale files in main bundle on Android

### DIFF
--- a/Source/GSLocale.m
+++ b/Source/GSLocale.m
@@ -255,23 +255,16 @@ NSString *
 GSLanguageFromLocale(NSString *locale)
 {
   NSString	*language = nil;
-  NSString	*aliases = nil;
-  NSBundle      *gbundle;
+  NSDictionary	*dict;
 
   if (locale == nil || [locale isEqual: @"C"] || [locale isEqual: @"POSIX"]
       || [locale length] < 2)
     return @"English";
 
   ENTER_POOL
-  gbundle = [NSBundle bundleForLibrary: @"gnustep-base"];
-  aliases = [gbundle pathForResource: @"Locale"
-		              ofType: @"aliases"
-		         inDirectory: @"Languages"];
-  if (aliases != nil)
+  dict = GSPrivateLanguageAliases();
+  if (dict != nil)
     {
-      NSDictionary	*dict;
-
-      dict = [NSDictionary dictionaryWithContentsOfFile: aliases];
       language = [[dict objectForKey: locale] copy];
       if (language == nil && [locale pathExtension] != nil)
 	{

--- a/Source/GSPrivate.h
+++ b/Source/GSPrivate.h
@@ -646,5 +646,13 @@ void GSWeakInit() GS_ATTRIB_PRIVATE;
 BOOL objc_delete_weak_refs(id obj);
 #endif
 
+/**
+ * Returns an unretained version of the language aliases,
+ * or nil if the NSBundle class is not initialised.
+ *
+ * Implementation in NSBundle.
+ */
+NSDictionary *GSPrivateLanguageAliases();
+
 #endif /* _GSPrivate_h_ */
 

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -77,6 +77,11 @@ manager()
 static NSDictionary     *langAliases = nil;
 static NSDictionary     *langCanonical = nil;
 
+NSDictionary *GSPrivateLanguageAliases()
+{
+  return langAliases;
+}
+
 /* Map a language name to any alternative versions.   This function should
  * return an array of alternative language/localisation directory names in
  * the preferred order of precedence (ie resources in the directories named
@@ -1720,8 +1725,14 @@ GSPrivateInfoDictionary(NSString *rootPath)
       if ((str = [env objectForKey: @"LIBRARY_COMBO"]) != nil)
 	library_combo = RETAIN(str);
 
+#if defined(__ANDROID__)
+      // TODO: Improve the overall bundle and domain system for platforms
+      // without a traditional filesystem hierarchy like Android
+      _gnustep_bundle = RETAIN([NSBundle mainBundle]);
+#else
       _gnustep_bundle = RETAIN([self bundleForLibrary: @"gnustep-base"
 					      version: _base_version]);
+#endif
 
       /* The Locale aliases map converts canonical names to old-style names
        */

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -1661,7 +1661,7 @@ GSInitializeProcessAndroid(JNIEnv *env, jobject context)
   jstring localeListJava = (*env)->CallObjectMethod(env, localeListObj, localeListToLanguageTagsMethod);
   GS_JNI_CHECK(env, localeListJava);
   
-  const char *localeListOrig = (*env)->GetStringUTFChars(env, localeIdJava, NULL);
+  const char *localeListOrig = (*env)->GetStringUTFChars(env, localeListJava, NULL);
 
   // Some devices return with it enclosed in []'s so check if both exists before
   // removing to ensure it is formatted correctly


### PR DESCRIPTION
On Android, we do not have a system-wide GNUstep installation and thus not
a 'gnustep-base' library bundle. Search the main bundle (the resource path of an Android app) for Languages/Locale.aliases instead.

https://github.com/gnustep/libs-base/issues/484 tracks a revamp of the config infrastructure
