### PR TITLE
Tools: Fix build failure with GCC 15

### DIFF
--- a/Tools/gdomap.c
+++ b/Tools/gdomap.c
@@ -2022,11 +2022,11 @@ init_ports()
    *	Turn off pipe signals so we don't get interrupted if we attempt
    *	to write a response to a process which has died.
    */
-  signal(SIGPIPE, SIG_IGN);
+  signal(SIGPIPE, (sighandler_t)SIG_IGN);
   /*
    *	Enable table dumping to /tmp/gdomap.dump
    */
-  signal(SIGUSR1, dump_tables);
+  signal(SIGUSR1, (sighandler_t)dump_tables);
 #endif /* !__MINGW__  */
 }
 
@@ -3704,13 +3704,13 @@ tryWrite(int desc, int tim, unsigned char* dat, int len)
 #if	defined(__MINGW__) /* FIXME: Is this correct? */
 	  rval = send(desc, (const char*)&dat[pos], len - pos, 0);
 #else
-	  void	(*ifun)();
+	  sighandler_t ifun;
 
 	  /*
 	   *	Should be able to write this short a message immediately, but
 	   *	if the connection is lost we will get a signal we must trap.
 	   */
-	  ifun = signal(SIGPIPE, (void(*)(int))SIG_IGN);
+	  ifun = signal(SIGPIPE, (sighandler_t)SIG_IGN);
 	  rval = write(desc, &dat[pos], len - pos);
 	  signal(SIGPIPE, ifun);
 #endif


### PR DESCRIPTION
This pull request fixes build failure with GCC 15.

```
gdomap.c: In function ‘init_ports’:
gdomap.c:2029:19: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
 2029 |   signal(SIGUSR1, dump_tables);
      |                   ^~~~~~~~~~~
      |                   |
      |                   void (*)(void)
In file included from /usr/include/sys/param.h:28,
                 from gdomap.c:40:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
gdomap.c:1138:1: note: ‘dump_tables’ declared here
 1138 | dump_tables()
      | ^~~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
gdomap.c: In function ‘tryWrite’:
gdomap.c:3713:16: error: assignment to ‘void (*)(void)’ from incompatible pointer type ‘__sighandler_t’ {aka ‘void (*)(int)’} [-Wincompatible-pointer-types]
 3713 |           ifun = signal(SIGPIPE, (void(*)(int))SIG_IGN);
      |                ^
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
gdomap.c:3715:27: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
 3715 |           signal(SIGPIPE, ifun);
      |                           ^~~~
      |                           |
      |                           void (*)(void)
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```