### PR TITLE
feat(NSFileHandle): Add new APIs with error handling, and refactor GSFileHandle

### DIFF
--- a/Headers/Foundation/NSFileHandle.h
+++ b/Headers/Foundation/NSFileHandle.h
@@ -76,6 +76,26 @@ GS_EXPORT_CLASS
 - (NSData*) readDataOfLength: (unsigned int)len;
 - (void) writeData: (NSData*)item;
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
+/**
+ * Writes the specified data synchronously to the file handle.
+ */
+- (BOOL) writeData: (NSData *) data 
+             error: (NSError **) error;
+
+/**
+ * Reads the data synchronously up to the specified number of bytes.
+ */
+- (NSData *) readDataUpToLength: (NSUInteger) length 
+                          error: (NSError **) error;
+
+/**
+ * Reads the data synchronously up to the end of file or maximum number of
+ * bytes.
+ */
+- (NSData *) readDataToEndOfFileAndReturnError: (NSError **) error;
+#endif
+
 // Asynchronous I/O operations
 
 - (void) acceptConnectionInBackgroundAndNotify;
@@ -92,6 +112,27 @@ GS_EXPORT_CLASS
 - (unsigned long long) offsetInFile;
 - (unsigned long long) seekToEndOfFile;
 - (void) seekToFileOffset: (unsigned long long)pos;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
+/**
+ * Get the current position of the file pointer within the file.
+ */
+- (BOOL) getOffset: (unsigned long long *) offsetInFile 
+             error: (NSError **) error;
+
+/**
+ * Sets the file pointer at the end of the file and returns the new file offset.
+ */
+- (BOOL) seekToEndReturningOffset: (unsigned long long *) offsetInFile 
+                            error: (NSError **) error;
+
+/**
+ * Sets the file pointer to the specified offset within the file.
+ */
+- (BOOL) seekToOffset: (unsigned long long) offset 
+                error: (NSError **) error;
+
+#endif
 
 // Operations on file
 

--- a/Headers/Foundation/NSFileHandle.h
+++ b/Headers/Foundation/NSFileHandle.h
@@ -73,7 +73,7 @@ GS_EXPORT_CLASS
 
 - (NSData*) availableData;
 - (NSData*) readDataToEndOfFile;
-- (NSData*) readDataOfLength: (unsigned int)len;
+- (NSData*) readDataOfLength: (NSUInteger)len;
 - (void) writeData: (NSData*)item;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)

--- a/Headers/Foundation/NSFileHandle.h
+++ b/Headers/Foundation/NSFileHandle.h
@@ -132,6 +132,9 @@ GS_EXPORT_CLASS
 - (BOOL) seekToOffset: (unsigned long long) offset 
                 error: (NSError **) error;
 
+- (BOOL) truncateAtOffset: (unsigned long long)offset 
+                    error: (out NSError **)error;
+
 #endif
 
 // Operations on file
@@ -139,17 +142,6 @@ GS_EXPORT_CLASS
 - (void) closeFile;
 - (void) synchronizeFile;
 - (void) truncateFileAtOffset: (unsigned long long)pos;
-
-#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
-- (BOOL) getOffset: (out unsigned long long *)offsetInFile 
-             error: (out NSError **)error;
-- (BOOL) seekToEndReturningOffset: (out unsigned long long *)offsetInFile 
-                            error: (out NSError **)error;
-- (BOOL) seekToOffset: (unsigned long long)offset 
-                error: (out NSError **)error;
-- (BOOL) truncateAtOffset: (unsigned long long)offset 
-                    error: (out NSError **)error;
-#endif
 
 @end
 

--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -1468,7 +1468,7 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
     return  data;
 }
 
-- (NSData*) readDataOfLength: (unsigned)len error: (NSError **) error
+- (NSData*) readDataUpToLength: (NSUInteger)len error: (NSError **) error
 {
   NSMutableData	*d;
   int		got;
@@ -1506,12 +1506,12 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   return d;
 }
 
