### PR TITLE
Add support for Rocky Linux 8 / libcurl 7.61

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,15 @@ jobs:
             CXX: clang++
             libdir: lib
 
-          - name: Rocky Linux x64 Clang gnustep-2.2
+          - name: Rocky Linux 8 x64 Clang gnustep-2.2
+            container: rockylinux:8
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-2.2
+            CC: clang
+            CXX: clang++
+            libdir: lib64
+
+          - name: Rocky Linux 9 x64 Clang gnustep-2.2
             container: rockylinux:9
             library-combo: ng-gnu-gnu
             runtime-version: gnustep-2.2

--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -397,9 +397,6 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
-/* Define to 1 if you have the `resolv' library (-lresolv). */
-#undef HAVE_LIBRESOLV
-
 /* Define to 1 if you have the `rt' library (-lrt). */
 #undef HAVE_LIBRT
 

--- a/Source/NSURLSessionConfiguration.m
+++ b/Source/NSURLSessionConfiguration.m
@@ -27,8 +27,11 @@
  * Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
  */
 
+#import "Foundation/NSException.h"
 #import "Foundation/NSURLSession.h"
 #import "Foundation/NSHTTPCookie.h"
+
+#include <curl/curl.h>
 
 // TODO: This is the old implementation. It requires a rewrite!
 
@@ -166,7 +169,14 @@ static NSURLSessionConfiguration * def = nil;
 
 - (void) setHTTPMaximumConnectionLifetime: (NSInteger)n
 {
+#if CURL_AT_LEAST_VERSION(7, 66, 0)
   _HTTPMaximumConnectionLifetime = n;
+#else
+  [NSException raise: NSInternalInconsistencyException
+    format: @"-[%@ %@] not supported by the version of Curl"
+    @" this library was built with",
+    NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+#endif
 }
 
 - (BOOL) HTTPShouldUsePipelining

--- a/Source/NSURLSessionTask.m
+++ b/Source/NSURLSessionTask.m
@@ -174,7 +174,9 @@ errorForCURLcode(CURL *handle, CURLcode code, char errorBuffer[CURL_ERROR_SIZE])
       case CURLE_COULDNT_RESOLVE_HOST:
         urlError = NSURLErrorDNSLookupFailed;
         break;
+#if CURL_AT_LEAST_VERSION(7, 69, 0)
       case CURLE_QUIC_CONNECT_ERROR:
+#endif
       case CURLE_COULDNT_CONNECT:
         urlError = NSURLErrorCannotConnectToHost;
         break;
@@ -1048,10 +1050,12 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       /* Set to HTTP/3 if requested */
       if ([request assumesHTTP3Capable])
         {
+#if CURL_AT_LEAST_VERSION(7, 66, 0)
           curl_easy_setopt(
             _easyHandle,
             CURLOPT_HTTP_VERSION,
             CURL_HTTP_VERSION_3);
+#endif
         }
 
       /* Configure the custom CA certificate if available */

--- a/configure
+++ b/configure
@@ -14686,9 +14686,9 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null && test "$SKIP_CURL_CONFIG
   curl_ver=`$CURL_CONFIG --version | sed -e "s/libcurl //g"`
   curl_maj=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\1/"`
   curl_min=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\2/"`
-  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 66 \); then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use" >&5
-printf "%s\n" "FAILED (version too old to use" >&6; }
+  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 61 \); then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version $curl_ver too old to use, need at least 7.61)" >&5
+printf "%s\n" "FAILED (version $curl_ver too old to use, need at least 7.61)" >&6; }
   else
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes ... version $curl_ver" >&5
 printf "%s\n" "yes ... version $curl_ver" >&6; }
@@ -14718,7 +14718,7 @@ else
     if pkg-config --exists libcurl; then
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes ... via pkg-config" >&5
 printf "%s\n" "yes ... via pkg-config" >&6; }
-      if $PKG_CONFIG --atleast-version 2.66.0 libcurl; then
+      if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
                for ac_header in curl/curl.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "curl/curl.h" "ac_cv_header_curl_curl_h" "$ac_includes_default"
@@ -14740,8 +14740,8 @@ done
           curl_all=yes
         fi
         else
-          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use" >&5
-printf "%s\n" "FAILED (version too old to use" >&6; }
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use, need at least 7.61)" >&5
+printf "%s\n" "FAILED (version too old to use, need at least 7.61)" >&6; }
           curl_all=no
       fi
     else

--- a/configure.ac
+++ b/configure.ac
@@ -3757,8 +3757,8 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null && test "$SKIP_CURL_CONFIG
   curl_ver=`$CURL_CONFIG --version | sed -e "s/libcurl //g"`
   curl_maj=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\1/"`
   curl_min=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\2/"`
-  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 66 \); then
-    AC_MSG_RESULT([FAILED (version too old to use])
+  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 61 \); then
+    AC_MSG_RESULT([FAILED (version $curl_ver too old to use, need at least 7.61)])
   else
     AC_MSG_RESULT(yes ... version $curl_ver)
     AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
@@ -3775,7 +3775,7 @@ else
   if test -n "$PKG_CONFIG"; then
     if pkg-config --exists libcurl; then
       AC_MSG_RESULT(yes ... via pkg-config)
-      if $PKG_CONFIG --atleast-version 2.66.0 libcurl; then
+      if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
         AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
         if test "$curl_ok" = yes; then
           HAVE_LIBCURL=1
@@ -3786,7 +3786,7 @@ else
           curl_all=yes
         fi
         else
-          AC_MSG_RESULT([FAILED (version too old to use])
+          AC_MSG_RESULT([FAILED (version too old to use, need at least 7.61)])
           curl_all=no
       fi
     else


### PR DESCRIPTION
RHEL 8 (and other members of the RHEL family, such as Rocky Linux 8) ship with libcurl 7.61.

With the latest release, curl was made a hard requirement when compiling with the ng runtime, and the minimum version was bumped to 7.66.  This means support for RHEL 8 was dropped when using the ng runtime.

This PR:
1. Adds a CI job which tests on Rocky Linux 8
2. Relaxes the curl requirement from 7.66 to 7.61

The changes look fairly minimal, and increase backward compatibility, so I hope this is worth the effort.