### PR TITLE
Use instancetype or actual type as initializer return types

### DIFF
--- a/Headers/Foundation/NSCalendar.h
+++ b/Headers/Foundation/NSCalendar.h
@@ -277,12 +277,12 @@ GS_EXPORT_CLASS
 /**
  * Returns the current calendar.
  */
-+ (id) currentCalendar;
++ (NSCalendar*) currentCalendar;
 
 /**
  * Create a calendar with the given string as identifier.
  */
-+ (id) calendarWithIdentifier: (NSString *) string;
++ (instancetype) calendarWithIdentifier: (NSString *) string;
 
 /**
  * Instantiate a calendar with the given string as identifier.
@@ -397,7 +397,7 @@ GS_EXPORT_CLASS
 /**
  * A calendar that tracks changes to the user's calendar.
  */
-+ (id) autoupdatingCurrentCalendar;
++ (NSCalendar*) autoupdatingCurrentCalendar;
 
 /**
  * Returns by referene the started time and duration of a given unit containing the given date.

--- a/Headers/Foundation/NSCalendarDate.h
+++ b/Headers/Foundation/NSCalendarDate.h
@@ -42,34 +42,34 @@ GS_EXPORT_CLASS
 }
 
 // Getting an NSCalendar Date
-+ (id) calendarDate;
-+ (id) dateWithString: (NSString*)description
-       calendarFormat: (NSString*)format;
-+ (id) dateWithString: (NSString*)description
-       calendarFormat: (NSString*)format
-	       locale: (NSDictionary*)dictionary;
-+ (id) dateWithYear: (NSInteger)year
-	      month: (NSUInteger)month
-	        day: (NSUInteger)day
-	       hour: (NSUInteger)hour
-	     minute: (NSUInteger)minute
-	     second: (NSUInteger)second
-	   timeZone: (NSTimeZone*)aTimeZone;
++ (instancetype) calendarDate;
++ (instancetype) dateWithString: (NSString*)description
+                 calendarFormat: (NSString*)format;
++ (instancetype) dateWithString: (NSString*)description
+                 calendarFormat: (NSString*)format
+                         locale: (NSDictionary*)dictionary;
++ (instancetype) dateWithYear: (NSInteger)year
+                        month: (NSUInteger)month
+                          day: (NSUInteger)day
+                         hour: (NSUInteger)hour
+                       minute: (NSUInteger)minute
+                       second: (NSUInteger)second
+                     timeZone: (NSTimeZone*)aTimeZone;
 
 // Initializing an NSCalendar Date
-- (id) initWithString: (NSString*)description;
-- (id) initWithString: (NSString*)description
-       calendarFormat: (NSString*)format;
-- (id) initWithString: (NSString*)description
-       calendarFormat: (NSString*)fmt
-	       locale: (NSDictionary*)locale;
-- (id) initWithYear: (NSInteger)year
-	      month: (NSUInteger)month
-	        day: (NSUInteger)day
-	       hour: (NSUInteger)hour
-	     minute: (NSUInteger)minute
-	     second: (NSUInteger)second
-	   timeZone: (NSTimeZone*)aTimeZone;
+- (instancetype) initWithString: (NSString*)description;
+- (instancetype) initWithString: (NSString*)description
+                 calendarFormat: (NSString*)format;
+- (instancetype) initWithString: (NSString*)description
+                 calendarFormat: (NSString*)fmt
+                         locale: (NSDictionary*)locale;
+- (instancetype) initWithYear: (NSInteger)year
+                        month: (NSUInteger)month
+                          day: (NSUInteger)day
+                         hour: (NSUInteger)hour
+                       minute: (NSUInteger)minute
+                       second: (NSUInteger)second
+                     timeZone: (NSTimeZone*)aTimeZone;
 
 // Retrieving Date Elements
 - (NSInteger) dayOfCommonEra;

--- a/Headers/Foundation/NSCharacterSet.h
+++ b/Headers/Foundation/NSCharacterSet.h
@@ -46,106 +46,106 @@ GS_EXPORT_CLASS
  *  marks.  Note that "letters" includes all alphabetic as well as Chinese
  *  characters, etc..
  */
-+ (id) alphanumericCharacterSet;
++ (NSCharacterSet*) alphanumericCharacterSet;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /**
  *  Returns a character set containing letters in the unicode
  *  Titlecase category.
  */