-- (NSData*) readDataOfLength: (unsigned)len
+- (NSData*) readDataOfLength: (NSUInteger)len
 {
   NSData *data;
   NSError *error = nil;
 
-  data = [self readDataOfLength: len error: &error];
+  data = [self readDataUpToLength: len error: &error];
   if (!data)
     {
       NSError *underlying = [[error userInfo] objectForKey: NSUnderlyingErrorKey];

--- a/Source/GSFileHandle.m
+++ b/Source/GSFileHandle.m
@@ -21,6 +21,8 @@
    Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
    */
 
+#include "Foundation/FoundationErrors.h"
+#include "Foundation/NSError.h"
 #import "common.h"
 #define	EXPOSE_NSFileHandle_IVARS	1
 #define	EXPOSE_GSFileHandle_IVARS	1
@@ -95,6 +97,23 @@
 // Maximum data in single I/O operation
 #define	NETBUF_SIZE	(1024 * 16)
 #define	READ_SIZE	NETBUF_SIZE*10
+
+// Convienience Macro for Error Handling
+#define SET_ERROR(err, errcode, desc) \
+      if (err) \
+      { \
+        NSDictionary *userInfo; \
+        userInfo = [NSDictionary dictionaryWithObject: desc forKey: NSLocalizedDescriptionKey]; \
+        *error = [NSError errorWithDomain: NSCocoaErrorDomain code: errcode userInfo: userInfo]; \
+      }
+
+#define SET_ERROR_WITH_UNDERLYING(err, errcode, underlying, desc) \
+      if (err) \
+      { \
+        NSDictionary *userInfo; \
+        userInfo = [NSDictionary dictionaryWithObjectsAndKeys: desc, NSLocalizedDescriptionKey, underlying, NSUnderlyingErrorKey, nil]; \
+        *err = [NSError errorWithDomain: NSCocoaErrorDomain code: errcode userInfo: userInfo]; \
+      }
 
 static GSFileHandle     *fh_stdin = nil;
 static GSFileHandle     *fh_stdout = nil;
@@ -1179,36 +1198,48 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   return [self initWithFileDescriptor: (uintptr_t)hdl closeOnDealloc: flag];
 }
 
-- (void) checkAccept
+- (BOOL) checkAcceptWithError: (NSError **) error
 {
   if (acceptOK == NO)
-    {
-      [NSException raise: NSFileHandleOperationException
-                  format: @"accept not permitted in this file handle"];
-    }
+  {
+    SET_ERROR(error, NSFileReadNoPermissionError, @"accept not permitted in this file handle");
+    return NO;
+  }
   if (readInfo)
     {
       id	operation = [readInfo objectForKey: NotificationKey];
 
       if (operation == NSFileHandleConnectionAcceptedNotification)
         {
-          [NSException raise: NSFileHandleOperationException
-                      format: @"accept already in progress"];
-	}
+          SET_ERROR(error, NSFileReadUnknownError, @"accept already in progress");
+          return NO;
+        }
       else
-	{
-          [NSException raise: NSFileHandleOperationException
-                      format: @"read already in progress"];
-	}
+        {
+          SET_ERROR(error, NSFileReadUnknownError, @"read already in progress");
+          return NO;
+        }
+    }
+  
+  return YES;
+}
+
+- (void) checkAccept
+{
+  NSError *error = nil;
+  if (![self checkAcceptWithError: &error])
+    {
+      [NSException raise: NSFileHandleOperationException
+                  format: @"%@", [error description]];
     }
 }
 
