### PR TITLE
Let a thread reuse the defaults it has already read

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-08-12 Todd White <todd.white@thalion.global>
+
+	* Source/NSUserDefaults.m: Answer a default from a small table
+	kept by the calling thread when nothing has changed the defaults
+	since that thread last asked, so that reads do not serialise on
+	the instance lock.  Every change to what a lookup can see
+	increments a generation counter, and an entry from an earlier
+	generation is not used.
+
 2026-08-11 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendarDate.m: Read the second that GSPrivateTimeNow

--- a/Source/NSUserDefaults.m
+++ b/Source/NSUserDefaults.m
@@ -72,6 +72,7 @@
 #endif
 
 #import "GSPrivate.h"
+#import "GSPThread.h"
 
 /* Wait for access */
 #define _MAX_COUNT 5          /* Max 10 sec. */
@@ -115,6 +116,74 @@ static BOOL		hasSharedDefaults = NO;
  * information.
  */
 static int		flags[GSUserDefaultMaxFlag] = { 0 };
+
+/* Every change to what a lookup can see increments this counter while the
+ * lock of the defaults object making the change is held, and a thread keeps
+ * the answers it has already been given along with the value the counter had
+ * when it got them.  An answer from an earlier generation is never used, so a
+ * thread whose defaults have not changed since it last looked answers from
+ * its own table and does not take the lock.  A new defaults object increments
+ * the counter as it sets up its volatile domains, so an entry cannot survive
+ * into an unrelated object which happens to be allocated at the same address.
+ */
+#define	GS_DEFAULTS_MEMO_SIZE	16
+
+typedef struct {
+  NSUserDefaults	*owner;		// compared, never messaged
+  NSString		*key;		// retained
+  id			value;		// retained, nil is an answer
+  uint64_t		generation;	// zero while the entry is unused
+} GSDefaultsMemoEntry;
+
+static uint64_t		defaultsGeneration = 1;
+static gs_thread_key_t	defaultsMemoKey;
+static BOOL		defaultsMemoKeyReady = NO;
+
+static void
+defaultsMemoFree(void *memo)
+{
+  GSDefaultsMemoEntry	*entries = (GSDefaultsMemoEntry*)memo;
+  unsigned		i;
+
+  for (i = 0; i < GS_DEFAULTS_MEMO_SIZE; i++)
+    {
+      RELEASE(entries[i].key);
+      RELEASE(entries[i].value);
+    }
+  free(entries);
+}
+
+static inline void
+defaultsDidChange(void)
+{
+  __atomic_fetch_add(&defaultsGeneration, 1, __ATOMIC_RELEASE);
+}
+
+static GSDefaultsMemoEntry*
+defaultsMemo(void)
+{
+  GSDefaultsMemoEntry	*memo;
+
+  if (NO == __atomic_load_n(&defaultsMemoKeyReady, __ATOMIC_ACQUIRE))
+    {
+      return 0;
+    }
+  memo = GS_THREAD_KEY_GET(defaultsMemoKey);
+  if (0 == memo)
+    {
+      memo = calloc(GS_DEFAULTS_MEMO_SIZE, sizeof(GSDefaultsMemoEntry));
+      if (0 != memo)
+	{
+	  GS_THREAD_KEY_SET(defaultsMemoKey, memo);
+	  if (GS_THREAD_KEY_GET(defaultsMemoKey) != memo)
+	    {
+	      free(memo);
+	      memo = 0;
+	    }
+	}
+    }
+  return memo;
+}
 
 /* An instance of the GSPersistentDomain class is used to encapsulate
  * a single persistent domain (represented as a property list file in
@@ -659,6 +728,10 @@ newLanguages(NSArray *oldNames)
 
       beenHere = YES;
       initializing = YES;
+      if (GS_THREAD_KEY_INIT(defaultsMemoKey, defaultsMemoFree))
+	{
+	  __atomic_store_n(&defaultsMemoKeyReady, YES, __ATOMIC_RELEASE);
+	}
       nextObjectSel = @selector(nextObject);
       objectForKeySel = @selector(objectForKey:);
       addSel = @selector(addEntriesFromDictionary:);
@@ -807,6 +880,7 @@ newLanguages(NSArray *oldNames)
 	{
 	  [defs->_lock lock];
 	  [defs->_tempDomains setObject: regDefs forKey: NSRegistrationDomain];
+	  defaultsDidChange();
 	  [defs->_lock unlock];
 	}
     }
@@ -1028,6 +1102,7 @@ newLanguages(NSArray *oldNames)
       [defs persistentDomainForName: NSGlobalDomain];
       [defs->_searchList addObject: GSConfigDomain];
       [defs->_searchList addObject: NSRegistrationDomain];
+      defaultsDidChange();
 
       /* Load persistent data into the new instance.
        */
@@ -1049,6 +1124,7 @@ newLanguages(NSArray *oldNames)
           unsigned	index = [defs->_searchList count] - 1;
 
           [defs->_searchList insertObject: lang atIndex: index];
+          defaultsDidChange();
         }
 
       /* Set up language constants */
@@ -1294,6 +1370,7 @@ newLanguages(NSArray *oldNames)
     setObject: [NSMutableDictionaryClass dictionaryWithCapacity: 10]
     forKey: NSRegistrationDomain];
   [_tempDomains setObject: GNUstepConfig(nil) forKey: GSConfigDomain];
+  defaultsDidChange();
 
   updateCache(self);
 