-+ (id) capitalizedLetterCharacterSet;
++ (NSCharacterSet*) capitalizedLetterCharacterSet;
 #endif
 
 /**
  * Returns a character set containing control and format characters.
  */
-+ (id) controlCharacterSet;
++ (NSCharacterSet*) controlCharacterSet;
 
 /**
  * Returns a character set containing characters that represent
  * the decimal digits 0 through 9.
  */
-+ (id) decimalDigitCharacterSet;
++ (NSCharacterSet*) decimalDigitCharacterSet;
 
 /**
  * Returns a character set containing individual characters that
  * can be represented also by a composed character sequence.
  */
-+ (id) decomposableCharacterSet;
++ (NSCharacterSet*) decomposableCharacterSet;
 
 /**
  * Returns a character set containing unassigned and explicitly illegal
  * character values.
  */
-+ (id) illegalCharacterSet;
++ (NSCharacterSet*) illegalCharacterSet;
 
 /**
  *  Returns a character set containing letters, including all alphabetic as
  *  well as Chinese characters, etc..
  */
-+ (id) letterCharacterSet;
++ (NSCharacterSet*) letterCharacterSet;
 
 /**
  * Returns a character set that contains the lowercase characters.
  * This set does not include caseless characters, only those that
  * have corresponding characters in uppercase and/or titlecase.
  */
-+ (id) lowercaseLetterCharacterSet;
++ (NSCharacterSet*) lowercaseLetterCharacterSet;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /**
  * Returns a character set containing the newline characters, values 
  * 0x000A and 0x000D and nextline 0x0085 character.
  */
-+ (id) newlineCharacterSet;
++ (NSCharacterSet*) newlineCharacterSet;
 
 /**
  * Returns allowed characers for URL fragment component.
  */
-+ (id) URLFragmentAllowedCharacterSet;
++ (NSCharacterSet*) URLFragmentAllowedCharacterSet;
 
 /**
  * Returns allowed characers for URL host component.
  */
-+ (id) URLHostAllowedCharacterSet;
++ (NSCharacterSet*) URLHostAllowedCharacterSet;
 
 /**
  * Returns allowed characers for URL password component.
  */
-+ (id) URLPasswordAllowedCharacterSet;
++ (NSCharacterSet*) URLPasswordAllowedCharacterSet;
 
 /**
  * Returns allowed characers for URL path component.
  */
-+ (id) URLPathAllowedCharacterSet;
++ (NSCharacterSet*) URLPathAllowedCharacterSet;
 
 /**
  * Returns allowed characers for URL query component.
  */
-+ (id) URLQueryAllowedCharacterSet;
++ (NSCharacterSet*) URLQueryAllowedCharacterSet;
 
 /**
  * Returns allowed characers for URL USER component.
  */
-+ (id) URLUserAllowedCharacterSet;
++ (NSCharacterSet*) URLUserAllowedCharacterSet;
 #endif
 
 /**
  *  Returns a character set containing characters for diacritical marks, which
  *  are usually only rendered in conjunction with another character.
  */
-+ (id) nonBaseCharacterSet;
++ (NSCharacterSet*) nonBaseCharacterSet;
 
 /**
  *  Returns a character set containing punctuation marks.
  */
-+ (id) punctuationCharacterSet;
++ (NSCharacterSet*) punctuationCharacterSet;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /**
  *  Returns a character set containing mathematical symbols, etc..
  */
-+ (id) symbolCharacterSet;
++ (NSCharacterSet*) symbolCharacterSet;
 #endif
 
 /**
@@ -153,36 +153,36 @@ GS_EXPORT_CLASS
  * This set does not include caseless characters, only those that
  * have corresponding characters in lowercase and/or titlecase.
  */
-+ (id) uppercaseLetterCharacterSet;
++ (NSCharacterSet*) uppercaseLetterCharacterSet;
 
 /**
  * Returns a character set that contains the whitespace characters,
  * plus the newline characters, values 0x000A and 0x000D and nextline
  * 0x0085 character.
  */
-+ (id) whitespaceAndNewlineCharacterSet;
++ (NSCharacterSet*) whitespaceAndNewlineCharacterSet;
 
 /**
  * Returns a character set that contains the whitespace characters.
  */
-+ (id) whitespaceCharacterSet;
++ (NSCharacterSet*) whitespaceCharacterSet;
 
 /**
  * Returns a character set containing characters as encoded in the
  * data object (8192 bytes)
  */