-- (void) checkConnect
+- (BOOL) checkConnectWithError: (NSError **) error
 {
   if (connectOK == NO)
     {
-      [NSException raise: NSFileHandleOperationException
-                  format: @"connect not permitted in this file handle"];
+      SET_ERROR(error, NSFileWriteNoPermissionError, @"connect not permitted in this file handle")
+      return NO;
     }
   if ([writeInfo count] > 0)
     {
@@ -1217,23 +1248,35 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 
       if (operation == GSFileHandleConnectCompletionNotification)
 	{
-          [NSException raise: NSFileHandleOperationException
-                      format: @"connect already in progress"];
+          SET_ERROR(error, NSFileWriteUnknownError, @"connect already in progress")
+          return NO;
 	}
       else
 	{
-          [NSException raise: NSFileHandleOperationException
-                      format: @"write already in progress"];
+          SET_ERROR(error, NSFileWriteUnknownError, @"write already in progress")
+          return NO;
 	}
+    }
+  
+  return YES;
+}
+
+- (void) checkConnect
+{
+  NSError *error = nil;
+  if (![self checkAcceptWithError: &error])
+    {
+      [NSException raise: NSFileHandleOperationException
+                  format: @"%@", [error description]];
     }
 }
 
-- (void) checkRead
+- (BOOL) checkReadWithError: (NSError **) error
 {
-  if (readOK == NO)
+    if (readOK == NO)
     {
-      [NSException raise: NSFileHandleOperationException
-                  format: @"read not permitted on this file handle"];
+      SET_ERROR(error, NSFileReadNoPermissionError, @"read not permitted on this file handle")
+      return NO;
     }
   if (readInfo)
     {
@@ -1241,23 +1284,35 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 
       if (operation == NSFileHandleConnectionAcceptedNotification)
         {
-          [NSException raise: NSFileHandleOperationException
-                      format: @"accept already in progress"];
+          SET_ERROR(error, NSFileReadUnknownError, @"accept already in progress")
+          return NO;
 	}
       else
 	{
-          [NSException raise: NSFileHandleOperationException
-                      format: @"read already in progress"];
+          SET_ERROR(error, NSFileReadUnknownError, @"read already in progress")
+          return NO;
 	}
+    }
+
+  return YES;
+}
+
+- (void) checkRead
+{
+  NSError *error = nil;
+  if (![self checkReadWithError: &error])
+    {
+      [NSException raise: NSFileHandleOperationException
+                  format: @"%@", [error description]];
     }
 }
 
-- (void) checkWrite
+- (BOOL) checkWriteWithError: (NSError **) error
 {
   if (writeOK == NO)
     {
-      [NSException raise: NSFileHandleOperationException
-                  format: @"write not permitted in this file handle"];
+      SET_ERROR(error, NSFileWriteNoPermissionError, @"write not permitted in this file handle")
+      return NO;
     }
   if ([writeInfo count] > 0)
     {
@@ -1265,11 +1320,24 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
       id		operation = [info objectForKey: NotificationKey];
 
       if (operation != GSFileHandleWriteCompletionNotification)
-	{
-          [NSException raise: NSFileHandleOperationException
-                      format: @"connect in progress"];
-	}
+      {
+        SET_ERROR(error, NSFileWriteUnknownError, @"connect in progress")
+        return NO;
+	    }
     }
+
+  return YES;
+}
+
+- (void) checkWrite
+{
+  NSError *error = nil;
+  if (![self checkWriteWithError: &error])
+  {
+          [NSException raise: NSFileHandleOperationException
+                      format: @"%@", [error description]];
+
+  }
 }
 
 // Returning file handles
@@ -1356,14 +1424,16 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   return d;
 }
 
