### PR TITLE
make va_copy work on muslc and gcc 14

### DIFF
--- a/Source/GSFormat.m
+++ b/Source/GSFormat.m
@@ -884,10 +884,10 @@ NSDictionary *locale)
   /* Initialize local variables.  */
   done = 0;
   grouping = (const char *) -1;
-#ifdef __va_copy
+#ifdef va_copy
   /* This macro will be available soon in gcc's <stdarg.h>.  We need it
      since on some systems `va_list' is not an integral type.  */
-  __va_copy (ap_save, ap);
+  va_copy (ap_save, ap);
 #else
   ap_save = ap;
 #endif


### PR DESCRIPTION
Should be safe from GCC 4.5 and optionally with -std=c99 from 3.0, We dropped 2.95 long ago.