-+ (id) characterSetWithBitmapRepresentation: (NSData*)data;
++ (NSCharacterSet*) characterSetWithBitmapRepresentation: (NSData*)data;
 
 /**
  *  Returns set with characters in aString, or empty set for empty string.
  *  Raises an exception if given a nil string.
  */
-+ (id) characterSetWithCharactersInString: (NSString*)aString;
++ (NSCharacterSet*) characterSetWithCharactersInString: (NSString*)aString;
 
 /**
  *  Returns set containing unicode index range given by aRange.
  */
-+ (id) characterSetWithRange: (NSRange)aRange;
++ (NSCharacterSet*) characterSetWithRange: (NSRange)aRange;
 
 #if OS_API_VERSION(GS_API_OPENSTEP, GS_API_MACOSX)
 /**
@@ -193,7 +193,7 @@ GS_EXPORT_CLASS
  *  To get around this load the file into data yourself and use
  *  [NSCharacterSet -characterSetWithBitmapRepresentation].
  */
-+ (id) characterSetWithContentsOfFile: (NSString*)aFile;
++ (NSCharacterSet*) characterSetWithContentsOfFile: (NSString*)aFile;
 #endif
 
 /**

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -85,27 +85,27 @@ GS_EXPORT_CLASS
 
 // Allocating and Initializing a Data Object
 
-+ (id) data;
-+ (id) dataWithBytes: (const void*)bytes
-	      length: (NSUInteger)length;
-+ (id) dataWithBytesNoCopy: (void*)bytes
-		    length: (NSUInteger)length;
++ (instancetype) data;
++ (instancetype) dataWithBytes: (const void*)bytes
+                        length: (NSUInteger)length;
++ (instancetype) dataWithBytesNoCopy: (void*)bytes
+                              length: (NSUInteger)length;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (id) dataWithBytesNoCopy: (void*)aBuffer
-		    length: (NSUInteger)bufferSize
-	      freeWhenDone: (BOOL)shouldFree;
++ (instancetype) dataWithBytesNoCopy: (void*)aBuffer
+                              length: (NSUInteger)bufferSize
+                        freeWhenDone: (BOOL)shouldFree;
 #endif
-+ (id) dataWithContentsOfFile: (NSString*)path;
-+ (id) dataWithContentsOfMappedFile: (NSString*)path;
++ (instancetype) dataWithContentsOfFile: (NSString*)path;
++ (instancetype) dataWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (id) dataWithContentsOfURL: (NSURL*)url;
++ (instancetype) dataWithContentsOfURL: (NSURL*)url;
 #endif
-+ (id) dataWithData: (NSData*)data;
++ (instancetype) dataWithData: (NSData*)data;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9,GS_API_LATEST)
-- (id) initWithBase64EncodedData: (NSData*)base64Data
-                         options: (NSDataBase64DecodingOptions)options;
-- (id) initWithBase64EncodedString: (NSString*)base64String
-                           options: (NSDataBase64DecodingOptions)options;
+- (instancetype) initWithBase64EncodedData: (NSData*)base64Data
+                                   options: (NSDataBase64DecodingOptions)options;
+- (instancetype) initWithBase64EncodedString: (NSString*)base64String
+                                     options: (NSDataBase64DecodingOptions)options;
 /**
  * <override-subclass/>
  * Initialize the receiver to hold memory pointed to by bytes without copying.
@@ -117,21 +117,21 @@ GS_EXPORT_CLASS
                               length: (NSUInteger)length
                          deallocator: (GSDataDeallocatorBlock)deallocBlock;
 #endif
-- (id) initWithBytes: (const void*)aBuffer
-	      length: (NSUInteger)bufferSize;
-- (id) initWithBytesNoCopy: (void*)aBuffer
-		    length: (NSUInteger)bufferSize;
+- (instancetype) initWithBytes: (const void*)aBuffer
+                        length: (NSUInteger)bufferSize;
+- (instancetype) initWithBytesNoCopy: (void*)aBuffer
+                              length: (NSUInteger)bufferSize;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (id) initWithBytesNoCopy: (void*)aBuffer
-		    length: (NSUInteger)bufferSize
-	      freeWhenDone: (BOOL)shouldFree;
+- (instancetype) initWithBytesNoCopy: (void*)aBuffer
+                              length: (NSUInteger)bufferSize
+                        freeWhenDone: (BOOL)shouldFree;
 #endif
-- (id) initWithContentsOfFile: (NSString*)path;
-- (id) initWithContentsOfMappedFile: (NSString*)path;
+- (instancetype) initWithContentsOfFile: (NSString*)path;
+- (instancetype) initWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (id) initWithContentsOfURL: (NSURL*)url;
+- (instancetype) initWithContentsOfURL: (NSURL*)url;
 #endif
-- (id) initWithData: (NSData*)data;
+- (instancetype) initWithData: (NSData*)data;
 
 // Accessing Data
 
@@ -315,10 +315,10 @@ GS_EXPORT_CLASS
 GS_EXPORT_CLASS
 @interface NSMutableData :  NSData
 
-+ (id) dataWithCapacity: (NSUInteger)numBytes;
-+ (id) dataWithLength: (NSUInteger)length;
-- (id) initWithCapacity: (NSUInteger)capacity;
-- (id) initWithLength: (NSUInteger)length;
++ (instancetype) dataWithCapacity: (NSUInteger)numBytes;
++ (instancetype) dataWithLength: (NSUInteger)length;
+- (instancetype) initWithCapacity: (NSUInteger)capacity;
+- (instancetype) initWithLength: (NSUInteger)length;
 
 // Adjusting Capacity
 

--- a/Headers/Foundation/NSError.h
+++ b/Headers/Foundation/NSError.h
@@ -152,9 +152,9 @@ GS_EXPORT_CLASS
  * Creates and returns an autoreleased NSError instance by calling
  * -initWithDomain:code:userInfo:
  */
