### PR TITLE
Bring `-compare:` implementations inline with macos

### DIFF
--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -3662,9 +3662,7 @@ transmute(GSStr self, NSString *aString)
     }
   GS_RANGE_CHECK(aRange, _count);
   if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    return NSOrderedDescending;
   if (GSObjCIsInstance(aString) == NO)
     [NSException raise: NSInvalidArgumentException
 		format: @"[%@ -%@] not a string argument",
@@ -4041,9 +4039,7 @@ agree, create a new GSCInlineString otherwise.
     }
   GS_RANGE_CHECK(aRange, _count);
   if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    return NSOrderedDescending;
   if (GSObjCIsInstance(aString) == NO)
     [NSException raise: NSInvalidArgumentException
 		format: @"[%@ -%@] not a string argument",
@@ -4497,9 +4493,7 @@ agree, create a new GSUInlineString otherwise.
     }
   GS_RANGE_CHECK(aRange, _count);
   if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    return NSOrderedDescending;
   if (GSObjCIsInstance(aString) == NO)
     [NSException raise: NSInvalidArgumentException
 		format: @"[%@ -%@] not a string argument",

--- a/Source/NSDate.m
+++ b/Source/NSDate.m
@@ -396,8 +396,7 @@ static BOOL useSmallDate;
     }
   if (unlikely(otherDate == nil))
     {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"nil argument for compare:"];
+      return NSOrderedSame;
     }
 
   if (IS_CONCRETE_CLASS(otherDate))

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -5914,8 +5914,7 @@ static NSFileManager *fm = nil;
   GS_RANGE_CHECK(compareRange, [self length]);
   if (nil == string)
     {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"compare with nil"];
+      return NSOrderedDescending;
     }
 
   /* A nil locale should trigger POSIX collation (i.e. 'A'-'Z' sort


### PR DESCRIPTION
updates the implementation of `-compare:` vs a `nil` argument to return the same results as the same code running on macos (output from a sample program on macos):
```
NSString 'compare:' nil arg: NSOrderedDescending
NSDate   'compare:' nil arg: NSOrderedSame
NSNumber 'compare:' nil arg: exceptions `-[__NSCFNumber compare:]: nil argument`
```

Related issue: https://github.com/gnustep/libs-base/issues/507