### PR TITLE
NSJSONSerialization: Implement NSJSONWritingSortedKeys

### DIFF
--- a/Headers/Foundation/NSJSONSerialization.h
+++ b/Headers/Foundation/NSJSONSerialization.h
@@ -50,7 +50,13 @@ enum
    * If this is not set, then the writer will not generate any superfluous
    * whitespace, producing space-efficient but not very human-friendly JSON.
    */
-  NSJSONWritingPrettyPrinted = (1UL << 0)
+  NSJSONWritingPrettyPrinted = (1UL << 0),
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_13, GS_API_LATEST)
+  /**
+   * When writing JSON, sort keys in lexicographic order.
+   */
+  NSJSONWritingSortedKeys = (1UL << 1)
+#endif
 };
 /**
  * A bitmask containing flags from the NSJSONWriting* set, specifying options

--- a/Tests/base/NSJSONSerialization/sorted.m
+++ b/Tests/base/NSJSONSerialization/sorted.m
@@ -31,4 +31,5 @@ int main(void) {
   testLexicographicalOrder();
 
   [arp release];
+  return 0;
 }

--- a/Tests/base/NSJSONSerialization/sorted.m
+++ b/Tests/base/NSJSONSerialization/sorted.m
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+void testLexicographicalOrder() {
+  NSArray *objects =
+      [NSArray arrayWithObjects:@"a", @"b", @"c", @"d", @"e", nil];
+  NSArray *keys = [NSArray
+      arrayWithObjects:@"c_ab", @"a_ab", @"d_ab", @"f_cb", @"f_ab", nil];
+  NSDictionary *dict = [NSDictionary dictionaryWithObjects:objects
+                                                   forKeys:keys];
+
+  NSError *error = nil;
+  NSData *actualData =
+      [NSJSONSerialization dataWithJSONObject:dict
+                                      options:NSJSONWritingSortedKeys
+                                        error:&error];
+  PASS_EQUAL(error, nil, "no error occurred during serialisation");
+
+
+  NSString *actual = [[NSString alloc] initWithData:actualData
+                                           encoding:NSUTF8StringEncoding];
+  NSString *expected = @"{\"a_ab\":\"b\",\"c_ab\":\"a\",\"d_ab\":\"c\",\"f_"
+                        "ab\":\"e\",\"f_cb\":\"d\"}";
+  PASS_EQUAL(actual, expected, "JSON is correctly sorted");
+  NSLog(@"%@", actual);
+}
+
+int main(void) {
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+
+  testLexicographicalOrder();
+
+  [arp release];
+}


### PR DESCRIPTION
This PR implements the option NSJSONWritingSortedKeys, which sorts keys of a JSON dictionary in lexicographic order.