### PR TITLE
Fix `Authorization` header generation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,11 @@
 2025-03-21 Earl Robsham <earl.robsham@savant.com>
+	* Headers/Foundation/NSURLHandle.h:
+	* Sources/externs.m:
 	* Source/GSHTTPURLHandle.m:
 	* Source/NSURLProtocol.m:
 	Updates `Authorization` header generation to include the query parameters (if present).
 	Brings the implementation inline with MacOS.
+	Also adds the `GSDigestURIOmitsQuery` key for use with ` -[NSHTTPURLHandle writeProperty:forKey:]` / `+[NSURLProtocol setProperty:forKey:inRequest:]` to toggle off this updated behavior.
 
 2025-03-08 Richard Frith-Macdonald <rfm@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-03-21 Earl Robsham <earl.robsham@savant.com>
+	* Source/GSHTTPURLHandle.m:
+	* Source/NSURLProtocol.m:
+	Updates `Authorization` header generation to include the query parameters (if present).
+	Brings the implementation inline with MacOS.
+
 2025-03-08 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/GSObjCRuntime.h:

--- a/Headers/Foundation/NSURLHandle.h
+++ b/Headers/Foundation/NSURLHandle.h
@@ -114,6 +114,14 @@ GS_EXPORT NSString * const GSHTTPPropertyKeyFileKey;
  */
 GS_EXPORT NSString * const GSHTTPPropertyPasswordKey;
 
+/**
+ * Key for passing to [NSURLHandle]'s and [NSHTTPURLProtocol]'s 
+ * <code>propertyForKey..</code> methods. Specifying <code>@YES</code> will 
+ * signal Digest Authentication logic to always omit the 'query' portion of the
+ * URI when generating the `Authorization` header.
+ */
+GS_EXPORT NSString * const GSDigestURIOmitsQuery;
+
 #endif
 
 /**

--- a/Source/GSHTTPURLHandle.m
+++ b/Source/GSHTTPURLHandle.m
@@ -535,6 +535,7 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 	  GSHTTPAuthentication	*authentication;
 	  NSURLCredential	*cred;
 	  NSString		*method;
+	  NSString		*path;
 
 	  /* Create credential from user and password stored in the URL.
 	   * Returns nil if we have no username or password.
@@ -572,9 +573,18 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 		}
 	    }
 
+	  if ([[u query] length] == 0)
+	    {
+		  path = [u pathWithEscapes];
+		}
+	      else
+		{
+		  path = [NSString stringWithFormat:@"%@?%@", [u pathWithEscapes], [u query]];
+		}
+
 	  auth = [authentication authorizationForAuthentication: nil
 	    method: method
-	    path: [u pathWithEscapes]];
+	    path: path];
 	  /* If authentication is nil then auth will also be nil
 	   */
 	  if (auth != nil)
@@ -837,6 +847,7 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 		  NSString		*ac;
 		  GSHTTPAuthentication	*authentication;
 		  NSString		*method;
+		  NSString		*path;
 		  NSString		*auth;
 
 		  ac = [ah value];
@@ -891,9 +902,18 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 			}
 		    }
 
+		  if ([[url query] length] == 0)
+			{
+			  path = [url pathWithEscapes];
+			}
+		      else
+			{
+			  path = [NSString stringWithFormat:@"%@?%@", [url pathWithEscapes], [url query]];
+			}
+
 		  auth = [authentication authorizationForAuthentication: ac
 		    method: method
-		    path: [url pathWithEscapes]];
+		    path: path];
 		  if (auth != nil)
 		    {
 		      [self writeProperty: auth forKey: @"Authorization"];

--- a/Source/GSHTTPURLHandle.m
+++ b/Source/GSHTTPURLHandle.m
@@ -536,6 +536,7 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 	  NSURLCredential	*cred;
 	  NSString		*method;
 	  NSString		*path;
+	  NSNumber		*omitQuery;
 
 	  /* Create credential from user and password stored in the URL.
 	   * Returns nil if we have no username or password.
@@ -573,7 +574,8 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 		}
 	    }
 
-	  if ([[u query] length] == 0)
+	  omitQuery = [request objectForKey:GSDigestURIOmitsQuery];
+	  if ([[u query] length] == 0 || [omitQuery boolValue])
 	    {
 		  path = [u pathWithEscapes];
 		}
@@ -849,6 +851,7 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 		  NSString		*method;
 		  NSString		*path;
 		  NSString		*auth;
+		  NSNumber		*omitQuery;
 
 		  ac = [ah value];
 		  space = [GSHTTPAuthentication
@@ -902,7 +905,8 @@ debugWrite(GSHTTPURLHandle *handle, NSData *data)
 			}
 		    }
 
-		  if ([[url query] length] == 0)
+		  omitQuery = [request objectForKey:GSDigestURIOmitsQuery];
+		  if ([[url query] length] == 0 || [omitQuery boolValue])
 			{
 			  path = [url pathWithEscapes];
 			}

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1413,7 +1413,10 @@ typedef struct {
 		      auth = [authentication
 			authorizationForAuthentication: hdr
 			method: [this->request HTTPMethod]
-			path: [url pathWithEscapes]];
+			path: [[url query] length] == 0 ?
+				[url pathWithEscapes] :
+				[NSString stringWithFormat:@"%@?%@", [url pathWithEscapes], [url query]]
+		      ];
 		    }
 
 		  if (auth == nil)

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1399,6 +1399,7 @@ typedef struct {
 		  if (_credential != nil)
 		    {
 		      GSHTTPAuthentication	*authentication;
+		      NSNumber				*omitQuery;
 
 		      /* Get information about basic or
 		       * digest authentication.
@@ -1410,10 +1411,11 @@ typedef struct {
 		      /* Generate authentication header value for the
 		       * authentication type in the challenge.
 		       */
+		      omitQuery = [this->request _propertyForKey:GSDigestURIOmitsQuery];
 		      auth = [authentication
 			authorizationForAuthentication: hdr
 			method: [this->request HTTPMethod]
-			path: [[url query] length] == 0 ?
+			path: [[url query] length] == 0 || [omitQuery boolValue] ?
 				[url pathWithEscapes] :
 				[NSString stringWithFormat:@"%@?%@", [url pathWithEscapes], [url query]]
 		      ];

--- a/Source/externs.m
+++ b/Source/externs.m
@@ -562,6 +562,7 @@ GS_DECLARE NSString* const GSHTTPPropertyProxyPortKey = @"GSHTTPPropertyProxyPor
 GS_DECLARE NSString* const GSHTTPPropertyCertificateFileKey = @"GSHTTPPropertyCertificateFileKey";
 GS_DECLARE NSString* const GSHTTPPropertyKeyFileKey = @"GSHTTPPropertyKeyFileKey";
 GS_DECLARE NSString* const GSHTTPPropertyPasswordKey = @"GSHTTPPropertyPasswordKey";
+GS_DECLARE NSString* const GSDigestURIOmitsQuery = @"GSDigestURIOmitsQuery";
 
 /* NSURLProtectionSpace */
 GS_DECLARE NSString* const NSURLProtectionSpaceFTPProxy = @"ftp";	


### PR DESCRIPTION
Fixes `Authorization` header generation to include the query parameters (if present). 
This brings the implementation inline with MacOS, and fixes digest auth with certain picky services.

Tested these changes against the IC Realtime ORB camera I was having issues with in https://github.com/gnustep/libs-base/issues/497, and our application successfully authenticated with this fix.