### PR TITLE
cast to iconv_t which is correct according to declaration and get rid of warnings

### DIFF
--- a/config/pathtls.m4
+++ b/config/pathtls.m4
@@ -6,10 +6,12 @@ dnl  notice and this notice are preserved.
 dnl AM_PATH_TLS([MINIMUM-VERSION [, ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
 AC_DEFUN([AM_PATH_TLS],[
 AC_ARG_WITH(tls-prefix,
-            [  --with-tls-prefix=PFX    Prefix where libgnutls is installed (optional)],
+            [AS_HELP_STRING([--with-tls-prefix=PFX],
+	    [Prefix where libgnutls is installed (optional)])],
             tls_config_prefix="$withval", tls_config_prefix="")
 AC_ARG_ENABLE(tlstest,
-              [  --disable-tlstest		Do not try to compile and run a test TLS program],,
+              [AS_HELP_STRING([--disable-tlstest],
+	      [Do not try to compile and run a test TLS program])],,
               enable_tlstest=yes)
 
   if test x$tls_config_prefix != x ; then

--- a/config/pathxml.m4
+++ b/config/pathxml.m4
@@ -6,10 +6,12 @@ dnl  notice and this notice are preserved.
 dnl AM_PATH_XML([MINIMUM-VERSION [, ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
 AC_DEFUN([AM_PATH_XML],[
 AC_ARG_WITH(xml-prefix,
-            [  --with-xml-prefix=PFX    Prefix where libxml is installed (optional)],
+            AS_HELP_STRING([--with-xml-prefix=PFX],
+	    [Prefix where libxml is installed (optional)]),
             xml_config_prefix="$withval", xml_config_prefix="")
 AC_ARG_ENABLE(xmltest,
-              [  --disable-xmltest		Do not try to compile and run a test XML program],,
+              [AS_HELP_STRING([--disable-xmltest],
+	      [Do not try to compile and run a test XML program])],,
               enable_xmltest=yes)
 
   if test x$xml_config_prefix != x ; then

--- a/config/procfs.m4
+++ b/config/procfs.m4
@@ -8,8 +8,9 @@ dnl AC_SYS_PROCFS
 dnl This macro defines HAVE_PROCFS if either it finds a mounted /proc
 dnl or the user explicitly enables it for cross-compiles.
 AC_DEFUN([AC_SYS_PROCFS],
-[ AC_ARG_ENABLE(procfs,
-    [  --enable-procfs               Use /proc filesystem (default)],
+  [AC_ARG_ENABLE(procfs,
+    [AS_HELP_STRING([--enable-procfs],
+    [Use /proc filesystem (default)])],
     enable_procfs="$enableval", if test "$cross_compiling" = yes; then enable_procfs=cross; else enable_procfs=yes; fi;)
 
   AC_CACHE_CHECK([kernel support for /proc filesystem], ac_cv_sys_procfs,
@@ -49,8 +50,9 @@ dnl AC_SYS_PROCFS_PSINFO
 dnl This macro defines HAVE_PROCFS_PSINFO if it can read the psinfo 
 dnl structure from the /proc/%pid% directory
 AC_DEFUN([AC_SYS_PROCFS_PSINFO],
-[ AC_ARG_ENABLE(procfs-psinfo,
-    [  --enable-procfs-psinfo         Use /proc/%pid% to get info],
+  [AC_ARG_ENABLE(procfs-psinfo,
+    [AS_HELP_STRING([--enable-procfs-psinfo],
+    [Use /proc/%pid% to get info])],
     enable_procfs_psinfo="$enableval", if test "$cross_compiling" = yes; then enable_procfs_psinfo=cross; else enable_procfs_psinfo=yes; fi;)
 
   AC_CACHE_CHECK([support for /proc psinfo struct], ac_cv_sys_procfs_psinfo,

--- a/configure
+++ b/configure
@@ -1512,132 +1512,126 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --disable-environment-config-file
-                                Disables the use of the GNUSTEP_CONFIG_FILE
-				environment variable to specify/override
-				the location of the GNUstep config file
-				at runtime.  This option is occasionally
-				useful to disable the environment variable
-				for sites which wish to 'lock down' users
-				to always work with a specific system-wide
-				configuration.  On unix-like systems the
-				default is for this option to be enabled.
-				It is disabled by default on windows systems
-				so that the base library will not use a
-				config file intended for the gnustep-make
-				system (and containing unix-style paths
-				which cannot be used by windows apps).
-				Normally this should be left at its default
-				setting.
+                          Disables the use of the GNUSTEP_CONFIG_FILE
+                          environment variable to specify/override the
+                          location of the GNUstep config file at runtime. This
+                          option is occasionally useful to disable the
+                          environment variable for sites which wish to 'lock
+                          down' users to always work with a specific
+                          system-wide configuration. On unix-like systems the
+                          default is for this option to be enabled. It is
+                          disabled by default on windows systems so that the
+                          base library will not use a config file intended for
+                          the gnustep-make system (and containing unix-style
+                          paths which cannot be used by windows apps).
+                          Normally this should be left at its default setting.
   --disable-importing-config-file
-                                Disable importing of an existing GNUstep config
-				file and use inbuilt defaults instead.
+                          Disable importing of an existing GNUstep config file
+                          and use inbuilt defaults instead.
   --disable-largefile     omit support for large files
   --enable-nxconstantstring
-	    Enables the use of the NXConstantString class for old compilers.
-  --enable-bfd
-	Enables the use of libbfd to provide symbolic stack traces.
-	Enabling this option provides support for symbolic stack traces
-	on platforms where the backtrace_symbols() function is not
-	available or does not work properly.
-	Enabling this option also has the effect of changing the license
-	of gnustep-base from LGPL to GPL since libbfd uses the GPL license
-  --enable-procfs               Use /proc filesystem (default)
-  --enable-procfs-psinfo         Use /proc/%pid% to get info
-  --enable-pass-arguments	Force user main call to NSProcessInfo initialize
-  --enable-fake-main  		Force redefine of user main function
-  --disable-libffi  		Disable use of libffi library
-  --enable-ffcall  		Enable use of the deprecated ffcall library
-  --disable-invocations		Build even if invocation-dependencies are not met
-  --disable-iconv		Build even if iconv is not available
-  --enable-limitediconv		Build even if iconv does not support lossy conversion
-  --disable-xml			Build even if XML-dependencies are not met
-  --disable-xmltest		Do not try to compile and run a test XML program
-  --disable-xslt		Build even if XSLT-dependency is not met
-  --disable-tls			Disable use of GNUTLS
-  --disable-tlstest		Do not try to compile and run a test TLS program
-  --disable-zeroconf		Disable NSNetServices support
-  --disable-icu			Disable International Components for Unicode
-  --disable-libdispatch		Disable dispatching blocks via libdispatch
-  --disable-newkvo		Disable new KVO implementation
-  --disable-nsurlsession  		Disable support for NSURLSession
-
-  --enable-setuid-gdomap        Enable installing gdomap as a setuid
-                                executable.  By default, it is installed
-                                as a normal program intended to be started
-				by root at system boot time, but it can
-                                also be started up automatically
-                                by any user at any time.  Use this
-                                option if you are happy having the program
-                                started automatically on demand.
-
+                          Enables the use of the NXConstantString class for
+                          old compilers.
+  --enable-bfd            Enables the use of libbfd to provide symbolic stack
+                          traces. Enabling this option provides support for
+                          symbolic stack traces on platforms where the
+                          backtrace_symbols() function is not available or
+                          does not work properly. Enabling this option also
+                          has the effect of changing the license of
+                          gnustep-base from LGPL to GPL since libbfd uses the
+                          GPL license
+  --enable-procfs         Use /proc filesystem (default)
+  --enable-procfs-psinfo  Use /proc/%pid% to get info
+  --enable-pass-arguments Force user main call to NSProcessInfo initialize
+  --enable-fake-main      Force redefine of user main function
+  --disable-libffi        Disable use of libffi library
+  --enable-ffcall         Enable use of the deprecated ffcall library
+  --disable-invocations   Build even if invocation-dependencies are not met
+  --disable-iconv         Build even if iconv is not available
+  --enable-limitediconv   Build even if iconv does not support lossy
+                          conversion
+  --disable-xm            Build even if XML-dependencies are not met
+  --disable-xmltest       Do not try to compile and run a test XML program
+  --disable-xslt          Build even if XSLT-dependency is not met
+  --disable-tls           Disable use of GNUTLS
+  --disable-tlstest       Do not try to compile and run a test TLS program
+  --disable-zeroconf      Disable NSNetServices support
+  --disable-icu           Disable International Components for Unicode
+  --disable-libdispatch   Disable dispatching blocks via libdispatch
+  --disable-newkvo        Disable new KVO implementation
+  --disable-nsurlsession  Disable support for NSURLSession
+  --enable-setuid-gdomap  Enable installing gdomap as a setuid executable. By
+                          default, it is installed as a normal program
+                          intended to be started by root at system boot time,
+                          but it can also be started up automatically by any
+                          user at any time. Use this option if you are happy
+                          having the program started automatically on demand.
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-cross-compilation-info=PATH
-				Specify path to the configuration file that
-				contains information for the configure script in
-				case of cross compilation. This information
-				replaces those obtained from running programmes
-				during the configuration phase.
-  --with-config-file=PATH       Specify path to the GNUstep config file.
-				This is the location to be used by the base
-				library to locate path information at
-				application or tool runtime.
-				This file might not even exist now; it is
-				not read at configure time.  The base library
-				will only read it at runtime.
-				If unspecified, this uses the same value as
-				the GNUstep make package on unix-like systems,
-				but uses ./GNUstep.conf on mingw so that
-				it is relative to the location of the
-				base library DLL.
-				If a leading './' is specified, the path
-				is taken to be relative to the base library
-				linked runtime, not all operating systems
-				can support this, so on some platforms you
-				may need to specify the location of the
-				config file using the GNUSTEP_CONFIG_FILE
-				environment variable at runtime.
-				If a trailing '/' is specified, the path is
-				used for locating domains but no GNUstep
-				config file is read at runtime.
-  --with-default-config=PATH   Specify path to a GNUstep config file to be
-				imported at configure time (now) and used to
-				provide default values for the base library
-				to use at runtime if no GNUstep config file
-				is found at runtime.  If this is not specified
-				then the path from the gnustep-make package
-				is used.
+                          Specify path to the configuration file that contains
+                          information for the configure script in case of
+                          cross compilation. This information replaces those
+                          obtained from running programmes during the
+                          configuration phase.
+  --with-config-file=PATH Specify path to the GNUstep config file. This is the
+                          location to be used by the base library to locate
+                          path information at application or tool runtime.
+                          This file might not even exist now; it is not read
+                          at configure time. The base library will only read
+                          it at runtime. If unspecified, this uses the same
+                          value as the GNUstep make package on unix-like
+                          systems, but uses ./GNUstep.conf on mingw so that it
+                          is relative to the location of the base library DLL.
+                          If a leading './' is specified, the path is taken to
+                          be relative to the base library linked runtime, not
+                          all operating systems can support this, so on some
+                          platforms you may need to specify the location of
+                          the config file using the GNUSTEP_CONFIG_FILE
+                          environment variable at runtime. If a trailing '/'
+                          is specified, the path is used for locating domains
+                          but no GNUstep config file is read at runtime.
+  --with-default-config=PATH
+                          Specify path to a GNUstep config file to be imported
+                          at configure time (now) and used to provide default
+                          values for the base library to use at runtime if no
+                          GNUstep config file is found at runtime. If this is
+                          not specified then the path from the gnustep-make
+                          package is used.
   --with-installation-domain=DOMAIN
-				Specify the domain (SYSTEM, LOCAL,
-				NETWORK or USER) into which
-				gnustep-base will be installed.
-				Whenever relative paths are hardcoded
-				into gnustep-base (at the moment, this
-				happens only on MinGW) this option
-				must be used and must match the domain
-				where you will be installing
-				gnustep-base.
-				If this is not specified, the output of
-				gnustep-config --installation-domain-for=gnustep-base
-				(which should normally be LOCAL) is used.
+                          Specify the domain (SYSTEM, LOCAL, NETWORK or USER)
+                          into which gnustep-base will be installed. Whenever
+                          relative paths are hardcoded into gnustep-base (at
+                          the moment, this happens only on MinGW) this option
+                          must be used and must match the domain where you
+                          will be installing gnustep-base. If this is not
+                          specified, the output of gnustep-config
+                          --installation-domain-for=gnustep-base (which should
+                          normally be LOCAL) is used.
   --without-unwind        Ignore unwind if found and disable it
-  --with-include-flags=FLAGS    Specify all include flags at once
-  --with-library-flags=FLAGS    Specify all library flags at once
-  --with-ffi-include=PATH       Include path for ffi headers
-  --with-ffi-library=PATH       Library path for ffi libs
-  --with-libiconv-library=PATH  Library path for libiconv libraries
-  --with-libiconv-include=PATH  Include path for libiconv header
-  --with-xml-prefix=PFX    Prefix where libxml is installed (optional)
-  --with-tls-prefix=PFX    Prefix where libgnutls is installed (optional)
-  --with-zeroconf-api=API  force use of a specific zeroconf API (mdns or avahi)
-  --with-dispatch-include=PATH       Include path for dispatch header
-  --with-dispatch-library=PATH       Library path for dispatch lib
+  --with-include-flags=FLAGS
+                          Specify all include flags at once
+  --with-library-flags=FLAGS
+                          Specify all library flags at once
+  --with-ffi-include=PATH Include path for ffi headers
+  --with-ffi-library=PATH Library path for ffi libs
+  --with-libiconv-library=PATH
+                          Library path for libiconv libraries
+  --with-libiconv-include=PATH
+                          Include path for libiconv header
+  --with-xml-prefix=PFX   Prefix where libxml is installed (optional)
+  --with-tls-prefix=PFX   Prefix where libgnutls is installed (optional)
+  --with-zeroconf-api=API force use of a specific zeroconf API (mdns or avahi)
+  --with-dispatch-include=PATH
+                          Include path for dispatch header
+  --with-dispatch-library=PATH
+                          Library path for dispatch lib
   --with-curl=<DIR>       use curl installed in directory <DIR>
-  --with-gmp-include=PATH  include path for gmp headers
-  --with-gmp-library=PATH  library path for gmp libraries
-  --with-gdomap-port=PORT  alternative port for gdomap
+  --with-gmp-include=PATH include path for gmp headers
+  --with-gmp-library=PATH library path for gmp libraries
+  --with-gdomap-port=PORT alternative port for gdomap
 
 Some influential environment variables:
   CC          C compiler command
@@ -11804,7 +11798,7 @@ then :
 
 fi
 
- # Check whether --enable-procfs was given.
+# Check whether --enable-procfs was given.
 if test ${enable_procfs+y}
 then :
   enableval=$enable_procfs; enable_procfs="$enableval"
@@ -11856,7 +11850,7 @@ printf "%s\n" "#define HAVE_PROCFS 1" >>confdefs.h
   fi
 
 
- # Check whether --enable-procfs-psinfo was given.
+# Check whether --enable-procfs-psinfo was given.
 if test ${enable_procfs_psinfo+y}
 then :
   enableval=$enable_procfs_psinfo; enable_procfs_psinfo="$enableval"
@@ -12876,10 +12870,13 @@ printf "%s\n" "no" >&6; }
   echo
   echo "You do not appear to have usable iconv header/library."
   echo "Building without them will disable much characterset support."
-  echo "If you really want to build gnustep-base without character conversion"
-  echo " support, please add --disable-iconv to the configure arguments."
   echo "Try adjusting --with-libiconv-include and --with-libiconv-library"
-  echo "If you have iconv installed."
+  echo " if you have iconv installed in an unusual location."
+  echo "If your iconv does not support the TRANSLIT operation (needed for"
+  echo " lossy character conversion), either install a more fully featured"
+  echo " version of iconv, or use the --enable-limitediconv argument."
+  echo "If you want to build gnustep-base with minimal character conversion"
+  echo " support, please add --disable-iconv to the configure arguments."
   as_fn_error $? "Missing support for character conversion functionality." "$LINENO" 5
 fi
 fi

--- a/configure
+++ b/configure
@@ -849,7 +849,7 @@ with_ffi_library
 enable_iconv
 with_libiconv_library
 with_libiconv_include
-enable_stricticonv
+enable_limitediconv
 enable_xml
 with_xml_prefix
 enable_xmltest
@@ -1549,7 +1549,7 @@ Optional Features:
   --enable-ffcall  		Enable use of the deprecated ffcall library
   --disable-invocations		Build even if invocation-dependencies are not met
   --disable-iconv		Build even if iconv is not available
-  --enable-stricticonv		Build even if iconv is strict
+  --enable-limitediconv		Build even if iconv does not support lossy conversion
   --disable-xml			Build even if XML-dependencies are not met
   --disable-xmltest		Do not try to compile and run a test XML program
   --disable-xslt		Build even if XSLT-dependency is not met
@@ -2207,7 +2207,7 @@ else $as_nop
 #define $2 innocuous_$2
 
 /* System header to define __stub macros and hopefully few prototypes,
-   which can conflict with char $2 (); below.  */
+   which can conflict with char $2 (void); below.  */
 
 #include <limits.h>
 #undef $2
@@ -2218,7 +2218,7 @@ else $as_nop
 #ifdef __cplusplus
 extern "C"
 #endif
-char $2 ();
+char $2 (void);
 /* The GNU C library defines this for functions which it implements
     to always fail with ENOSYS.  Some functions are actually named
     something starting with __ and the normal name is an alias.  */
@@ -2671,9 +2671,7 @@ struct stat;
 /* Most of the following tests are stolen from RCS 5.7 src/conf.sh.  */
 struct buf { int x; };
 struct buf * (*rcsopen) (struct buf *, struct stat *, int);
-static char *e (p, i)
-     char **p;
-     int i;
+static char *e (char **p, int i)
 {
   return p[i];
 }
@@ -2724,6 +2722,7 @@ extern int puts (const char *);
 extern int printf (const char *, ...);
 extern int dprintf (int, const char *, ...);
 extern void *malloc (size_t);
+extern void free (void *);
 
 // Check varargs macros.  These examples are taken from C99 6.10.3.5.
 // dprintf is used instead of fprintf to avoid needing to declare
@@ -6813,22 +6812,23 @@ unsigned short int ascii_mm[] =
 		int use_ebcdic (int i) {
 		  return ebcdic_mm[i] + ebcdic_ii[i];
 		}
-		extern int foo;
-
-int
-main (void)
-{
-return use_ascii (foo) == use_ebcdic (foo);
-  ;
-  return 0;
-}
+		int
+		main (int argc, char **argv)
+		{
+		  /* Intimidate the compiler so that it does not
+		     optimize the arrays away.  */
+		  char *p = argv[0];
+		  ascii_mm[1] = *p++; ebcdic_mm[1] = *p++;
+		  ascii_ii[1] = *p++; ebcdic_ii[1] = *p++;
+		  return use_ascii (argc) == use_ebcdic (*p);
+		}
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
+if ac_fn_c_try_link "$LINENO"
 then :
-  if grep BIGenDianSyS conftest.$ac_objext >/dev/null; then
+  if grep BIGenDianSyS conftest$ac_exeext >/dev/null; then
 	      ac_cv_c_bigendian=yes
 	    fi
-	    if grep LiTTleEnDian conftest.$ac_objext >/dev/null ; then
+	    if grep LiTTleEnDian conftest$ac_exeext >/dev/null ; then
 	      if test "$ac_cv_c_bigendian" = unknown; then
 		ac_cv_c_bigendian=no
 	      else
@@ -6837,7 +6837,8 @@ then :
 	      fi
 	    fi
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -7556,8 +7557,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char dladdr ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dladdr (void);
 int
 main (void)
 {
@@ -7620,8 +7627,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char gethostbyname ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gethostbyname (void);
 int
 main (void)
 {
@@ -7682,8 +7695,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char res_query ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char res_query (void);
 int
 main (void)
 {
@@ -7971,8 +7990,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char pthread_join ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join (void);
 int
 main (void)
 {
@@ -8019,8 +8044,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char pthread_join ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join (void);
 int
 main (void)
 {
@@ -8066,8 +8097,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char pthread_join ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join (void);
 int
 main (void)
 {
@@ -8114,8 +8151,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char pthread_join ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join (void);
 int
 main (void)
 {
@@ -8182,8 +8225,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char sched_yield ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char sched_yield (void);
 int
 main (void)
 {
@@ -9984,8 +10033,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char libintl_fprintf ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char libintl_fprintf (void);
 int
 main (void)
 {
@@ -10027,8 +10082,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char ZSTD_compress ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char ZSTD_compress (void);
 int
 main (void)
 {
@@ -10070,8 +10131,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char dyn_string_append ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dyn_string_append (void);
 int
 main (void)
 {
@@ -10113,8 +10180,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char gzseek ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gzseek (void);
 int
 main (void)
 {
@@ -10155,8 +10228,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char sframe ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char sframe (void);
 int
 main (void)
 {
@@ -10215,8 +10294,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char bfd_openr ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char bfd_openr (void);
 int
 main (void)
 {
@@ -10616,8 +10701,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char opendir ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char opendir (void);
 int
 main (void)
 {
@@ -10676,8 +10767,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char opendir ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char opendir (void);
 int
 main (void)
 {
@@ -11140,8 +11237,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char inet_ntop ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char inet_ntop (void);
 int
 main (void)
 {
@@ -11241,8 +11344,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char gzseek ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gzseek (void);
 int
 main (void)
 {
@@ -11885,8 +11994,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char kvm_getenvv ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char kvm_getenvv (void);
 int
 main (void)
 {
@@ -12605,17 +12720,17 @@ fi
 
 fi
 
-# Check whether --enable-stricticonv was given.
-if test ${enable_stricticonv+y}
+# Check whether --enable-limitediconv was given.
+if test ${enable_limitediconv+y}
 then :
-  enableval=$enable_stricticonv;
+  enableval=$enable_limitediconv;
 else $as_nop
-  enable_stricticonv=no
+  enable_limitediconv=no
 fi
 
-if test $enable_stricticonv = yes; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking non-lossy iconv support" >&5
-printf %s "checking non-lossy iconv support... " >&6; }
+if test $enable_limitediconv = yes; then
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking iconv without lossy conversion support" >&5
+printf %s "checking iconv without lossy conversion support... " >&6; }
 if test "$cross_compiling" = yes
 then :
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -12763,6 +12878,8 @@ printf "%s\n" "no" >&6; }
   echo "Building without them will disable much characterset support."
   echo "If you really want to build gnustep-base without character conversion"
   echo " support, please add --disable-iconv to the configure arguments."
+  echo "Try adjusting --with-libiconv-include and --with-libiconv-library"
+  echo "If you have iconv installed."
   as_fn_error $? "Missing support for character conversion functionality." "$LINENO" 5
 fi
 fi
@@ -13995,8 +14112,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char gcry_control ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gcry_control (void);
 int
 main (void)
 {
@@ -14132,8 +14255,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char DNSServiceBrowse ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char DNSServiceBrowse (void);
 int
 main (void)
 {
@@ -14194,8 +14323,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char avahi_client_new ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char avahi_client_new (void);
 int
 main (void)
 {
@@ -14500,8 +14635,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char dispatch_queue_create ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dispatch_queue_create (void);
 int
 main (void)
 {
@@ -14863,8 +15004,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char mpf_abs ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char mpf_abs (void);
 int
 main (void)
 {
@@ -14906,8 +15053,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char __gmpf_abs ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char __gmpf_abs (void);
 int
 main (void)
 {

--- a/configure
+++ b/configure
@@ -12529,7 +12529,7 @@ else $as_nop
 /* end confdefs.h.  */
 #include <iconv.h>
   int main(int argc,char **argv)
-  { return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }
+  { return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
@@ -12579,7 +12579,7 @@ else $as_nop
 /* end confdefs.h.  */
 #include <giconv.h>
   int main(int argc,char **argv)
-  { return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }
+  { return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
@@ -12627,7 +12627,7 @@ else $as_nop
 /* end confdefs.h.  */
 #include <iconv.h>
 int main(int argc,char **argv)
-{ return iconv_open("UTF-8","ASCII") == -1 ? 1 : 0; }
+{ return iconv_open("UTF-8","ASCII") == (iconv_t)-1 ? 1 : 0; }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"

--- a/configure
+++ b/configure
@@ -12447,7 +12447,7 @@ else $as_nop
 /* end confdefs.h.  */
 #include <iconv.h>
 int main(int argc,char **argv)
-{ return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }
+{ return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"

--- a/configure.ac
+++ b/configure.ac
@@ -3390,6 +3390,8 @@ if test $found_iconv = no ; then
   echo "Building without them will disable much characterset support."
   echo "If you really want to build gnustep-base without character conversion"
   echo " support, please add --disable-iconv to the configure arguments."
+  echo "Try adjusting --with-libiconv-include and --with-libiconv-library"
+  echo "If you have iconv installed."
   AC_MSG_ERROR([Missing support for character conversion functionality.])
 fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3232,7 +3232,7 @@ if test $enable_iconv = yes; then
 AC_MSG_CHECKING(iconv support)
 AC_RUN_IFELSE([AC_LANG_SOURCE([#include <iconv.h>
 int main(int argc,char **argv)
-{ return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }])]
+{ return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }])]
 ,
   # libc has a working iconv.
   AC_DEFINE(HAVE_ICONV,1, [Define if you have this function])

--- a/configure.ac
+++ b/configure.ac
@@ -3388,10 +3388,13 @@ if test $found_iconv = no ; then
   echo
   echo "You do not appear to have usable iconv header/library."
   echo "Building without them will disable much characterset support."
-  echo "If you really want to build gnustep-base without character conversion"
-  echo " support, please add --disable-iconv to the configure arguments."
   echo "Try adjusting --with-libiconv-include and --with-libiconv-library"
-  echo "If you have iconv installed."
+  echo " if you have iconv installed in an unusual location."
+  echo "If your iconv does not support the TRANSLIT operation (needed for"
+  echo " lossy character conversion), either install a more fully featured"
+  echo " version of iconv, or use the --enable-limitediconv argument."
+  echo "If you want to build gnustep-base with minimal character conversion"
+  echo " support, please add --disable-iconv to the configure arguments."
   AC_MSG_ERROR([Missing support for character conversion functionality.])
 fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -168,12 +168,8 @@ AC_CANONICAL_TARGET([])
 #--------------------------------------------------------------------
 
 AC_ARG_WITH(cross-compilation-info,
-[  --with-cross-compilation-info=PATH
-				Specify path to the configuration file that
-				contains information for the configure script in
-				case of cross compilation. This information
-				replaces those obtained from running programmes
-				during the configuration phase.],
+[AS_HELP_STRING([--with-cross-compilation-info=PATH],
+[Specify path to the configuration file that contains information for the configure script in case of cross compilation. This information replaces those obtained from running programmes during the configuration phase.])],
   cross_result="$withval",
   cross_result="no"
 )
@@ -214,28 +210,9 @@ if test "$GNUSTEP_MAKE_CONFIG"  = ""; then
 fi
 
 AC_ARG_WITH(config-file,
-[  --with-config-file=PATH       Specify path to the GNUstep config file.
-				This is the location to be used by the base
-				library to locate path information at
-				application or tool runtime.
-				This file might not even exist now; it is
-				not read at configure time.  The base library
-				will only read it at runtime.
-				If unspecified, this uses the same value as
-				the GNUstep make package on unix-like systems,
-				but uses ./GNUstep.conf on mingw so that
-				it is relative to the location of the
-				base library DLL.
-				If a leading './' is specified, the path
-				is taken to be relative to the base library
-				linked runtime, not all operating systems
-				can support this, so on some platforms you
-				may need to specify the location of the
-				config file using the GNUSTEP_CONFIG_FILE
-				environment variable at runtime.
-				If a trailing '/' is specified, the path is
-				used for locating domains but no GNUstep
-				config file is read at runtime.],
+  [AS_HELP_STRING([--with-config-file=PATH],
+  [Specify path to the GNUstep config file.  This is the location to be used by the base library to locate path information at application or tool runtime.
+  This file might not even exist now; it is not read at configure time.  The base library will only read it at runtime.   If unspecified, this uses the same value as the GNUstep make package on unix-like systems, but uses ./GNUstep.conf on mingw so that it is relative to the location of the base library DLL. If a leading './' is specified, the path is taken to be relative to the base library linked runtime, not all operating systems can support this, so on some platforms you may need to specify the location of the config file using the GNUSTEP_CONFIG_FILE environment variable at runtime.   If a trailing '/' is specified, the path is used for locating domains but no GNUstep config file is read at runtime.])],
   result="$withval",
   result="no"
 )
@@ -267,23 +244,8 @@ case "$target_os" in
 esac
 AC_MSG_CHECKING([whether the GNUstep.conf file path can be set in the environment])
 AC_ARG_ENABLE(environment-config-file,
-[  --disable-environment-config-file
-                                Disables the use of the GNUSTEP_CONFIG_FILE
-				environment variable to specify/override
-				the location of the GNUstep config file
-				at runtime.  This option is occasionally
-				useful to disable the environment variable
-				for sites which wish to 'lock down' users
-				to always work with a specific system-wide
-				configuration.  On unix-like systems the
-				default is for this option to be enabled.
-				It is disabled by default on windows systems
-				so that the base library will not use a
-				config file intended for the gnustep-make
-				system (and containing unix-style paths
-				which cannot be used by windows apps).
-				Normally this should be left at its default
-				setting.],
+  [AS_HELP_STRING([--disable-environment-config-file],
+  [Disables the use of the GNUSTEP_CONFIG_FILE environment variable to specify/override the location of the GNUstep config file at runtime. This option is occasionally useful to disable the environment variable for sites which wish to 'lock down' users to always work with a specific system-wide configuration. On unix-like systems the default is for this option to be enabled. It is disabled by default on windows systems so that the base library will not use a config file intended for the gnustep-make system (and containing unix-style paths which cannot be used by windows apps). Normally this should be left at its default setting.])],
   ac_cv_environment_config_file=$enableval,
   ac_cv_environment_config_file=$enable_env_config)
 if test "$ac_cv_environment_config_file" = "yes"; then
@@ -328,9 +290,8 @@ esac
 # turn it off.
 AC_MSG_CHECKING([if we should import an existing configuration file now])
 AC_ARG_ENABLE(importing-config-file,
-[  --disable-importing-config-file
-                                Disable importing of an existing GNUstep config
-				file and use inbuilt defaults instead.],
+  [AS_HELP_STRING([--disable-importing-config-file],
+  [Disable importing of an existing GNUstep config file and use inbuilt defaults instead.])],
   ac_cv_importing_config_file=$enableval,
   ac_cv_importing_config_file="yes")
 if test "$ac_cv_importing_config_file" = "no"; then
@@ -344,13 +305,8 @@ if test "$ac_cv_importing_config_file" = "yes" ;
 then
   AC_MSG_CHECKING([for default GNUstep configuration file to use])
   AC_ARG_WITH(default-config,
-[  --with-default-config=PATH   Specify path to a GNUstep config file to be
-				imported at configure time (now) and used to
-				provide default values for the base library
-				to use at runtime if no GNUstep config file
-				is found at runtime.  If this is not specified
-				then the path from the gnustep-make package
-				is used.],
+  [AS_HELP_STRING([--with-default-config=PATH],
+  [Specify path to a GNUstep config file to be imported at configure time (now) and used to provide default values for the base library to use at runtime if no GNUstep config file is found at runtime.  If this is not specified then the path from the gnustep-make package is used.])],
     result="$withval",
     result="no"
   )
@@ -478,19 +434,8 @@ if test x"$GNUSTEP_USER_DIR_DOC_INFO" = x""; then GNUSTEP_USER_DIR_DOC_INFO=$GNU
 
 AC_MSG_CHECKING([for GNUstep-base installation domain])
 AC_ARG_WITH(installation-domain,
-[  --with-installation-domain=DOMAIN
-				Specify the domain (SYSTEM, LOCAL,
-				NETWORK or USER) into which
-				gnustep-base will be installed.
-				Whenever relative paths are hardcoded
-				into gnustep-base (at the moment, this
-				happens only on MinGW) this option
-				must be used and must match the domain
-				where you will be installing
-				gnustep-base.
-				If this is not specified, the output of
-				gnustep-config --installation-domain-for=gnustep-base
-				(which should normally be LOCAL) is used.],
+[AS_HELP_STRING([--with-installation-domain=DOMAIN],
+[Specify the domain (SYSTEM, LOCAL, NETWORK or USER) into which gnustep-base will be installed.  Whenever relative paths are hardcoded into gnustep-base (at the moment, this happens only on MinGW) this option must be used and must match the domain where you will be installing gnustep-base.  If this is not specified, the output of gnustep-config --installation-domain-for=gnustep-base (which should normally be LOCAL) is used.])],
   result="$withval",
   result="no"
 )
@@ -2041,8 +1986,8 @@ else
   else
     AC_MSG_RESULT(no)
     AC_ARG_ENABLE(nxconstantstring,
-        [  --enable-nxconstantstring
-	    Enables the use of the NXConstantString class for old compilers.],,
+        [AS_HELP_STRING([--enable-nxconstantstring],
+	[Enables the use of the NXConstantString class for old compilers.])],,
         enable_nxconstantstring=no)
     if test $enable_nxconstantstring = yes; then
       NX_CONST_STRING_OBJCFLAGS=""
@@ -2469,13 +2414,8 @@ dnl AC_REPLACE_FUNCS(recvfrom)
 # These headers/functions needed for stacktrace in NSException.m
 #--------------------------------------------------------------------
 AC_ARG_ENABLE(bfd,
-  [  --enable-bfd
-	Enables the use of libbfd to provide symbolic stack traces.
-	Enabling this option provides support for symbolic stack traces
-	on platforms where the backtrace_symbols() function is not
-	available or does not work properly.
-	Enabling this option also has the effect of changing the license
-	of gnustep-base from LGPL to GPL since libbfd uses the GPL license],,
+  [AS_HELP_STRING([--enable-bfd],
+  [Enables the use of libbfd to provide symbolic stack traces. Enabling this option provides support for symbolic stack traces on platforms where the backtrace_symbols() function is not available or does not work properly.  Enabling this option also has the effect of changing the license of gnustep-base from LGPL to GPL since libbfd uses the GPL license])],,
   enable_bfd=no)
 if test $enable_bfd = yes ; then
   AC_DEFINE(USE_BFD,1, [Define to use bfd library for stack traces])
@@ -2928,7 +2868,8 @@ esac
 
 AC_MSG_CHECKING(use of pass-through arguments)
 AC_ARG_ENABLE(pass-arguments,
-  [  --enable-pass-arguments	Force user main call to NSProcessInfo initialize],,
+  [AS_HELP_STRING([--enable-pass-arguments],
+  [Force user main call to NSProcessInfo initialize])],,
   enable_pass_arguments=$PASS_ARG)
 
 if test "$enable_pass_arguments" = "yes"; then
@@ -2941,7 +2882,8 @@ AC_MSG_RESULT($enable_pass_arguments)
 
 AC_MSG_CHECKING(use of fake-main definition)
 AC_ARG_ENABLE(fake-main,
-  [  --enable-fake-main  		Force redefine of user main function],,
+  [AS_HELP_STRING([--enable-fake-main],
+  [Force redefine of user main function])],,
   enable_fake_main=no)
 
 if test "$enable_pass_arguments" = "no"; then
@@ -2983,7 +2925,8 @@ AC_MSG_RESULT($enable_fake_main)
 # Simple way to add a bunch of paths to the flags
 #--------------------------------------------------------------------
 AC_ARG_WITH(include-flags,
-    [  --with-include-flags=FLAGS    Specify all include flags at once],
+    [AS_HELP_STRING([--with-include-flags=FLAGS],
+    [Specify all include flags at once])],
     include_flags="$withval", include_flags="no")
 if test ${include_flags} != "no"; then
     CPPFLAGS="$CPPFLAGS ${include_flags}"
@@ -2991,7 +2934,8 @@ if test ${include_flags} != "no"; then
 fi
 
 AC_ARG_WITH(library-flags,
-    [  --with-library-flags=FLAGS    Specify all library flags at once],
+    [AS_HELP_STRING([--with-library-flags=FLAGS],
+    [Specify all library flags at once])],
     library_flags="$withval", library_flags="no")
 if test ${library_flags} != "no"; then
     LDFLAGS="$LDFLAGS ${library_flags}"
@@ -3026,11 +2970,13 @@ if test "$exceptions" = "yes"; then
 fi
 
 AC_ARG_ENABLE(libffi,
-  [  --disable-libffi  		Disable use of libffi library],,
+  [AS_HELP_STRING([--disable-libffi],
+  [Disable use of libffi library])],,
   enable_libffi=$do_enable_libffi)
 
 AC_ARG_ENABLE(ffcall,
-  [  --enable-ffcall  		Enable use of the deprecated ffcall library],,
+  [AS_HELP_STRING([--enable-ffcall],
+  [Enable use of the deprecated ffcall library])],,
   enable_ffcall=$do_enable_libffcall)
 
 if test $enable_ffcall = yes; then
@@ -3038,7 +2984,8 @@ if test $enable_ffcall = yes; then
 fi
 
 AC_ARG_ENABLE(invocations,
-  [  --disable-invocations		Build even if invocation-dependencies are not met],,
+  [AS_HELP_STRING([--disable-invocations],
+  [Build even if invocation-dependencies are not met])],,
   enable_invocations=yes)
 
 # DO isn't used on apple-apple-apple
@@ -3047,7 +2994,8 @@ if test $LIBRARY_COMBO = apple-apple-apple; then
 fi
 
 AC_ARG_WITH(ffi-include,
-[  --with-ffi-include=PATH       Include path for ffi headers],
+  [AS_HELP_STRING([--with-ffi-include=PATH],
+  [Include path for ffi headers])],
     ffi_incdir="$withval", ffi_incdir="no")
 if test ${ffi_incdir} != "no"; then
     CPPFLAGS="$CPPFLAGS -I${ffi_incdir}"
@@ -3055,7 +3003,8 @@ if test ${ffi_incdir} != "no"; then
 fi
 
 AC_ARG_WITH(ffi-library,
-[  --with-ffi-library=PATH       Library path for ffi libs],
+  [AS_HELP_STRING([--with-ffi-library=PATH],
+  [Library path for ffi libs])],
     ffi_libdir="$withval", ffi_libdir="no")
 if test ${ffi_libdir} != "no"; then
   GS_ADD_LIBRARY_PATH([${ffi_libdir}])
@@ -3225,7 +3174,8 @@ AC_SUBST(WITH_FFI)
 # First, check if there's a working iconv in libc (ie. if the test program
 # runs without any extra flags).
 AC_ARG_ENABLE(iconv,
-  [  --disable-iconv		Build even if iconv is not available],,
+  [AS_HELP_STRING([--disable-iconv],
+  [Build even if iconv is not available])],,
   enable_iconv=yes)
 
 if test $enable_iconv = yes; then
@@ -3252,7 +3202,8 @@ if test $found_iconv = no ; then
   # libc doesn't have a working iconv with translit.
   # Try adding -liconv and any user supplied directory.
   AC_ARG_WITH(libiconv-library,
-    [  --with-libiconv-library=PATH  Library path for libiconv libraries],
+    [AS_HELP_STRING([--with-libiconv-library=PATH],
+    [Library path for libiconv libraries])],
     libiconv_libdir="$withval", libiconv_libdir="no")
 
   if test "$libiconv_libdir" != "no"; then
@@ -3260,7 +3211,8 @@ if test $found_iconv = no ; then
   fi
 
   AC_ARG_WITH(libiconv-include,
-    [  --with-libiconv-include=PATH  Include path for libiconv header],
+    [AS_HELP_STRING([--with-libiconv-include=PATH],
+    [Include path for libiconv header])],
     libiconv_incdir="$withval", libiconv_incdir="no")
   if test ${libiconv_incdir} != "no"; then
       CPPFLAGS="$CPPFLAGS -I${libiconv_incdir}"
@@ -3320,7 +3272,8 @@ if test $found_iconv = no ; then
 fi
 
 AC_ARG_ENABLE(limitediconv,
-  [  --enable-limitediconv		Build even if iconv does not support lossy conversion],,
+  [AS_HELP_STRING([--enable-limitediconv],
+  [Build even if iconv does not support lossy conversion])],,
   enable_limitediconv=no)
 if test $enable_limitediconv = yes; then
 AC_MSG_CHECKING(iconv without lossy conversion support)
@@ -3340,7 +3293,8 @@ if test $found_iconv = no ; then
   # libc doesn't have a working iconv. Try adding -liconv and any user
   # supplied directory.
   AC_ARG_WITH(libiconv-library,
-    [  --with-libiconv-library=PATH  Library path for libiconv libraries],
+    [AS_HELP_STRING([--with-libiconv-library=PATH],
+    [Library path for libiconv libraries])],
     libiconv_libdir="$withval", libiconv_libdir="no")
 
   if test "$libiconv_libdir" != "no"; then
@@ -3404,7 +3358,8 @@ fi
 # See DEPENDENCIES POLICY at the start of this file.
 #--------------------------------------------------------------------
 AC_ARG_ENABLE(xml,
-  [  --disable-xml			Build even if XML-dependencies are not met],,
+  [AS_HELP_STRING([--disable-xm],
+  [Build even if XML-dependencies are not met])],,
   enable_xml=yes)
 
 HAVE_LIBXML=0
@@ -3426,7 +3381,8 @@ if test $enable_xml = yes; then
     # Check for (optional) libxslt
     #--------------------------------------------------------------------
     AC_ARG_ENABLE(xslt,
-      [  --disable-xslt		Build even if XSLT-dependency is not met],,
+      [AS_HELP_STRING([--disable-xslt],
+      [Build even if XSLT-dependency is not met])],,
       enable_xslt=yes)
 
     if test $enable_xslt = yes; then
@@ -3472,7 +3428,8 @@ AC_SUBST(HAVE_LIBXML)
 # See DEPENDENCIES POLICY at the start of this file.
 #--------------------------------------------------------------------
 AC_ARG_ENABLE(tls,
-  [  --disable-tls			Disable use of GNUTLS],,
+  [AS_HELP_STRING([--disable-tls],
+  [Disable use of GNUTLS])],,
   enable_tls=yes)
 
 if test $enable_tls = yes; then
@@ -3549,10 +3506,12 @@ AC_SUBST(HAVE_GNUTLS)
 HAVE_MDNS=0
 HAVE_AVAHI=0
 AC_ARG_ENABLE(zeroconf,
-  [  --disable-zeroconf		Disable NSNetServices support],,
+  [AS_HELP_STRING([--disable-zeroconf],
+  [Disable NSNetServices support])],,
   enable_zeroconf=yes)
 AC_ARG_WITH(zeroconf-api,
-  [  --with-zeroconf-api=API  force use of a specific zeroconf API (mdns or avahi)],
+  [AS_HELP_STRING([--with-zeroconf-api=API],
+  [force use of a specific zeroconf API (mdns or avahi)])],
   zeroconf_api="$withval", zeroconf_api="any")
 if test $enable_zeroconf = yes; then
   if test "$zeroconf_api" = "any" || test "$zeroconf_api" = "mdns"; then
@@ -3594,7 +3553,8 @@ AC_SUBST(HAVE_AVAHI)
 #--------------------------------------------------------------------
 HAVE_ICU=0
 AC_ARG_ENABLE(icu,
-  [  --disable-icu			Disable International Components for Unicode],,
+  [AS_HELP_STRING([--disable-icu],
+  [Disable International Components for Unicode])],,
   enable_icu=yes)
 
 AS_IF([test "x$enable_icu" = "xyes"], [
@@ -3635,13 +3595,15 @@ AC_SUBST(HAVE_ICU)
 
 HAVE_LIBDISPATCH=0
 AC_ARG_ENABLE(libdispatch,
-  [  --disable-libdispatch		Disable dispatching blocks via libdispatch],
+  [AS_HELP_STRING([--disable-libdispatch],
+  [Disable dispatching blocks via libdispatch])],
   enable_libdispatch=$enableval,
   enable_libdispatch=yes)
 
 if test $enable_libdispatch = yes; then
   AC_ARG_WITH(dispatch-include,
-  [  --with-dispatch-include=PATH       Include path for dispatch header],
+  [AS_HELP_STRING([--with-dispatch-include=PATH],
+  [Include path for dispatch header])],
       dispatch_incdir="$withval", dispatch_incdir="no")
   if test ${dispatch_incdir} != "no"; then
       CPPFLAGS="$CPPFLAGS -I${dispatch_incdir}"
@@ -3649,7 +3611,8 @@ if test $enable_libdispatch = yes; then
   fi
 
   AC_ARG_WITH(dispatch-library,
-  [  --with-dispatch-library=PATH       Library path for dispatch lib],
+  [AS_HELP_STRING([--with-dispatch-library=PATH],
+  [Library path for dispatch lib])],
       dispatch_libdir="$withval", dispatch_libdir="no")
   if test ${dispatch_libdir} != "no"; then
     GS_ADD_LIBRARY_PATH([${dispatch_libdir}])
@@ -3717,7 +3680,8 @@ AC_SUBST(HAVE_LIBDISPATCH_RUNLOOP)
 #--------------------------------------------------------------------
 HAVE_NEWKVO=0
 AC_ARG_ENABLE(newkvo,
-  [  --disable-newkvo		Disable new KVO implementation],,[
+  [AS_HELP_STRING([--disable-newkvo],
+  [Disable new KVO implementation])],,[
 if test "$OBJC_RUNTIME_LIB" = "ng"; then
   enable_newkvo=yes
 else
@@ -3815,7 +3779,8 @@ fi
 
 GS_HAVE_NSURLSESSION=0
 AC_ARG_ENABLE(nsurlsession,
-  [  --disable-nsurlsession  		Disable support for NSURLSession],,
+  [AS_HELP_STRING([--disable-nsurlsession],
+  [Disable support for NSURLSession])],,
   enable_nsurlsession=$nsurlsessiondefault)
 if test $enable_nsurlsession = yes; then
   if test "$OBJC_RUNTIME_LIB" != "ng"; then
@@ -3840,11 +3805,13 @@ AC_SUBST(GS_HAVE_NSURLSESSION)
 # Check GMP for NSDecimal
 #--------------------------------------------------------------------
 AC_ARG_WITH(gmp-include,
-  [  --with-gmp-include=PATH  include path for gmp headers],
+  [AS_HELP_STRING([--with-gmp-include=PATH],
+  [include path for gmp headers])],
   gmp_incdir="$withval", gmp_incdir="no")
 
 AC_ARG_WITH(gmp-library,
-  [  --with-gmp-library=PATH  library path for gmp libraries],
+  [AS_HELP_STRING([--with-gmp-library=PATH],
+  [library path for gmp libraries])],
   gmp_libdir="$withval", gmp_libdir="no")
 
 libs_temp=$LIBS
@@ -3913,7 +3880,8 @@ AC_SUBST(WARN_FLAGS)
 # Check if we should use an alternative gdomap port
 #--------------------------------------------------------------------
 AC_ARG_WITH(gdomap-port,
-  [  --with-gdomap-port=PORT  alternative port for gdomap],
+  [AS_HELP_STRING([--with-gdomap-port=PORT],
+  [alternative port for gdomap])],
   gdomap_port="$withval", gdomap_port="no")
 
 if test "$gdomap_port" = "no"; then
@@ -3927,16 +3895,9 @@ AC_SUBST(GNUSTEP_GDOMAP_PORT_OVERRIDE)
 # Check if we should install gdomap as setuid
 #--------------------------------------------------------------------
 AC_MSG_CHECKING([if we should install gdomap as setuid])
-AC_ARG_ENABLE(setuid-gdomap,[
-  --enable-setuid-gdomap        Enable installing gdomap as a setuid
-                                executable.  By default, it is installed
-                                as a normal program intended to be started
-				by root at system boot time, but it can
-                                also be started up automatically
-                                by any user at any time.  Use this
-                                option if you are happy having the program
-                                started automatically on demand.
-],
+AC_ARG_ENABLE(setuid-gdomap,
+  [AS_HELP_STRING([--enable-setuid-gdomap],
+  [Enable installing gdomap as a setuid executable.  By default, it is installed as a normal program intended to be started by root at system boot time, but it can also be started up automatically by any user at any time.  Use this option if you are happy having the program started automatically on demand.])],
   ac_cv_setuid_gdomap=$enableval,
   ac_cv_setuid_gdomap="no")
 

--- a/configure.ac
+++ b/configure.ac
@@ -3271,7 +3271,7 @@ if test $found_iconv = no ; then
   LIBS="-liconv $LIBS"
   AC_RUN_IFELSE([AC_LANG_SOURCE([#include <iconv.h>
   int main(int argc,char **argv)
-  { return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }])]
+  { return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }])]
   ,
     # -liconv works.
     AC_DEFINE(HAVE_ICONV,1, [Define if you have this function])
@@ -3298,7 +3298,7 @@ if test $found_iconv = no ; then
   LIBS="-lgiconv $LIBS"
   AC_RUN_IFELSE([AC_LANG_SOURCE([#include <giconv.h>
   int main(int argc,char **argv)
-  { return iconv_open("UTF-8//TRANSLIT","ASCII") == -1 ? 1 : 0; }])]
+  { return iconv_open("UTF-8//TRANSLIT","ASCII") == (iconv_t)-1 ? 1 : 0; }])]
   ,
     AC_DEFINE(HAVE_ICONV,1, [Define if you have this function])
     AC_DEFINE(HAVE_GICONV,1, [Define if you have this function])
@@ -3326,7 +3326,7 @@ if test $enable_stricticonv = yes; then
 AC_MSG_CHECKING(non-lossy iconv support)
 AC_RUN_IFELSE([AC_LANG_SOURCE([#include <iconv.h>
 int main(int argc,char **argv)
-{ return iconv_open("UTF-8","ASCII") == -1 ? 1 : 0; }])]
+{ return iconv_open("UTF-8","ASCII") == (iconv_t)-1 ? 1 : 0; }])]
 ,
   # libc has a working iconv.
   AC_DEFINE(HAVE_ICONV,1, [Define if you have this function])

--- a/configure.ac
+++ b/configure.ac
@@ -3319,11 +3319,11 @@ if test $found_iconv = no ; then
   )
 fi
 
-AC_ARG_ENABLE(stricticonv,
-  [  --enable-stricticonv		Build even if iconv is strict],,
-  enable_stricticonv=no)
-if test $enable_stricticonv = yes; then
-AC_MSG_CHECKING(non-lossy iconv support)
+AC_ARG_ENABLE(limitediconv,
+  [  --enable-limitediconv		Build even if iconv does not support lossy conversion],,
+  enable_limitediconv=no)
+if test $enable_limitediconv = yes; then
+AC_MSG_CHECKING(iconv without lossy conversion support)
 AC_RUN_IFELSE([AC_LANG_SOURCE([#include <iconv.h>
 int main(int argc,char **argv)
 { return iconv_open("UTF-8","ASCII") == (iconv_t)-1 ? 1 : 0; }])]


### PR DESCRIPTION
As we are it, clean up all help messages with AS_HELP_STRING