-- (NSData*) readDataToEndOfFile
-{
+- (NSData *) readDataToEndOfFileAndReturnError:(NSError **)error {
   int			rmax = [GSTcpTune recvSize];
   char			buf[rmax];
   NSMutableData*	d;
   int			len;
 
-  [self checkRead];
+  if (![self checkReadWithError: error])
+    {
+    return nil;
+    }
   if (isNonBlocking == YES)
     {
       [self setNonBlocking: NO];
@@ -1375,21 +1445,40 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
     }
   if (len < 0)
     {
-      [NSException raise: NSFileHandleOperationException
-                  format: @"unable to read from descriptor - %@",
-                  [NSError _last]];
+      SET_ERROR_WITH_UNDERLYING(error, NSFileReadUnknownError, [NSError _last], @"unable to read from descriptor")
+      return nil;
     }
+
   return d;
 }
 
-- (NSData*) readDataOfLength: (unsigned)len
+- (NSData*) readDataToEndOfFile
+{
+  NSData *data;
+  NSError *error = nil;
+
+  data = [self readDataToEndOfFileAndReturnError: &error];
+  if (!data)
+    {
+      NSError *underlying = [[error userInfo] objectForKey: NSUnderlyingErrorKey];
+      [NSException raise: NSFileHandleOperationException
+                  format: @"%@ - %@", [error description], underlying];
+    }
+
+    return  data;
+}
+
+- (NSData*) readDataOfLength: (unsigned)len error: (NSError **) error
 {
   NSMutableData	*d;
   int		got;
   int		rmax = [GSTcpTune recvSize];
   char		buf[rmax];
 
-  [self checkRead];
+  if (![self checkReadWithError: error])
+    {
+      return nil;
+    }
   if (isNonBlocking == YES)
     {
       [self setNonBlocking: NO];
@@ -1408,9 +1497,8 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
 	}
       else if (got < 0)
 	{
-	  [NSException raise: NSFileHandleOperationException
-		      format: @"unable to read from descriptor - %@",
-		      [NSError _last]];
+    SET_ERROR_WITH_UNDERLYING(error, NSFileReadUnknownError, [NSError _last], @"unable to read from descriptor");
+    return nil;
 	}
     }
   while (len > 0 && got > 0);
@@ -1418,14 +1506,33 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
   return d;
 }
 
-- (void) writeData: (NSData*)item
+- (NSData*) readDataOfLength: (unsigned)len
 {
-  int		rval = 0;
+  NSData *data;
+  NSError *error = nil;
+
+  data = [self readDataOfLength: len error: &error];
+  if (!data)
+    {
+      NSError *underlying = [[error userInfo] objectForKey: NSUnderlyingErrorKey];
+      [NSException raise: NSFileHandleOperationException
+                  format: @"%@ - %@", [error description], underlying];
+    }
+
+  return data;
+}
+
+- (BOOL) writeData: (NSData*)item error: (NSError **) error
+{
+    int		rval = 0;
   const void*	ptr = [item bytes];
   unsigned int	len = [item length];
   unsigned int	pos = 0;
 
-  [self checkWrite];
+  if (![self checkWriteWithError: error])
+    {
+      return NO;
+    }
   if (isNonBlocking == YES)
     {
       [self setNonBlocking: NO];
@@ -1454,9 +1561,22 @@ NSString * const GSSOCKSRecvAddr = @"GSSOCKSRecvAddr";
     }
   if (rval < 0)
     {
+      SET_ERROR_WITH_UNDERLYING(error, NSFileWriteUnknownError, [NSError _last], @"unable to write to descriptor")
+      return NO;
+    }
+
+  return YES;
+}
+
+- (void) writeData: (NSData*)item
+{
+  NSError *error = nil;
+
+  if (![self writeData: item error: &error])
+    {
+      NSError *underlying = [[error userInfo] objectForKey: NSUnderlyingErrorKey];
       [NSException raise: NSFileHandleOperationException
-                  format: @"unable to write to descriptor - %@",
-                  [NSError _last]];
+                  format: @"%@ - %@", [error description], underlying];
     }
 }
 

--- a/Source/NSFileHandle.m
+++ b/Source/NSFileHandle.m
@@ -319,6 +319,23 @@ static Class NSFileHandle_ssl_class = nil;
   [self subclassResponsibility: _cmd];
 }
 