-+ (id) errorWithDomain: (NSErrorDomain)aDomain
-		  code: (NSInteger)aCode
-	      userInfo: (NSDictionary*)aDictionary;
++ (instancetype) errorWithDomain: (NSErrorDomain)aDomain
+                            code: (NSInteger)aCode
+                        userInfo: (NSDictionary*)aDictionary;
 
 /**
  * Return the error code ... which is not globally unique, just unique for
@@ -171,9 +171,9 @@ GS_EXPORT_CLASS
  * Initialises the receiver using the supplied domain, code, and info.<br />
  * The domain must be non-nil.
  */
-- (id) initWithDomain: (NSErrorDomain)aDomain
-		 code: (NSInteger)aCode
-	     userInfo: (NSDictionary*)aDictionary;
+- (instancetype) initWithDomain: (NSErrorDomain)aDomain
+                           code: (NSInteger)aCode
+                       userInfo: (NSDictionary*)aDictionary;
 
 /**
  * Return a human readable description for the error.<br />

--- a/Headers/Foundation/NSIndexPath.h
+++ b/Headers/Foundation/NSIndexPath.h
@@ -64,18 +64,18 @@ GS_EXPORT_CLASS
 /**
  * Return a path containing the single value anIndex.
  */
-+ (id) indexPathWithIndex: (NSUInteger)anIndex;
++ (instancetype) indexPathWithIndex: (NSUInteger)anIndex;
 
 /**
  * Return a path containing all the indexes in the supplied array.
  */
-+ (id) indexPathWithIndexes: (NSUInteger*)indexes length: (NSUInteger)length;
++ (instancetype) indexPathWithIndexes: (NSUInteger*)indexes length: (NSUInteger)length;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11,GS_API_LATEST)
 /**
  * Return a path containing an item number and section.
  */
-+ (NSIndexPath *) indexPathForItem: (NSInteger)item inSection: (NSInteger)section;
++ (instancetype) indexPathForItem: (NSInteger)item inSection: (NSInteger)section;
 
 /**
  * Return an index number identifying an item in a collection view
@@ -92,7 +92,7 @@ GS_EXPORT_CLASS
 /**
  * Return a path containing row number and section.
  */
-+ (NSIndexPath *) indexPathForRow: (NSInteger)item inSection: (NSInteger)section;
++ (instancetype) indexPathForRow: (NSInteger)item inSection: (NSInteger)section;
 
 /**
  * Return an index number identifying a row in a table view

--- a/Headers/Foundation/NSPointerArray.h
+++ b/Headers/Foundation/NSPointerArray.h
@@ -47,20 +47,20 @@ GS_EXPORT_CLASS
 /** Allocate an instance, initialise using initWithOptions: and
  * return it autoreleased.
  */