@@ -1379,6 +1456,7 @@ newLanguages(NSArray *oldNames)
   NS_DURING
     {
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       [_searchList removeObject: aName];
       index = [_searchList indexOfObject: bundleIdentifier];
       index = (index == NSNotFound) ? 0 : (index + 1);
@@ -1477,7 +1555,23 @@ newLanguages(NSArray *oldNames)
 
 - (id) objectForKey: (NSString*)defaultName
 {
-  id	object = nil;
+  id			object = nil;
+  GSDefaultsMemoEntry	*memo = defaultsMemo();
+  GSDefaultsMemoEntry	*entry = 0;
+  uint64_t		generation = 0;
+
+  if (0 != memo && nil != defaultName)
+    {
+      entry = memo + ([defaultName hash] % GS_DEFAULTS_MEMO_SIZE);
+      if (entry->owner == self
+	&& entry->generation
+	  == __atomic_load_n(&defaultsGeneration, __ATOMIC_ACQUIRE)
+	&& (entry->key == defaultName
+	  || [entry->key isEqual: defaultName]))
+	{
+	  return AUTORELEASE(RETAIN(entry->value));
+	}
+    }
 
   [_lock lock];
   NS_DURING
@@ -1505,6 +1599,7 @@ newLanguages(NSArray *oldNames)
 	    break;
         }
       RETAIN(object);
+      generation = __atomic_load_n(&defaultsGeneration, __ATOMIC_RELAXED);
       GS_ENDITEMBUF();
       [_lock unlock];
     }
@@ -1514,6 +1609,19 @@ newLanguages(NSArray *oldNames)
       [localException raise];
     }
   NS_ENDHANDLER
+
+  if (0 != entry)
+    {
+      NSString	*oldKey = entry->key;
+      id	oldValue = entry->value;
+
+      entry->owner = self;
+      entry->key = [defaultName copy];
+      entry->value = RETAIN(object);
+      entry->generation = generation;
+      RELEASE(oldKey);
+      RELEASE(oldValue);
+    }
   return AUTORELEASE(object);
 }
 
@@ -1790,6 +1898,7 @@ static BOOL isPlistObject(id o)
           NSString	*n;
 
           DESTROY(_dictionaryRep);
+          defaultsDidChange();
           RELEASE(_searchList);
           _searchList = [newList mutableCopy];
           /* Ensure that any domains we need are loaded.
@@ -2005,6 +2114,7 @@ static BOOL isPlistObject(id o)
 	      if (YES == haveChange)
 		{
 		  DESTROY(_dictionaryRep);
+		  defaultsDidChange();
 		}
 
 	      if (_changedDomains != nil)
@@ -2112,6 +2222,7 @@ static BOOL isPlistObject(id o)
   NS_DURING
     {
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       [_tempDomains removeObjectForKey: domainName];
       if ([_searchList containsObject: domainName])
         {
@@ -2149,6 +2260,7 @@ static BOOL isPlistObject(id o)
         }
 
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       domain = [domain mutableCopy];
       [_tempDomains setObject: domain forKey: domainName];
       RELEASE(domain);
@@ -2280,6 +2392,7 @@ static BOOL isPlistObject(id o)
           [_tempDomains setObject: regDefs forKey: NSRegistrationDomain];
         }
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       [regDefs addEntriesFromDictionary: newVals];
       updateCache(self);
       [_lock unlock];
@@ -2303,6 +2416,7 @@ static BOOL isPlistObject(id o)
   NS_DURING
     {
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       [_searchList removeObject: aName];
       updateCache(self);
       [_lock unlock];
@@ -2537,6 +2651,7 @@ NSDictionary *GSPrivateDefaultLocale()
   NS_DURING
     {
       DESTROY(_dictionaryRep);
+      defaultsDidChange();
       if (_changedDomains == nil)
         {
           _changedDomains = [[NSMutableArray alloc] initWithObjects: &domainName
@@ -2863,6 +2978,7 @@ static BOOL isLocked = NO;
           [removed addObject: aKey];
         }
       [contents removeObjectForKey: aKey];
+      defaultsDidChange();
       return YES;
     }
   else
@@ -2890,6 +3006,7 @@ static BOOL isLocked = NO;
             }
         }
       [contents setObject: anObject forKey: aKey];
+      defaultsDidChange();
       return YES;
     }
 }
@@ -3007,6 +3124,7 @@ setPermissions(NSString *file)
                 }
             }
           ASSIGN(contents, disk);
+          defaultsDidChange();
         }
       if (YES == hasLocalChanges)
         {


### PR DESCRIPTION
objectForKey: takes the instance lock and walks the search list on every call, so every read of a default serialises on one lock whatever key it asks for.

A thread now keeps the last few answers it was given and uses one again while nothing has changed the defaults. Every change increments a counter under the lock, and an entry stamped with an earlier value is not used, so a read that hits takes no lock and does not walk the list.

ns per objectForKey:, each thread on its own key, 32 cores, median of 3 interleaved runs: 1 thread 500.6 to 41.2, 8 threads 24270.0 to 46.0, 24 threads 86965.4 to 80.2. On one shared key 24 threads is 81016.1 to 2167.0, the retain and release of that value.

The whole suite gives 13466 passed and 45 dashed hopes before and after. A probe with 16 readers and a writer checks 26M reads with no mismatch.

The counter is global, so a change to any defaults object costs every thread its entries.
