### PR TITLE
expose declarations in NSDebug.h even when NDEBUG is defined

### DIFF
--- a/Headers/Foundation/NSDebug.h
+++ b/Headers/Foundation/NSDebug.h
@@ -115,8 +115,6 @@ extern "C" {
  */
 extern BOOL NSDebugEnabled;
 
-#ifndef	NDEBUG
-
 /**
  * Used internally by NSAllocateObject() ... you probably don't need this.
  */
@@ -320,8 +318,6 @@ GS_EXPORT id GSDebugAllocationTagRecordedObject(id object, id tag);
 GS_EXPORT void  GSSetDebugAllocationFunctions(
   void (*newAddObjectFunc)(Class c, id o),
   void (*newRemoveObjectFunc)(Class c, id o));
-
-#endif
 
 /**
  * Enable/disable zombies.


### PR DESCRIPTION
Fixes #513. I don't know if this is the right solution to the problem, since I don't know why the declarations were hidden when NDEBUG was defined in the first place.