-+ (id) pointerArrayWithOptions: (NSPointerFunctionsOptions)options;
++ (instancetype) pointerArrayWithOptions: (NSPointerFunctionsOptions)options;
 
 /** Allocate an instance, initialise using initWithPointerFunctions: and
  * return it autoreleased.
  */
-+ (id) pointerArrayWithPointerFunctions: (NSPointerFunctions *)functions;
++ (instancetype) pointerArrayWithPointerFunctions: (NSPointerFunctions *)functions;
 
 /** Returns a new pointer array for storing strong (retained) references to
  * objects.
  */
-+ (id) strongObjectsPointerArray;
++ (instancetype) strongObjectsPointerArray;
 /** Returns a new pointer array for storing weak references to objects.
  */
-+ (id) weakObjectsPointerArray;
++ (instancetype) weakObjectsPointerArray;
 
 
 /** Removes all nil/zero items from the array.

--- a/Headers/Foundation/NSPointerFunctions.h
+++ b/Headers/Foundation/NSPointerFunctions.h
@@ -104,9 +104,9 @@ typedef	NSUInteger NSPointerFunctionsOptions;
 GS_EXPORT_CLASS
 @interface NSPointerFunctions : NSObject <NSCopying>
 
-+ (id) pointerFunctionsWithOptions: (NSPointerFunctionsOptions)options;
++ (instancetype) pointerFunctionsWithOptions: (NSPointerFunctionsOptions)options;
 
-- (id) initWithOptions: (NSPointerFunctionsOptions)options;
+- (instancetype) initWithOptions: (NSPointerFunctionsOptions)options;
 
 - (void* (*)(const void *item,
   NSUInteger (*size)(const void *item), BOOL shouldCopy)) acquireFunction;

--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -262,7 +262,7 @@ static NSRecursiveLock *classLock = nil;
     }
 }
 
-+ (id) currentCalendar
++ (NSCalendar*) currentCalendar
 {
   NSCalendar *result;
   NSString *identifier;
@@ -274,7 +274,7 @@ static NSRecursiveLock *classLock = nil;
   return AUTORELEASE(result);
 }
 
-+ (id) autoupdatingCurrentCalendar
++ (NSCalendar*) autoupdatingCurrentCalendar
 {
   [classLock lock];
   if (nil == autoupdatingCalendar)

--- a/Source/NSCharacterSet.m
+++ b/Source/NSCharacterSet.m
@@ -781,84 +781,84 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
   return AUTORELEASE(set);
 }
 
-+ (id) alphanumericCharacterSet
++ (NSCharacterSet*) alphanumericCharacterSet
 {
   return [self _staticSet: alphanumericCharSet
 		   length: sizeof(alphanumericCharSet)
 		   number: 0];
 }
 
-+ (id) capitalizedLetterCharacterSet
++ (NSCharacterSet*) capitalizedLetterCharacterSet
 {
   return [self _staticSet: titlecaseLetterCharSet
 		   length: sizeof(titlecaseLetterCharSet)
 		   number: 13];
 }
 
-+ (id) controlCharacterSet
++ (NSCharacterSet*) controlCharacterSet
 {
   return [self _staticSet: controlCharSet
 		   length: sizeof(controlCharSet)
 		   number: 1];
 }
 
-+ (id) decimalDigitCharacterSet
++ (NSCharacterSet*) decimalDigitCharacterSet
 {
   return [self _staticSet: decimalDigitCharSet
 		   length: sizeof(decimalDigitCharSet)
 		   number: 2];
 }
 
-+ (id) decomposableCharacterSet
++ (NSCharacterSet*) decomposableCharacterSet
 {
   return [self _staticSet: decomposableCharSet
 		   length: sizeof(decomposableCharSet)
 		   number: 3];
 }
 
-+ (id) illegalCharacterSet
++ (NSCharacterSet*) illegalCharacterSet
 {
   return [self _staticSet: illegalCharSet
 		   length: sizeof(illegalCharSet)
 		   number: 4];
 }
 
-+ (id) letterCharacterSet
++ (NSCharacterSet*) letterCharacterSet
 {
   return [self _staticSet: letterCharSet
 		   length: sizeof(letterCharSet)
 		   number: 5];
 }
 
-+ (id) lowercaseLetterCharacterSet
++ (NSCharacterSet*) lowercaseLetterCharacterSet
 {
   return [self _staticSet: lowercaseLetterCharSet
 		   length: sizeof(lowercaseLetterCharSet)
 		   number: 6];
 }
 
-+ (id) newlineCharacterSet
++ (NSCharacterSet*) newlineCharacterSet
 {
   return [self _staticSet: newlineCharSet
 		   length: sizeof(newlineCharSet)
 		   number: 14];
 }
 
-+ (id) nonBaseCharacterSet
++ (NSCharacterSet*) nonBaseCharacterSet
 {
   return [self _staticSet: nonBaseCharSet
 		   length: sizeof(nonBaseCharSet)
 		   number: 7];
 }
 
-+ (id) punctuationCharacterSet
++ (NSCharacterSet*) punctuationCharacterSet
 {
   return [self _staticSet: punctuationCharSet
 		   length: sizeof(punctuationCharSet)
 		   number: 8];
 }
 
-+ (id) symbolCharacterSet
++ (NSCharacterSet*) symbolCharacterSet
 {
   return [self _staticSet: symbolAndOperatorCharSet
 		   length: sizeof(symbolAndOperatorCharSet)
@@ -866,7 +866,7 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
 }
 
 // FIXME ... deprecated ... remove after next release.
-+ (id) symbolAndOperatorCharacterSet
++ (NSCharacterSet*) symbolAndOperatorCharacterSet
 {
   GSOnceMLog(@"symbolAndOperatorCharacterSet is deprecated ... use symbolCharacterSet");
   return [self _staticSet: symbolAndOperatorCharSet
@@ -874,33 +874,33 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
 		   number: 9];
 }
 
-+ (id) uppercaseLetterCharacterSet
++ (NSCharacterSet*) uppercaseLetterCharacterSet
 {
   return [self _staticSet: uppercaseLetterCharSet
 		   length: sizeof(uppercaseLetterCharSet)
 		   number: 10];
 }
 
-+ (id) whitespaceAndNewlineCharacterSet
++ (NSCharacterSet*) whitespaceAndNewlineCharacterSet
 {
   return [self _staticSet: whitespaceAndNlCharSet
 		   length: sizeof(whitespaceAndNlCharSet)
 		   number: 11];
 }
 
-+ (id) whitespaceCharacterSet
++ (NSCharacterSet*) whitespaceCharacterSet
 {
   return [self _staticSet: whitespaceCharSet
 		   length: sizeof(whitespaceCharSet)
 		   number: 12];
 }
 
-+ (id) characterSetWithBitmapRepresentation: (NSData*)data
++ (NSCharacterSet*) characterSetWithBitmapRepresentation: (NSData*)data
 {
   return AUTORELEASE([[concreteClass alloc] initWithBitmap: data]);
 }
 
-+ (id) characterSetWithCharactersInString: (NSString*)aString
++ (NSCharacterSet*) characterSetWithCharactersInString: (NSString*)aString
 {
   NSMutableCharacterSet	*ms;
   NSCharacterSet	*cs;
@@ -912,7 +912,7 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
   return AUTORELEASE(cs);
 }
 
-+ (id) characterSetWithRange: (NSRange)aRange
++ (NSCharacterSet*) characterSetWithRange: (NSRange)aRange
 {
   NSMutableCharacterSet	*ms;
   NSCharacterSet	*cs;
@@ -924,7 +924,7 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
   return AUTORELEASE(cs);
 }
 
-+ (id) characterSetWithContentsOfFile: (NSString*)aFile
++ (NSCharacterSet*) characterSetWithContentsOfFile: (NSString*)aFile
 {
   if ([@"bitmap" isEqual: [aFile pathExtension]])
     {
@@ -935,42 +935,42 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
     return nil;
 }
 
-+ (id) URLFragmentAllowedCharacterSet
++ (NSCharacterSet*) URLFragmentAllowedCharacterSet
 {
   return [self _staticSet: URLFragmentAllowedCharSet
 		   length: sizeof(URLFragmentAllowedCharSet)
 		   number: 15]; 
 }
 
-+ (id) URLPasswordAllowedCharacterSet
++ (NSCharacterSet*) URLPasswordAllowedCharacterSet
 {
   return [self _staticSet: URLPasswordAllowedCharSet
 		   length: sizeof(URLPasswordAllowedCharSet)
 		   number: 16];
 }
 
-+ (id) URLPathAllowedCharacterSet
++ (NSCharacterSet*) URLPathAllowedCharacterSet
 {
   return [self _staticSet: URLPathAllowedCharSet
 		   length: sizeof(URLPathAllowedCharSet)
 		   number: 17];
 }
 
-+ (id) URLQueryAllowedCharacterSet
++ (NSCharacterSet*) URLQueryAllowedCharacterSet
 {
   return [self _staticSet: URLQueryAllowedCharSet
 		   length: sizeof(URLQueryAllowedCharSet)
 		   number: 18];
 }
 
-+ (id) URLUserAllowedCharacterSet
++ (NSCharacterSet*) URLUserAllowedCharacterSet
 {
   return [self _staticSet: URLUserAllowedCharSet
 		   length: sizeof(URLUserAllowedCharSet)
 		   number: 19];
 }
 
-+ (id) URLHostAllowedCharacterSet
++ (NSCharacterSet*) URLHostAllowedCharacterSet
 {
   return [self _staticSet: URLHostAllowedCharSet
 		   length: sizeof(URLHostAllowedCharSet)
@@ -1182,123 +1182,123 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
 @implementation NSMutableCharacterSet
 
 /* Override this from NSCharacterSet to create the correct class */
