### PR TITLE
Fix NSNotFound definition to use NSInteger type

### DIFF
--- a/Headers/Foundation/NSCalendar.h
+++ b/Headers/Foundation/NSCalendar.h
@@ -139,7 +139,7 @@ enum
   NSWrapCalendarComponents = (1UL << 0)
 };
 
-enum
+NS_ENUM(NSInteger)
 {
   NSDateComponentUndefined = NSIntegerMax,
   NSUndefinedDateComponent = NSDateComponentUndefined

--- a/Headers/Foundation/NSObjCRuntime.h
+++ b/Headers/Foundation/NSObjCRuntime.h
@@ -292,7 +292,7 @@ typedef NS_ENUM(NSInteger, NSComparisonResult)
   NSOrderedAscending = (NSInteger)-1, NSOrderedSame, NSOrderedDescending
 };
 
-enum {NSNotFound = NSIntegerMax};
+static const NSInteger NSNotFound = NSIntegerMax;
 
 DEFINE_BLOCK_TYPE(NSComparator, NSComparisonResult, id, id);
 

--- a/Source/NSCoder.m
+++ b/Source/NSCoder.m
@@ -100,7 +100,7 @@ static unsigned	systemVersion = MAX_SUPPORTED_SYSTEM_VERSION;
 - (NSInteger) versionForClassName: (NSString*)className
 {
   [self subclassResponsibility: _cmd];
-  return (NSInteger)NSNotFound;
+  return NSNotFound;
 }
 
 // Encoding Data

--- a/Source/NSUnarchiver.m
+++ b/Source/NSUnarchiver.m
@@ -1683,7 +1683,7 @@ scalarSize(char type)
   info = [objDict objectForKey: className];
   if (info == nil)
     {
-      return (NSInteger)NSNotFound;
+      return NSNotFound;
     }
   return info->version;
 }


### PR DESCRIPTION
Fixes #494.

I’m guessing this is an ABI breaking change, not sure how this should be handled.