+- (BOOL)writeData:(NSData *)data error:(NSError **)error
+{
+  [self subclassResponsibility: _cmd];
+  return NO;
+}
+
+- (NSData *)readDataUpToLength:(NSUInteger)length error:(NSError **)error
+{
+  [self subclassResponsibility: _cmd];
+  return nil;
+}
+
+- (NSData *)readDataToEndOfFileAndReturnError:(NSError **)error
+{
+  [self subclassResponsibility: _cmd];
+  return nil;
+}
 
 // Asynchronous I/O operations
 

--- a/Source/NSFileHandle.m
+++ b/Source/NSFileHandle.m
@@ -305,7 +305,7 @@ static Class NSFileHandle_ssl_class = nil;
 /**
  *  Reads up to len bytes from file or communications channel into return data.
  */
-- (NSData*) readDataOfLength: (unsigned int)len
+- (NSData*) readDataOfLength: (NSUInteger)len
 {
   [self subclassResponsibility: _cmd];
   return nil;

--- a/Tests/base/NSFileHandle/reading.m
+++ b/Tests/base/NSFileHandle/reading.m
@@ -1,0 +1,46 @@
+#include "Foundation/NSObjCRuntime.h"
+#import "Testing.h"
+#import "ObjectTesting.h"
+#import <Foundation/Foundation.h>
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileHandle *writeFH, *readFH;
+  NSString *tempPath = [NSString stringWithFormat:@"%@/%@", NSTemporaryDirectory(), [[NSProcessInfo processInfo] globallyUniqueString]];
+  NSData *writeData = [@"GNUstep-Testing" dataUsingEncoding: NSUTF8StringEncoding];
+  NSData *readData;
+  NSError *error = nil;
+
+  PASS([@"" writeToFile: tempPath atomically: YES],
+       "Created temp file");
+
+  writeFH = [NSFileHandle fileHandleForWritingAtPath: tempPath];
+  PASS(writeFH != nil, "+fileHandleForWritingAtPath: opened successfully");
+
+  BOOL writeResult = [writeFH writeData: writeData error: &error];
+  PASS(writeResult && error == nil,
+       "-writeData:error: wrote successfully");
+
+  [writeFH closeFile];
+
+  readFH = [NSFileHandle fileHandleForReadingAtPath: tempPath];
+  PASS(readFH != nil, "+fileHandleForReadingAtPath: opened successfully");
+
+  readData = [readFH readDataUpToLength: [writeData length] error: &error];
+  PASS(error == nil && [readData isEqual: writeData],
+       "-readDataUpToLength:error: returns correct data");
+
+  [readFH seekToFileOffset: 0];
+
+  readData = [readFH readDataToEndOfFileAndReturnError: &error];
+  PASS(error == nil && [readData isEqual: writeData],
+       "-readDataToEndOfFileAndReturnError: returns correct data");
+
+
+  [readFH closeFile];
+  [[NSFileManager defaultManager] removeItemAtPath: tempPath error: NULL];
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSString/basic.m
+++ b/Tests/base/NSString/basic.m
@@ -1,6 +1,7 @@
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSString.h>
+#import <Foundation/NSByteOrder.h>
 
 static NSString*
 makeFormattedString(NSString *theFormat, ...)


### PR DESCRIPTION
As part of Apple's ongoing improvements for interoperability between Swift and Foundation, a significant part of NSFileHandle was deprecated in favour of methods that write out errors.

This pull request implements the following new APIs:
```objc
- (BOOL) writeData: (NSData *) data 
             error: (NSError **) error;
- (NSData *) readDataUpToLength: (NSUInteger) length 
                          error: (NSError **) error;
- (NSData *) readDataToEndOfFileAndReturnError: (NSError **) error;
```

Refactors GSFileHandle to return errors in private helper methods, and fixes some declaration differences between Apple's Foundation and GNUstep.