-+ (id) characterSetWithBitmapRepresentation: (NSData*)data
++ (NSCharacterSet*) characterSetWithBitmapRepresentation: (NSData*)data
 {
   return AUTORELEASE([[concreteMutableClass alloc] initWithBitmap: data]);
 }
 
-+ (id) alphanumericCharacterSet
++ (NSCharacterSet*) alphanumericCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) capitalizedLetterCharacterSet
++ (NSCharacterSet*) capitalizedLetterCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) controlCharacterSet
++ (NSCharacterSet*) controlCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) decimalDigitCharacterSet
++ (NSCharacterSet*) decimalDigitCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) decomposableCharacterSet
++ (NSCharacterSet*) decomposableCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) illegalCharacterSet
++ (NSCharacterSet*) illegalCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) letterCharacterSet
++ (NSCharacterSet*) letterCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) lowercaseLetterCharacterSet
++ (NSCharacterSet*) lowercaseLetterCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) newlineCharacterSet
++ (NSCharacterSet*) newlineCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) nonBaseCharacterSet
++ (NSCharacterSet*) nonBaseCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) punctuationCharacterSet
++ (NSCharacterSet*) punctuationCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) symbolCharacterSet
++ (NSCharacterSet*) symbolCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
 // FIXME ... deprecated ... remove after next release.
-+ (id) symbolAndOperatorCharacterSet
++ (NSCharacterSet*) symbolAndOperatorCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) uppercaseLetterCharacterSet
++ (NSCharacterSet*) uppercaseLetterCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) whitespaceAndNewlineCharacterSet
++ (NSCharacterSet*) whitespaceAndNewlineCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) whitespaceCharacterSet
++ (NSCharacterSet*) whitespaceCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLFragmentAllowedCharacterSet
++ (NSCharacterSet*) URLFragmentAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLHostAllowedCharacterSet
++ (NSCharacterSet*) URLHostAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLPasswordAllowedCharacterSet
++ (NSCharacterSet*) URLPasswordAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLPathAllowedCharacterSet
++ (NSCharacterSet*) URLPathAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLQueryAllowedCharacterSet
++ (NSCharacterSet*) URLQueryAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) URLUserAllowedCharacterSet
++ (NSCharacterSet*) URLUserAllowedCharacterSet
 {
   return AUTORELEASE([[abstractClass performSelector: _cmd] mutableCopy]);
 }
 
-+ (id) characterSetWithCharactersInString: (NSString*)aString
++ (NSCharacterSet*) characterSetWithCharactersInString: (NSString*)aString
 {
   NSMutableCharacterSet	*ms;
 
@@ -1307,7 +1307,7 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
   return AUTORELEASE(ms);
 }
 
-+ (id) characterSetWithRange: (NSRange)aRange
++ (NSCharacterSet*) characterSetWithRange: (NSRange)aRange
 {
   NSMutableCharacterSet	*ms;
 


### PR DESCRIPTION
These changes match Apple headers and the actual implementations, i.e. `instancetype` is used if the implementation calls `[self alloc]`, and otherwise the actual type is used.

This enables using dot notation on the returned objects (e.g. `[NSData dataWithContentsOfURL:url].length`), which the compiler will not accept with an `id` return type.