### PR TITLE
Build the NSURLSession implementation without blocks

### DIFF
--- a/Headers/Foundation/NSURLSession.h
+++ b/Headers/Foundation/NSURLSession.h
@@ -225,14 +225,14 @@ GS_NSURLSession_IVARS;
  * handler is called before this method returns.
  */
 - (void) getTasksWithCompletionHandler:
-  (GSNSURLSessionTasksCompletionHandler)completionHandler;
+  (GSNSURLSessionTasksCompletionHandler)completionHandler GS_DEPRECATED;
 
 /**
  * Deprecated: use -allTasks instead.  The completion handler is called
  * before this method returns.
  */
 - (void) getAllTasksWithCompletionHandler:
-  (GSNSURLSessionAllTasksCompletionHandler)completionHandler;
+  (GSNSURLSessionAllTasksCompletionHandler)completionHandler GS_DEPRECATED;
 
 /**
  * This serial NSOperationQueue queue is used for dispatching delegate messages
@@ -660,7 +660,8 @@ GS_EXPORT_CLASS
   task: (NSURLSessionTask *)task
   willPerformHTTPRedirection: (NSHTTPURLResponse *)response
   newRequest: (NSURLRequest *)request
-  completionHandler: (GSNSURLSessionRedirectHandler)completionHandler;
+  completionHandler: (GSNSURLSessionRedirectHandler)completionHandler
+  GS_DEPRECATED;
 
 /* An HTTP request is attempting to perform a redirection to a different URL.
  * Reply by sending -resumeWithRedirectRequest: to the task, with the request
@@ -679,7 +680,8 @@ GS_EXPORT_CLASS
  */
 - (void) URLSession: (NSURLSession *)session
   task: (NSURLSessionTask *)task
-  needNewBodyStream: (GSNSURLSessionBodyStreamHandler)completionHandler;
+  needNewBodyStream: (GSNSURLSessionBodyStreamHandler)completionHandler
+  GS_DEPRECATED;
 
 /* A new body stream is needed to continue the upload.  Reply by sending
  * -resumeWithBodyStream: to the task.  The reply may be sent at any time and
@@ -705,7 +707,8 @@ GS_EXPORT_CLASS
 - (void) URLSession: (NSURLSession *)session
   dataTask: (NSURLSessionDataTask *)dataTask
   didReceiveResponse: (NSURLResponse *)response
-  completionHandler: (GSNSURLSessionResponseDispositionHandler)completionHandler;
+  completionHandler: (GSNSURLSessionResponseDispositionHandler)completionHandler
+  GS_DEPRECATED;
 
 /** Informs the delegate of a response.  This message is sent when all the
  * response headers have arrived, before the body of the response arrives.

--- a/Headers/Foundation/NSURLSession.h
+++ b/Headers/Foundation/NSURLSession.h
@@ -37,6 +37,7 @@
 #import <Foundation/NSOperation.h>
 #import <Foundation/NSProgress.h>
 #import <Foundation/NSDate.h>
+#import <GNUstepBase/GSBlocks.h>
 
 #if GS_HAVE_NSURLSESSION
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9, GS_API_LATEST)
@@ -46,6 +47,7 @@
 
 @class NSError;
 @class NSHTTPURLResponse;
+@class NSInputStream;
 @class NSOperationQueue;
 @class NSURL;
 @class NSURLAuthenticationChallenge;
@@ -62,13 +64,43 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^GSNSURLSessionDataCompletionHandler)(
-  NSData *_Nullable data, NSURLResponse *_Nullable response,
-  NSError *_Nullable error);
+DEFINE_BLOCK_TYPE(GSNSURLSessionDataCompletionHandler, void,
+  NSData *_Nullable, NSURLResponse *_Nullable, NSError *_Nullable);
 
-typedef void (^GSNSURLSessionDownloadCompletionHandler)(
-  NSURL *_Nullable location, NSURLResponse *_Nullable response,
-  NSError *_Nullable error);
+DEFINE_BLOCK_TYPE(GSNSURLSessionDownloadCompletionHandler, void,
+  NSURL *_Nullable, NSURLResponse *_Nullable, NSError *_Nullable);
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionTasksCompletionHandler, void,
+  GS_GENERIC_CLASS(NSArray, NSURLSessionDataTask *) *,
+  GS_GENERIC_CLASS(NSArray, NSURLSessionUploadTask *) *,
+  GS_GENERIC_CLASS(NSArray, NSURLSessionDownloadTask *) *);
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionAllTasksCompletionHandler, void,
+  GS_GENERIC_CLASS(NSArray, __kindof NSURLSessionTask *) *);
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionRedirectHandler, void, NSURLRequest *);
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionBodyStreamHandler, void, NSInputStream *);
+
+typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
+  NSURLSessionResponseCancel = 0,
+  NSURLSessionResponseAllow = 1,
+  NSURLSessionResponseBecomeDownload = 2,
+  NSURLSessionResponseBecomeStream = 3
+};
+
+typedef NS_ENUM(NSInteger, NSURLSessionAuthChallengeDisposition) {
+  NSURLSessionAuthChallengeUseCredential = 0,
+  NSURLSessionAuthChallengePerformDefaultHandling = 1,
+  NSURLSessionAuthChallengeCancelAuthenticationChallenge = 2,
+  NSURLSessionAuthChallengeRejectProtectionSpace = 3
+};
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionResponseDispositionHandler, void,
+  NSURLSessionResponseDisposition);
+
+DEFINE_BLOCK_TYPE(GSNSURLSessionChallengeHandler, void,
+  NSURLSessionAuthChallengeDisposition, NSURLCredential *);
 
 /**
  * NSURLSession is a replacement API for NSURLConnection.  It provides
@@ -118,8 +150,8 @@ GS_EXPORT_CLASS
  */
 + (NSURLSession *) sessionWithConfiguration:
   (NSURLSessionConfiguration *)configuration
-  delegate: (nullable id<NSURLSessionDelegate>)delegate
-  delegateQueue: (nullable NSOperationQueue *)queue;
+  delegate: (id<NSURLSessionDelegate> _Nullable)delegate
+  delegateQueue: (NSOperationQueue * _Nullable)queue;
 
 /** -finishTasksAndInvalidate returns immediately and existing tasks will be
  * allowed to run to completion.  New tasks may not be created.  The session
@@ -168,14 +200,32 @@ GS_EXPORT_CLASS
 
 - (NSURLSessionDownloadTask *) downloadTaskWithResumeData: (NSData *)resumeData;
 
-- (void) getTasksWithCompletionHandler:
-  (void (^)(NSArray<NSURLSessionDataTask *> *dataTasks,
-    NSArray<NSURLSessionUploadTask *> *uploadTasks,
-    NSArray<NSURLSessionDownloadTask *> *downloadTasks)) completionHandler;
+/**
+ * Returns every task the session currently holds.  Use this in preference to
+ * -getAllTasksWithCompletionHandler:, which requires a compiler with blocks.
+ */
+- (GS_GENERIC_CLASS(NSArray, NSURLSessionTask *) *) allTasks;
 
+/**
+ * Returns the tasks the session currently holds which are a kind of aClass.
+ * Use this in preference to -getTasksWithCompletionHandler:, which requires a
+ * compiler with blocks.
+ */
+- (GS_GENERIC_CLASS(NSArray, NSURLSessionTask *) *) tasksOfKind: (Class)aClass;
+
+/**
+ * Deprecated: use -allTasks and -tasksOfKind: instead.  The completion
+ * handler is called before this method returns.
+ */
+- (void) getTasksWithCompletionHandler:
+  (GSNSURLSessionTasksCompletionHandler)completionHandler;
+
+/**
+ * Deprecated: use -allTasks instead.  The completion handler is called
+ * before this method returns.
+ */
 - (void) getAllTasksWithCompletionHandler:
-  (void (^)(GS_GENERIC_CLASS(NSArray, __kindof NSURLSessionTask *) * tasks))
-    completionHandler;
+  (GSNSURLSessionAllTasksCompletionHandler)completionHandler;
 
 /**
  * This serial NSOperationQueue queue is used for dispatching delegate messages
@@ -189,7 +239,7 @@ GS_EXPORT_CLASS
  *
  * The session keeps a strong reference to the delegate.
  */
-- (nullable id<NSURLSessionDelegate>) delegate;
+- (id<NSURLSessionDelegate> _Nullable) delegate;
 
 /**
  * The configuration object used to create the session.
@@ -203,7 +253,7 @@ GS_EXPORT_CLASS
 /**
  * An App-specific description of the session.
  */
-- (nullable NSString *) sessionDescription;
+- (NSString * _Nullable) sessionDescription;
 
 /**
  * Sets an app-specific description of the session.
@@ -319,24 +369,44 @@ GS_EXPORT_CLASS
 - (int64_t) countOfBytesExpectedToReceive;
 - (int64_t) countOfBytesExpectedToSend;
 
-- (nullable NSURLRequest *) currentRequest;
-- (nullable id<NSURLSessionTaskDelegate>) delegate;
-- (nullable NSDate *) earliestBeginDate;
-- (nullable NSError *) error;
-- (nullable NSURLRequest *) originalRequest;
+- (NSURLRequest * _Nullable) currentRequest;
+- (id<NSURLSessionTaskDelegate> _Nullable) delegate;
+- (NSDate * _Nullable) earliestBeginDate;
+- (NSError * _Nullable) error;
+- (NSURLRequest * _Nullable) originalRequest;
 - (float) priority;
 - (NSProgress *) progress;
-- (nullable NSURLResponse *) response;
+- (NSURLResponse * _Nullable) response;
 - (void) resume;
 
-- (void) setDelegate: (nullable id<NSURLSessionTaskDelegate>)delegate;
-- (void) setEarliestBeginDate: (nullable NSDate *)date;
+/**
+ * Answers URLSession:task:willRedirectToResponse:newRequest:.  Pass the
+ * request to follow, or nil to refuse the redirection.  May be sent at any
+ * time and from any thread.
+ */
+- (void) resumeWithRedirectRequest: (NSURLRequest * _Nullable)request;
+
+/**
+ * Answers URLSession:taskNeedsNewBodyStream:.  May be sent at any time and
+ * from any thread.
+ */
+- (void) resumeWithBodyStream: (NSInputStream * _Nullable)bodyStream;
+
+/**
+ * Answers URLSession:dataTask:didReceiveResponse:, and so is only meaningful
+ * for a data task.  May be sent at any time and from any thread.
+ */
+- (void) resumeWithResponseDisposition:
+  (NSURLSessionResponseDisposition)disposition;
+
+- (void) setDelegate: (id<NSURLSessionTaskDelegate> _Nullable)delegate;
+- (void) setEarliestBeginDate: (NSDate * _Nullable)date;
 - (void) setPriority: (float)priority;
 
 /**
  * Sets an app-specific description of the task.
  */
-- (void) setTaskDescription: (nullable NSString *)description;
+- (void) setTaskDescription: (NSString * _Nullable)description;
 
 - (NSURLSessionTaskState) state;
 - (void) suspend;
@@ -344,7 +414,7 @@ GS_EXPORT_CLASS
 /**
  * App-specific description of the task.
  */
-- (nullable NSString *) taskDescription;
+- (NSString * _Nullable) taskDescription;
 
 - (NSUInteger) taskIdentifier;
 
@@ -406,12 +476,12 @@ GS_EXPORT_CLASS
 
 - (NSURLRequest *) configureRequest: (NSURLRequest *)request;
 
-- (nullable NSDictionary *) HTTPAdditionalHeaders;
+- (NSDictionary * _Nullable) HTTPAdditionalHeaders;
 - (NSHTTPCookieAcceptPolicy) HTTPCookieAcceptPolicy;
-- (nullable NSHTTPCookieStorage *) HTTPCookieStorage;
+- (NSHTTPCookieStorage * _Nullable) HTTPCookieStorage;
 - (NSInteger) HTTPMaximumConnectionsPerHost;
 
-- (nullable NSString *) identifier;
+- (NSString * _Nullable) identifier;
 
 /**
  * Indicates whether the session should set cookies.
@@ -439,7 +509,7 @@ GS_EXPORT_CLASS
  */
 - (BOOL) HTTPShouldUsePipelining;
 
-- (nullable NSArray *) protocolClasses;
+- (NSArray * _Nullable) protocolClasses;
 
 - (NSURLRequestCachePolicy) requestCachePolicy;
 
@@ -508,8 +578,8 @@ GS_EXPORT_CLASS
 - (NSTimeInterval) timeoutIntervalForResource;
 
 
-- (nullable NSURLCache *) URLCache;
-- (nullable NSURLCredentialStorage *) URLCredentialStorage;
+- (NSURLCache * _Nullable) URLCache;
+- (NSURLCredentialStorage * _Nullable) URLCredentialStorage;
 
 #if !NO_GNUSTEP
 /** Permits a session to be configured so that older connections are reused.
@@ -523,20 +593,6 @@ GS_EXPORT_CLASS
 
 @end
 
-typedef NS_ENUM(NSInteger, NSURLSessionAuthChallengeDisposition) {
-  NSURLSessionAuthChallengeUseCredential = 0,
-  NSURLSessionAuthChallengePerformDefaultHandling = 1,
-  NSURLSessionAuthChallengeCancelAuthenticationChallenge = 2,
-  NSURLSessionAuthChallengeRejectProtectionSpace = 3
-};
-
-typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
-  NSURLSessionResponseCancel = 0,
-  NSURLSessionResponseAllow = 1,
-  NSURLSessionResponseBecomeDownload = 2,
-  NSURLSessionResponseBecomeStream = 3
-};
-
 @protocol NSURLSessionDelegate <NSObject>
 @optional
 /* The last message a session receives.  A session will only become
@@ -544,16 +600,14 @@ typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
  * explicitly invalidated, in which case the error parameter will be nil.
  */
 - (void) URLSession: (NSURLSession *)session
-  didBecomeInvalidWithError: (nullable NSError *)error;
+  didBecomeInvalidWithError: (NSError * _Nullable)error;
 
 /* Implementing this method permits a delegate to provide authentication
  * credentials in response to a challenge from the remote server.
  */
 - (void) URLSession: (NSURLSession *)session
   didReceiveChallenge: (NSURLAuthenticationChallenge *)challenge
-  completionHandler:
-      (void (^)(NSURLSessionAuthChallengeDisposition disposition,
-                NSURLCredential                     *credential))handler;
+  completionHandler: (GSNSURLSessionChallengeHandler)handler;
 
 @end
 
@@ -570,7 +624,7 @@ typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
  */
 - (void) URLSession: (NSURLSession *)session
   task: (NSURLSessionTask *)task
-  didCompleteWithError: (nullable NSError *)error;
+  didCompleteWithError: (NSError * _Nullable)error;
 
 /* Called to request authentication credentials from the delegate when
  * an authentication request is received from the server which is specific
@@ -579,8 +633,7 @@ typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
 - (void) URLSession: (NSURLSession *)session
   task: (NSURLSessionTask *)task
   didReceiveChallenge: (NSURLAuthenticationChallenge *)challenge
-  completionHandler: (void (^)(NSURLSessionAuthChallengeDisposition disposition,
-    NSURLCredential *credential))handler;
+  completionHandler: (GSNSURLSessionChallengeHandler)handler;
 
 /* Periodically informs the delegate of the progress of sending body content
  * to the server.
@@ -599,15 +652,41 @@ typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
  * is to follow redirections.
  *
  */
+/* Deprecated: implement URLSession:task:willRedirectToResponse:newRequest:
+ * instead.  This method requires a compiler with blocks and is not looked
+ * for by a library built without them.
+ */
 - (void) URLSession: (NSURLSession *)session
   task: (NSURLSessionTask *)task
   willPerformHTTPRedirection: (NSHTTPURLResponse *)response
   newRequest: (NSURLRequest *)request
-  completionHandler: (void (^)(NSURLRequest *))completionHandler;
+  completionHandler: (GSNSURLSessionRedirectHandler)completionHandler;
 
+/* An HTTP request is attempting to perform a redirection to a different URL.
+ * Reply by sending -resumeWithRedirectRequest: to the task, with the request
+ * to follow, or nil to refuse the redirection and have the body of the
+ * redirection response delivered as the payload of this request.  The reply
+ * may be sent at any time and from any thread.
+ */
 - (void) URLSession: (NSURLSession *)session
   task: (NSURLSessionTask *)task
-  needNewBodyStream: (void (^)(NSInputStream *bodyStream))completionHandler;
+  willRedirectToResponse: (NSHTTPURLResponse *)response
+  newRequest: (NSURLRequest *)request;
+
+/* Deprecated: implement URLSession:taskNeedsNewBodyStream: instead.  This
+ * method requires a compiler with blocks and is not looked for by a library
+ * built without them.
+ */
+- (void) URLSession: (NSURLSession *)session
+  task: (NSURLSessionTask *)task
+  needNewBodyStream: (GSNSURLSessionBodyStreamHandler)completionHandler;
+
+/* A new body stream is needed to continue the upload.  Reply by sending
+ * -resumeWithBodyStream: to the task.  The reply may be sent at any time and
+ * from any thread.
+ */
+- (void) URLSession: (NSURLSession *)session
+  taskNeedsNewBodyStream: (NSURLSessionTask *)task;
 
 @end
 
@@ -619,14 +698,23 @@ typedef NS_ENUM(NSInteger, NSURLSessionResponseDisposition) {
   dataTask: (NSURLSessionDataTask *)dataTask
   didReceiveData: (NSData *)data;
 
-/** Informs the delegate of a response.  This message is sent when all the
- * response headers have arrived, before the body of the response arrives.
+/** Deprecated: implement URLSession:dataTask:didReceiveResponse: instead.
+ * This method requires a compiler with blocks and is not looked for by a
+ * library built without them.
  */
 - (void) URLSession: (NSURLSession *)session
   dataTask: (NSURLSessionDataTask *)dataTask
   didReceiveResponse: (NSURLResponse *)response
-  completionHandler:
-    (void (^)(NSURLSessionResponseDisposition disposition))completionHandler;
+  completionHandler: (GSNSURLSessionResponseDispositionHandler)completionHandler;
+
+/** Informs the delegate of a response.  This message is sent when all the
+ * response headers have arrived, before the body of the response arrives.
+ * Reply by sending -resumeWithResponseDisposition: to the task.  The reply
+ * may be sent at any time and from any thread.
+ */
+- (void) URLSession: (NSURLSession *)session
+  dataTask: (NSURLSessionDataTask *)dataTask
+  didReceiveResponse: (NSURLResponse *)response;
 
 @end
 

--- a/Headers/Foundation/NSURLSession.h
+++ b/Headers/Foundation/NSURLSession.h
@@ -130,12 +130,19 @@ DEFINE_BLOCK_TYPE(GSNSURLSessionChallengeHandler, void,
 GS_EXPORT_CLASS
 @interface NSURLSession : NSObject
 {
-@private
-  NSOperationQueue          *_delegateQueue;
-  id<NSURLSessionDelegate>   _delegate;
-  NSURLSessionConfiguration *_configuration;
-
-  NSString *_sessionDescription;
+#if	GS_NONFRAGILE
+#  if	defined(GS_NSURLSession_IVARS)
+@public
+GS_NSURLSession_IVARS;
+#  endif
+#else
+  /* Pointer to private additional data used to avoid breaking ABI
+   * when we don't have the non-fragile ABI available.
+   * Use this mechanism rather than changing the instance variable
+   * layout (see Source/GSInternal.h for details).
+   */
+@private id _internal GS_UNUSED_IVAR;
+#endif
 }
 
 + (NSURLSession *) sharedSession;

--- a/Headers/Foundation/NSURLSession.h
+++ b/Headers/Foundation/NSURLSession.h
@@ -342,26 +342,19 @@ GS_EXPORT const int64_t NSURLSessionTransferSizeUnknown;
 GS_EXPORT_CLASS
 @interface NSURLSessionTask : NSObject <NSCopying, NSProgressReporting>
 {
-  NSUInteger    _taskIdentifier;
-  NSURLRequest *_originalRequest;
-
-  id<NSURLSessionTaskDelegate> _delegate;
-  NSURLSessionTaskState        _state;
-  NSURLRequest                *_currentRequest;
-  NSURLResponse               *_response;
-  NSProgress                  *_progress;
-  NSDate                      *_earliestBeginDate;
-
-  _Atomic(int64_t) _countOfBytesClientExpectsToSend;
-  _Atomic(int64_t) _countOfBytesClientExpectsToReceive;
-  _Atomic(int64_t) _countOfBytesSent;
-  _Atomic(int64_t) _countOfBytesReceived;
-  _Atomic(int64_t) _countOfBytesExpectedToSend;
-  _Atomic(int64_t) _countOfBytesExpectedToReceive;
-  _Atomic(double)  _priority;
-
-  NSString *_taskDescription;
-  NSError  *_error;
+#if	GS_NONFRAGILE
+#  if	defined(GS_NSURLSessionTask_IVARS)
+@public
+GS_NSURLSessionTask_IVARS;
+#  endif
+#else
+  /* Pointer to private additional data used to avoid breaking ABI
+   * when we don't have the non-fragile ABI available.
+   * Use this mechanism rather than changing the instance variable
+   * layout (see Source/GSInternal.h for details).
+   */
+@private id _internal GS_UNUSED_IVAR;
+#endif
 }
 
 /**

--- a/Source/GSAtomic.h
+++ b/Source/GSAtomic.h
@@ -13,7 +13,14 @@
 #define __has_extension(x) 0
 #endif
 
-#if __has_extension(c_atomic) || __has_extension(cxx_atomic)
+/* __c11_atomic_load and __c11_atomic_store are clang builtins, and
+ * __has_extension answers for clang, so ask for the compiler as well as the
+ * extension.  Where GNUstepBase/GNUstep.h has already defined
+ * __has_extension in terms of __has_feature, gcc can otherwise reach this
+ * branch and then has neither the builtins nor a usable _Atomic.
+ */
+#if defined(__clang__) \
+  && (__has_extension(c_atomic) || __has_extension(cxx_atomic))
 
 /*
  * Use native C11 atomic operations. _Atomic() should be defined by the

--- a/Source/NSURLSession.m
+++ b/Source/NSURLSession.m
@@ -383,10 +383,12 @@ static NSURLSession * sharedSession = nil;
       [queueLabel release];
       [internal->_workHelper->thread start];
 
-      /* Use the provided delegateQueue if available */
+      /* Use the provided delegateQueue if available.  It is retained, since
+       * -dealloc releases it and the caller may share one queue between
+       * several sessions. */
       if (queue)
         {
-          internal->_delegateQueue = queue;
+          ASSIGN(internal->_delegateQueue, queue);
         }
       else
         {

--- a/Source/NSURLSession.m
+++ b/Source/NSURLSession.m
@@ -112,9 +112,10 @@
   /* Path to PEM encoded CA certificate file. */ \
   NSString * _certificatePath; \
  \
-  /* The task identifier for the next task \
+  /* The task identifier for the next task.  Read and incremented under \
+   * _taskLock, so it needs no atomic type of its own. \
    */ \
-  _Atomic(NSInteger) _taskIdentifier; \
+  NSInteger _taskIdentifier; \
   /* Lock for _taskIdentifier and _tasks \
    */ \
   gs_mutex_t _taskLock;

--- a/Source/NSURLSession.m
+++ b/Source/NSURLSession.m
@@ -41,12 +41,27 @@
 #import "Foundation/NSUserDefaults.h"
 #import "Foundation/NSBundle.h"
 #import "Foundation/NSData.h"
+#import "Foundation/NSInvocation.h"
+#import "Foundation/NSInvocationOperation.h"
+#import "Foundation/NSMethodSignature.h"
 
 #import "GNUstepBase/NSDebug+GNUstepBase.h"  /* For NSDebugMLLog */
 #import "GNUstepBase/NSObject+GNUstepBase.h" /* For -notImplemented */
 #import "GSPThread.h"                        /* For nextSessionIdentifier() */
 
 NSString * GS_NSURLSESSION_DEBUG_KEY = @"NSURLSession";
+
+NSInvocation *
+GSURLSessionInvocation(id target, SEL aSelector)
+{
+  NSInvocation	*inv;
+
+  inv = [NSInvocation invocationWithMethodSignature:
+    [target methodSignatureForSelector: aSelector]];
+  [inv setTarget: target];
+  [inv setSelector: aSelector];
+  return inv;
+}
 
 /* We need a globably unique label for the NSURLSession workQueues.
  */
@@ -230,7 +245,7 @@ socket_callback(CURL * easy,           /* easy handle */
 
   /* List of active tasks. Access is synchronised via the work thread.
    */
-  NSMutableArray<NSURLSessionTask *> * _tasks;
+  GS_GENERIC_CLASS(NSMutableArray, NSURLSessionTask *) * _tasks;
 
   /* PEM encoded blob of one or more certificates.
    *
@@ -426,26 +441,31 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _resumeTask: (NSURLSessionTask *)task
 {
-  [self _performOnWorkThread: ^{
-    CURLMcode code;
-    CURLM * multiHandle = _multiHandle;
+  [self _performSelectorOnWorkThread: @selector(_workResumeTask:)
+			      target: self
+			  withObject: task];
+}
 
-    code = curl_multi_add_handle(multiHandle, [task _easyHandle]);
+- (void) _workResumeTask: (NSURLSessionTask *)task
+{
+  CURLMcode	code;
+  CURLM		*multiHandle = _multiHandle;
 
-    NSDebugMLLog(
-      GS_NSURLSESSION_DEBUG_KEY,
-      @"Added task=%@ easy=%p to multi=%p with return value %d",
-      task,
-      [task _easyHandle],
-      multiHandle,
-      code);
+  code = curl_multi_add_handle(multiHandle, [task _easyHandle]);
 
-    /* Kick the transfer off now rather than waiting for the timer callback
-     * (see -_addHandle:). */
-    curl_multi_socket_action(multiHandle, CURL_SOCKET_TIMEOUT, 0,
-      &_stillRunning);
-    [self _checkForCompletion];
-  }];
+  NSDebugMLLog(
+    GS_NSURLSESSION_DEBUG_KEY,
+    @"Added task=%@ easy=%p to multi=%p with return value %d",
+    task,
+    [task _easyHandle],
+    multiHandle,
+    code);
+
+  /* Kick the transfer off now rather than waiting for the timer callback
+   * (see -_addHandle:). */
+  curl_multi_socket_action(multiHandle, CURL_SOCKET_TIMEOUT, 0,
+    &_stillRunning);
+  [self _checkForCompletion];
 }
 
 - (void) _addHandle: (CURL *)easy
@@ -495,10 +515,16 @@ static NSURLSession * sharedSession = nil;
       [_delegate respondsToSelector: @selector(URLSession:
                                                didBecomeInvalidWithError:)])
     {
-      [_delegateQueue addOperationWithBlock:^{
-         /* We only support explicit invalidation for now, so error is nil. */
-         [_delegate URLSession: self didBecomeInvalidWithError: nil];
-       }];
+      /* We only support explicit invalidation for now, so error is nil. */
+      NSInvocation	*inv;
+      NSURLSession	*session = self;
+      NSError		*error = nil;
+
+      inv = GSURLSessionInvocation(_delegate,
+	@selector(URLSession:didBecomeInvalidWithError:));
+      [inv setArgument: &session atIndex: 2];
+      [inv setArgument: &error atIndex: 3];
+      [self _enqueueDelegateInvocation: inv];
     }
   RELEASE(self);
 }
@@ -560,29 +586,69 @@ static NSURLSession * sharedSession = nil;
 
 #pragma mark - Work thread
 
-- (void) _runWorkBlock: (id)block
+- (void) _runWorkInvocation: (NSInvocation *)anInvocation
 {
-  ((GSURLSessionWorkBlock)block)();
+  [anInvocation invoke];
 }
 
-- (void) _performOnWorkThread: (GSURLSessionWorkBlock)block
+- (void) _performSelectorOnWorkThread: (SEL)aSelector
+			       target: (id)target
+			   withObject: (id)anObject
+{
+  [self _performSelectorOnWorkThread: aSelector
+			      target: target
+			  withObject: anObject
+		       waitUntilDone: NO];
+}
+
+- (void) _performSelectorOnWorkThread: (SEL)aSelector
+			       target: (id)target
+			   withObject: (id)anObject
+			waitUntilDone: (BOOL)shouldWait
 {
   /* Run immediately if we are already on the work thread (e.g. called from
    * a libcurl callback), otherwise schedule on its run loop. */
   if ([NSThread currentThread] == _workHelper->thread)
     {
-      block();
+      [target performSelector: aSelector withObject: anObject];
     }
   else
     {
-      id copy = [block copy];
-
-      [self performSelector: @selector(_runWorkBlock:)
-                   onThread: _workHelper->thread
-                 withObject: copy
-              waitUntilDone: NO];
-      [copy release];
+      [target performSelector: aSelector
+		     onThread: _workHelper->thread
+		   withObject: anObject
+		waitUntilDone: shouldWait];
     }
+}
+
+- (void) _performInvocationOnWorkThread: (NSInvocation *)anInvocation
+{
+  if ([NSThread currentThread] == _workHelper->thread)
+    {
+      [anInvocation invoke];
+    }
+  else
+    {
+      [anInvocation retainArguments];
+      [self performSelector: @selector(_runWorkInvocation:)
+		   onThread: _workHelper->thread
+		 withObject: anInvocation
+	      waitUntilDone: NO];
+    }
+}
+
+- (void) _enqueueDelegateInvocation: (NSInvocation *)anInvocation
+{
+  NSInvocationOperation	*op;
+
+  if (nil == _delegateQueue)
+    {
+      return;
+    }
+  [anInvocation retainArguments];
+  op = [[NSInvocationOperation alloc] initWithInvocation: anInvocation];
+  [_delegateQueue addOperation: op];
+  RELEASE(op);
 }
 
 #pragma mark - Socket monitoring
@@ -899,17 +965,26 @@ static NSURLSession * sharedSession = nil;
 /* Adds task to _tasks and updates the delegate */
 - (void) _didCreateTask: (NSURLSessionTask *)task
 {
-  [self _performOnWorkThread: ^{
-    [_tasks addObject: task];
-  }];
+  [self _performSelectorOnWorkThread: @selector(_workAddTask:)
+			      target: self
+			  withObject: task];
 
   if ([_delegate respondsToSelector: @selector(URLSession:didCreateTask:)])
     {
-      [_delegateQueue addOperationWithBlock:^{
-         [(id<NSURLSessionTaskDelegate>) _delegate URLSession: self
-                                                didCreateTask  : task];
-       }];
+      NSInvocation	*inv;
+      NSURLSession	*session = self;
+
+      inv = GSURLSessionInvocation(_delegate,
+	@selector(URLSession:didCreateTask:));
+      [inv setArgument: &session atIndex: 2];
+      [inv setArgument: &task atIndex: 3];
+      [self _enqueueDelegateInvocation: inv];
     }
+}
+
+- (void) _workAddTask: (NSURLSessionTask *)task
+{
+  [_tasks addObject: task];
 }
 
 #pragma mark - Public API
@@ -921,9 +996,14 @@ static NSURLSession * sharedSession = nil;
       return;
     }
 
-  [self _performOnWorkThread: ^{
-    _invalidated = YES;
-  }];
+  [self _performSelectorOnWorkThread: @selector(_workInvalidate)
+			      target: self
+			  withObject: nil];
+}
+
+- (void) _workInvalidate
+{
+  _invalidated = YES;
 }
 
 - (void) invalidateAndCancel
@@ -933,15 +1013,20 @@ static NSURLSession * sharedSession = nil;
       return;
     }
 
-  [self _performOnWorkThread: ^{
-    _invalidated = YES;
+  [self _performSelectorOnWorkThread: @selector(_workInvalidateAndCancel)
+			      target: self
+			  withObject: nil];
+}
 
-    /* Cancel all tasks */
-    for (NSURLSessionTask * task in _tasks)
+- (void) _workInvalidateAndCancel
+{
+  _invalidated = YES;
+
+  /* Cancel all tasks */
+  for (NSURLSessionTask * task in _tasks)
     {
       [task cancel];
     }
-  }];
 }
 
 - (NSURLSessionDataTask *) dataTaskWithRequest: (NSURLRequest *)request
@@ -1083,58 +1168,75 @@ static NSURLSession * sharedSession = nil;
   return [self notImplemented: _cmd];
 }
 
-- (void) getTasksWithCompletionHandler:
-  (void (^)(
-     NSArray<NSURLSessionDataTask *> * dataTasks,
-     NSArray<NSURLSessionUploadTask *> * uploadTasks,
-     NSArray<NSURLSessionDownloadTask *> * downloadTasks))
-  completionHandler
+- (GS_GENERIC_CLASS(NSArray, NSURLSessionTask *) *) allTasks
 {
-  [self _performOnWorkThread: ^{
-    NSMutableArray<NSURLSessionDataTask *> * dataTasks;
-    NSMutableArray<NSURLSessionUploadTask *> * uploadTasks;
-    NSMutableArray<NSURLSessionDownloadTask *> * downloadTasks;
-    NSInteger numberOfTasks;
+  NSMutableArray	*collected = [NSMutableArray array];
 
-    Class dataTaskClass;
-    Class uploadTaskClass;
-    Class downloadTaskClass;
+  [self _performSelectorOnWorkThread: @selector(_workCollectTasksInto:)
+			      target: self
+			  withObject: collected
+		       waitUntilDone: YES];
+  return collected;
+}
 
-    numberOfTasks = [_tasks count];
-    dataTasks = [NSMutableArray arrayWithCapacity: numberOfTasks / 2];
-    uploadTasks = [NSMutableArray arrayWithCapacity: numberOfTasks / 2];
-    downloadTasks = [NSMutableArray arrayWithCapacity: numberOfTasks / 2];
+- (void) _workCollectTasksInto: (NSMutableArray *)collected
+{
+  [collected addObjectsFromArray: _tasks];
+}
 
-    dataTaskClass = [NSURLSessionDataTask class];
-    uploadTaskClass = [NSURLSessionUploadTask class];
-    downloadTaskClass = [NSURLSessionDownloadTask class];
+- (GS_GENERIC_CLASS(NSArray, NSURLSessionTask *) *) tasksOfKind: (Class)aClass
+{
+  NSMutableArray	*matched = [NSMutableArray array];
+  NSEnumerator		*e = [[self allTasks] objectEnumerator];
+  NSURLSessionTask	*task;
 
-    for (NSURLSessionTask * task in _tasks)
+  while ((task = [e nextObject]) != nil)
     {
-      if ([task isKindOfClass: dataTaskClass])
-      {
-        [dataTasks addObject: (NSURLSessionDataTask *)task];
-      }
-      else if ([task isKindOfClass: uploadTaskClass])
-      {
-        [uploadTasks addObject: (NSURLSessionUploadTask *)task];
-      }
+      if ([task isKindOfClass: aClass])
+	{
+	  [matched addObject: task];
+	}
+    }
+  return matched;
+}
+
+- (void) getTasksWithCompletionHandler:
+  (GSNSURLSessionTasksCompletionHandler)completionHandler
+{
+  NSArray	*all = [self allTasks];
+  NSMutableArray *dataTasks = [NSMutableArray array];
+  NSMutableArray *uploadTasks = [NSMutableArray array];
+  NSMutableArray *downloadTasks = [NSMutableArray array];
+  Class		dataTaskClass = [NSURLSessionDataTask class];
+  Class		uploadTaskClass = [NSURLSessionUploadTask class];
+  Class		downloadTaskClass = [NSURLSessionDownloadTask class];
+  NSEnumerator	*e = [all objectEnumerator];
+  NSURLSessionTask *task;
+
+  while ((task = [e nextObject]) != nil)
+    {
+      /* An upload task is a kind of data task, so test for it first. */
+      if ([task isKindOfClass: uploadTaskClass])
+	{
+	  [uploadTasks addObject: task];
+	}
+      else if ([task isKindOfClass: dataTaskClass])
+	{
+	  [dataTasks addObject: task];
+	}
       else if ([task isKindOfClass: downloadTaskClass])
-      {
-        [downloadTasks addObject: (NSURLSessionDownloadTask *)task];
-      }
+	{
+	  [downloadTasks addObject: task];
+	}
     }
 
-    completionHandler(dataTasks, uploadTasks, downloadTasks);
-  }];
+  CALL_BLOCK(completionHandler, dataTasks, uploadTasks, downloadTasks);
 } /* getTasksWithCompletionHandler */
 
 - (void) getAllTasksWithCompletionHandler:
-  (void (^)(NSArray<__kindof NSURLSessionTask *> * tasks))completionHandler
+  (GSNSURLSessionAllTasksCompletionHandler)completionHandler
 {
-  [self _performOnWorkThread: ^{
-    completionHandler(_tasks);
-  }];
+  CALL_BLOCK(completionHandler, [self allTasks]);
 }
 
 #pragma mark - Getter and Setter

--- a/Source/NSURLSession.m
+++ b/Source/NSURLSession.m
@@ -27,6 +27,98 @@
  * Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
  */
 
+/* The ivar macro below is expanded by Foundation/NSURLSession.h, so the types
+ * it names have to be known before that header is imported.
+ */
+#import "common.h"
+#import <curl/curl.h>
+#import "GSPThread.h"
+
+@class GSURLSessionWorkThread;
+@class NSMapTable;
+@class NSTimer;
+
+/* The socket-to-event map is only needed where the run loop has no descriptor
+ * events.  A preprocessor conditional cannot appear inside the ivar macro, so
+ * it is a macro of its own.
+ */
+#if	defined(_WIN32)
+/* Maps a registered WSAEVENT back to its socket, since the run loop only
+ * hands the event handle back to -receivedEvent:type:extra:forMode:.
+ */
+#define	GS_NSURLSession_PLATFORM_IVARS	NSMapTable * _socketForEvent;
+#else
+#define	GS_NSURLSession_PLATFORM_IVARS
+#endif
+
+#define	GS_NSURLSession_IVARS \
+  NSOperationQueue          *_delegateQueue; \
+  id<NSURLSessionDelegate>   _delegate; \
+  NSURLSessionConfiguration *_configuration; \
+ \
+  NSString *_sessionDescription; \
+ \
+  /* The libcurl multi handle associated with this session. \
+   * We use the curl_multi_socket_action API as we utilise our \
+   * own event-handling system integrated with the work thread run loop. \
+   * \
+   * Event creation and deletion is driven by the various callbacks \
+   * registered during initialisation of the multi handle. \
+   */ \
+  CURLM * _multiHandle; \
+  /* Drives a dedicated thread running an NSRunLoop.  All libcurl multi \
+   * handle activity (adding handles, socket events and the timer) happens on \
+   * that thread, which serialises access in place of a dispatch queue and \
+   * keeps GNUstep free of a libdispatch dependency.  The helper holds the \
+   * session unretained so that it does not keep the session alive. \
+   */ \
+  GSURLSessionWorkThread * _workHelper; \
+ \
+  GS_NSURLSession_PLATFORM_IVARS \
+ \
+  /* This timer is driven by libcurl and used by \
+   * libcurl's multi API. \
+   * \
+   * The handler notifies libcurl using curl_multi_socket_action \
+   * and checks for completed requests by calling \
+   * _checkForCompletion. \
+   * \
+   * See https://curl.se/libcurl/c/CURLMOPT_TIMERFUNCTION.html \
+   * and https://curl.se/libcurl/c/curl_multi_socket_action.html \
+   * respectively.  It is scheduled on the work thread run loop. \
+   */ \
+  NSTimer * _timer; \
+ \
+  /* Only set when session originates from +[NSURLSession sharedSession] */ \
+  BOOL _isSharedSession; \
+  BOOL _invalidated; \
+ \
+  /* \
+   * Number of currently running handles. \
+   * This number is updated by curl_multi_socket_action \
+   * in the socket source handlers. \
+   */ \
+  int _stillRunning; \
+ \
+  /* List of active tasks. Access is synchronised via the work thread. \
+   */ \
+  GS_GENERIC_CLASS(NSMutableArray, NSURLSessionTask *) * _tasks; \
+ \
+  /* PEM encoded blob of one or more certificates. \
+   * \
+   * See GSCACertificateFilePath in NSUserDefaults.h \
+   */ \
+  NSData * _certificateBlob; \
+  /* Path to PEM encoded CA certificate file. */ \
+  NSString * _certificatePath; \
+ \
+  /* The task identifier for the next task \
+   */ \
+  _Atomic(NSInteger) _taskIdentifier; \
+  /* Lock for _taskIdentifier and _tasks \
+   */ \
+  gs_mutex_t _taskLock;
+
 #import "NSURLSessionPrivate.h"
 #import "NSURLSessionTaskPrivate.h"
 #import "Foundation/NSString.h"
@@ -48,6 +140,10 @@
 #import "GNUstepBase/NSDebug+GNUstepBase.h"  /* For NSDebugMLLog */
 #import "GNUstepBase/NSObject+GNUstepBase.h" /* For -notImplemented */
 #import "GSPThread.h"                        /* For nextSessionIdentifier() */
+
+#define	GSInternal	NSURLSessionInternal
+#include "GSInternal.h"
+GS_PRIVATE_INTERNAL(NSURLSession)
 
 NSString * GS_NSURLSESSION_DEBUG_KEY = @"NSURLSession";
 
@@ -195,73 +291,6 @@ socket_callback(CURL * easy,           /* easy handle */
 @end
 
 @implementation NSURLSession
-{
-  /* The libcurl multi handle associated with this session.
-   * We use the curl_multi_socket_action API as we utilise our
-   * own event-handling system integrated with the work thread run loop.
-   *
-   * Event creation and deletion is driven by the various callbacks
-   * registered during initialisation of the multi handle.
-   */
-  CURLM * _multiHandle;
-  /* Drives a dedicated thread running an NSRunLoop.  All libcurl multi
-   * handle activity (adding handles, socket events and the timer) happens on
-   * that thread, which serialises access in place of a dispatch queue and
-   * keeps GNUstep free of a libdispatch dependency.  The helper holds the
-   * session unretained so that it does not keep the session alive.
-   */
-  GSURLSessionWorkThread * _workHelper;
-
-#if	defined(_WIN32)
-  /* Maps a registered WSAEVENT back to its socket, since the run loop only
-   * hands the event handle back to -receivedEvent:type:extra:forMode:.
-   */
-  NSMapTable * _socketForEvent;
-#endif
-
-  /* This timer is driven by libcurl and used by
-   * libcurl's multi API.
-   *
-   * The handler notifies libcurl using curl_multi_socket_action
-   * and checks for completed requests by calling
-   * _checkForCompletion.
-   *
-   * See https://curl.se/libcurl/c/CURLMOPT_TIMERFUNCTION.html
-   * and https://curl.se/libcurl/c/curl_multi_socket_action.html
-   * respectively.  It is scheduled on the work thread run loop.
-   */
-  NSTimer * _timer;
-
-  /* Only set when session originates from +[NSURLSession sharedSession] */
-  BOOL _isSharedSession;
-  BOOL _invalidated;
-
-  /*
-   * Number of currently running handles.
-   * This number is updated by curl_multi_socket_action
-   * in the socket source handlers.
-   */
-  int _stillRunning;
-
-  /* List of active tasks. Access is synchronised via the work thread.
-   */
-  GS_GENERIC_CLASS(NSMutableArray, NSURLSessionTask *) * _tasks;
-
-  /* PEM encoded blob of one or more certificates.
-   *
-   * See GSCACertificateFilePath in NSUserDefaults.h
-   */
-  NSData * _certificateBlob;
-  /* Path to PEM encoded CA certificate file. */
-  NSString * _certificatePath;
-
-  /* The task identifier for the next task
-   */
-  _Atomic(NSInteger) _taskIdentifier;
-  /* Lock for _taskIdentifier and _tasks
-   */
-  gs_mutex_t _taskLock;
-}
 
 static NSURLSession * sharedSession = nil;
 
@@ -325,62 +354,64 @@ static NSURLSession * sharedSession = nil;
       NSString * caPath;
       NSUInteger sessionIdentifier;
 
+      GS_CREATE_INTERNAL(NSURLSession);
+
       sessionIdentifier = nextSessionIdentifier();
       queueLabel = [[NSString alloc]
                     initWithFormat: @"org.gnustep.NSURLSession.WorkQueue%ld",
                     sessionIdentifier];
-      ASSIGN(_delegate, delegate);
-      ASSIGNCOPY(_configuration, configuration);
+      ASSIGN(internal->_delegate, delegate);
+      ASSIGNCOPY(internal->_configuration, configuration);
 
-      _tasks = [[NSMutableArray alloc] init];
-      GS_MUTEX_INIT(_taskLock);
+      internal->_tasks = [[NSMutableArray alloc] init];
+      GS_MUTEX_INIT(internal->_taskLock);
 
-      _timer = nil;
+      internal->_timer = nil;
 #if	defined(_WIN32)
-      _socketForEvent = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
+      internal->_socketForEvent = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
         NSIntegerMapValueCallBacks, 0);
 #endif
       /* A port keeps the work thread run loop from exiting when it has no
        * other input sources. */
-      _workHelper = [[GSURLSessionWorkThread alloc] init];
-      _workHelper->port = [[NSPort port] retain];
-      _workHelper->thread = [[NSThread alloc] initWithTarget: _workHelper
+      internal->_workHelper = [[GSURLSessionWorkThread alloc] init];
+      internal->_workHelper->port = [[NSPort port] retain];
+      internal->_workHelper->thread = [[NSThread alloc] initWithTarget: internal->_workHelper
                                                     selector: @selector(run)
                                                       object: nil];
-      [_workHelper->thread setName: queueLabel];
+      [internal->_workHelper->thread setName: queueLabel];
       [queueLabel release];
-      [_workHelper->thread start];
+      [internal->_workHelper->thread start];
 
       /* Use the provided delegateQueue if available */
       if (queue)
         {
-          _delegateQueue = queue;
+          internal->_delegateQueue = queue;
         }
       else
         {
           /* This (serial) NSOperationQueue is only used for dispatching
            * delegate callbacks and is orthogonal to the workQueue.
            */
-          _delegateQueue = [[NSOperationQueue alloc] init];
-          [_delegateQueue setMaxConcurrentOperationCount: 1];
+          internal->_delegateQueue = [[NSOperationQueue alloc] init];
+          [internal->_delegateQueue setMaxConcurrentOperationCount: 1];
         }
 
       /* libcurl Configuration */
       curl_global_init(CURL_GLOBAL_SSL);
 
-      _multiHandle = curl_multi_init();
+      internal->_multiHandle = curl_multi_init();
 
       // Set up CURL multi callbacks
-      curl_multi_setopt(_multiHandle, CURLMOPT_SOCKETFUNCTION, socket_callback);
-      curl_multi_setopt(_multiHandle, CURLMOPT_SOCKETDATA, self);
-      curl_multi_setopt(_multiHandle, CURLMOPT_TIMERFUNCTION, timer_callback);
-      curl_multi_setopt(_multiHandle, CURLMOPT_TIMERDATA, self);
+      curl_multi_setopt(internal->_multiHandle, CURLMOPT_SOCKETFUNCTION, socket_callback);
+      curl_multi_setopt(internal->_multiHandle, CURLMOPT_SOCKETDATA, self);
+      curl_multi_setopt(internal->_multiHandle, CURLMOPT_TIMERFUNCTION, timer_callback);
+      curl_multi_setopt(internal->_multiHandle, CURLMOPT_TIMERDATA, self);
 
       // Configure Multi Handle
       curl_multi_setopt(
-        _multiHandle,
+        internal->_multiHandle,
         CURLMOPT_MAX_HOST_CONNECTIONS,
-        [_configuration HTTPMaximumConnectionsPerHost]);
+        [internal->_configuration HTTPMaximumConnectionsPerHost]);
 
       /* Check if GSCACertificateFilePath is set */
 
@@ -392,8 +423,8 @@ static NSURLSession * sharedSession = nil;
             GS_NSURLSESSION_DEBUG_KEY,
             @"Found a GSCACertificateFilePath entry in UserDefaults");
 
-          _certificateBlob = [[NSData alloc] initWithContentsOfFile: caPath];
-          if (!_certificateBlob)
+          internal->_certificateBlob = [[NSData alloc] initWithContentsOfFile: caPath];
+          if (!internal->_certificateBlob)
             {
               NSDebugMLLog(
                 GS_NSURLSESSION_DEBUG_KEY,
@@ -402,7 +433,7 @@ static NSURLSession * sharedSession = nil;
             }
           else
             {
-              ASSIGN(_certificatePath, caPath);
+              ASSIGN(internal->_certificatePath, caPath);
             }
         }
     }
@@ -414,27 +445,27 @@ static NSURLSession * sharedSession = nil;
 
 - (NSData *) _certificateBlob
 {
-  return _certificateBlob;
+  return internal->_certificateBlob;
 }
 
 - (NSString *) _certificatePath
 {
-  return _certificatePath;
+  return internal->_certificatePath;
 }
 
 - (void) _setSharedSession: (BOOL)flag
 {
-  _isSharedSession = flag;
+  internal->_isSharedSession = flag;
 }
 
 - (NSInteger) _nextTaskIdentifier
 {
   NSInteger identifier;
 
-  GS_MUTEX_LOCK(_taskLock);
-  identifier = _taskIdentifier;
-  _taskIdentifier += 1;
-  GS_MUTEX_UNLOCK(_taskLock);
+  GS_MUTEX_LOCK(internal->_taskLock);
+  identifier = internal->_taskIdentifier;
+  internal->_taskIdentifier += 1;
+  GS_MUTEX_UNLOCK(internal->_taskLock);
 
   return identifier;
 }
@@ -449,7 +480,7 @@ static NSURLSession * sharedSession = nil;
 - (void) _workResumeTask: (NSURLSessionTask *)task
 {
   CURLMcode	code;
-  CURLM		*multiHandle = _multiHandle;
+  CURLM		*multiHandle = internal->_multiHandle;
 
   code = curl_multi_add_handle(multiHandle, [task _easyHandle]);
 
@@ -464,26 +495,26 @@ static NSURLSession * sharedSession = nil;
   /* Kick the transfer off now rather than waiting for the timer callback
    * (see -_addHandle:). */
   curl_multi_socket_action(multiHandle, CURL_SOCKET_TIMEOUT, 0,
-    &_stillRunning);
+    &internal->_stillRunning);
   [self _checkForCompletion];
 }
 
 - (void) _addHandle: (CURL *)easy
 {
-  curl_multi_add_handle(_multiHandle, easy);
+  curl_multi_add_handle(internal->_multiHandle, easy);
 
   /* Kick the added transfer off now rather than waiting for libcurl to fire
    * the timer callback.  Relying on the timer alone races with the run loop,
    * which shows up most on a handle that is re-added after a redirect: the
    * transfer can stall until an unrelated event drives the multi handle.
    * See https://curl.se/libcurl/c/curl_multi_socket_action.html . */
-  curl_multi_socket_action(_multiHandle, CURL_SOCKET_TIMEOUT, 0,
-    &_stillRunning);
+  curl_multi_socket_action(internal->_multiHandle, CURL_SOCKET_TIMEOUT, 0,
+    &internal->_stillRunning);
   [self _checkForCompletion];
 }
 - (void) _removeHandle: (CURL *)easy
 {
-  curl_multi_remove_handle(_multiHandle, easy);
+  curl_multi_remove_handle(internal->_multiHandle, easy);
 }
 
 /* The single point at which a task's transfer is finished.  Every completion
@@ -495,24 +526,24 @@ static NSURLSession * sharedSession = nil;
  * has already been finished by another path. */
 - (void) _finishTask: (NSURLSessionTask *)task withCode: (CURLcode)code
 {
-  if (![_tasks containsObject: task])
+  if (![internal->_tasks containsObject: task])
     {
       return;
     }
-  curl_multi_remove_handle(_multiHandle, [task _easyHandle]);
+  curl_multi_remove_handle(internal->_multiHandle, [task _easyHandle]);
 
   /* -_transferFinishedWithCode: may release the last reference to the
    * session, so keep both alive across the call. */
   RETAIN(self);
   RETAIN(task);
-  [_tasks removeObject: task];
+  [internal->_tasks removeObject: task];
   [task _transferFinishedWithCode: code];
   RELEASE(task);
 
   /* Send URLSession:didBecomeInvalidWithError: to the delegate once the last
    * task of an invalidated session has finished. */
-  if (_invalidated && [_tasks count] == 0 &&
-      [_delegate respondsToSelector: @selector(URLSession:
+  if (internal->_invalidated && [internal->_tasks count] == 0 &&
+      [internal->_delegate respondsToSelector: @selector(URLSession:
                                                didBecomeInvalidWithError:)])
     {
       /* We only support explicit invalidation for now, so error is nil. */
@@ -520,7 +551,7 @@ static NSURLSession * sharedSession = nil;
       NSURLSession	*session = self;
       NSError		*error = nil;
 
-      inv = GSURLSessionInvocation(_delegate,
+      inv = GSURLSessionInvocation(internal->_delegate,
 	@selector(URLSession:didBecomeInvalidWithError:));
       [inv setArgument: &session atIndex: 2];
       [inv setArgument: &error atIndex: 3];
@@ -557,8 +588,8 @@ static NSURLSession * sharedSession = nil;
  */
 - (void) _setTimer: (NSInteger)timeoutMs
 {
-  [_timer invalidate];
-  _timer = [NSTimer scheduledTimerWithTimeInterval: (double)timeoutMs / 1000.0
+  [internal->_timer invalidate];
+  internal->_timer = [NSTimer scheduledTimerWithTimeInterval: (double)timeoutMs / 1000.0
                                             target: self
                                           selector: @selector(_timerFired:)
                                           userInfo: nil
@@ -567,20 +598,20 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _suspendTimer
 {
-  [_timer invalidate];
-  _timer = nil;
+  [internal->_timer invalidate];
+  internal->_timer = nil;
 }
 
 - (void) _timerFired: (NSTimer *)timer
 {
   /* The run loop releases the fired non-repeating timer. */
-  _timer = nil;
+  internal->_timer = nil;
 
   curl_multi_socket_action(
-    _multiHandle,
+    internal->_multiHandle,
     CURL_SOCKET_TIMEOUT,
     0,
-    &_stillRunning);
+    &internal->_stillRunning);
   [self _checkForCompletion];
 }
 
@@ -608,14 +639,14 @@ static NSURLSession * sharedSession = nil;
 {
   /* Run immediately if we are already on the work thread (e.g. called from
    * a libcurl callback), otherwise schedule on its run loop. */
-  if ([NSThread currentThread] == _workHelper->thread)
+  if ([NSThread currentThread] == internal->_workHelper->thread)
     {
       [target performSelector: aSelector withObject: anObject];
     }
   else
     {
       [target performSelector: aSelector
-		     onThread: _workHelper->thread
+		     onThread: internal->_workHelper->thread
 		   withObject: anObject
 		waitUntilDone: shouldWait];
     }
@@ -623,7 +654,7 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _performInvocationOnWorkThread: (NSInvocation *)anInvocation
 {
-  if ([NSThread currentThread] == _workHelper->thread)
+  if ([NSThread currentThread] == internal->_workHelper->thread)
     {
       [anInvocation invoke];
     }
@@ -631,7 +662,7 @@ static NSURLSession * sharedSession = nil;
     {
       [anInvocation retainArguments];
       [self performSelector: @selector(_runWorkInvocation:)
-		   onThread: _workHelper->thread
+		   onThread: internal->_workHelper->thread
 		 withObject: anInvocation
 	      waitUntilDone: NO];
     }
@@ -641,13 +672,13 @@ static NSURLSession * sharedSession = nil;
 {
   NSInvocationOperation	*op;
 
-  if (nil == _delegateQueue)
+  if (nil == internal->_delegateQueue)
     {
       return;
     }
   [anInvocation retainArguments];
   op = [[NSInvocationOperation alloc] initWithInvocation: anInvocation];
-  [_delegateQueue addOperation: op];
+  [internal->_delegateQueue addOperation: op];
   RELEASE(op);
 }
 
@@ -674,7 +705,7 @@ static NSURLSession * sharedSession = nil;
               forMode: NSDefaultRunLoopMode
                   all: YES];
       WSAEventSelect(sources->socket, sources->event, 0);
-      NSMapRemove(_socketForEvent, (void*)sources->event);
+      NSMapRemove(internal->_socketForEvent, (void*)sources->event);
       WSACloseEvent(sources->event);
       sources->event = WSA_INVALID_EVENT;
     }
@@ -734,7 +765,7 @@ static NSURLSession * sharedSession = nil;
       return -1;
     }
   /* Assign the SourceInfo for access in subsequent socket_callback calls */
-  curl_multi_assign(_multiHandle, socket, info);
+  curl_multi_assign(internal->_multiHandle, socket, info);
   return 0;
 } /* _addSocket */
 
@@ -782,7 +813,7 @@ static NSURLSession * sharedSession = nil;
                     type: ET_HANDLE
                  watcher: self
                  forMode: NSDefaultRunLoopMode];
-            NSMapInsert(_socketForEvent, (void*)sources->event,
+            NSMapInsert(internal->_socketForEvent, (void*)sources->event,
               (void*)(intptr_t)socket);
           }
         if (SOCKET_ERROR == WSAEventSelect(socket, sources->event, mask))
@@ -845,7 +876,7 @@ static NSURLSession * sharedSession = nil;
 #if	defined(_WIN32)
   WSANETWORKEVENTS occurred;
 
-  socket = (curl_socket_t)(intptr_t)NSMapGet(_socketForEvent, data);
+  socket = (curl_socket_t)(intptr_t)NSMapGet(internal->_socketForEvent, data);
   if (0 == WSAEnumNetworkEvents(socket, (WSAEVENT)data, &occurred))
     {
       if (occurred.lNetworkEvents & (FD_READ | FD_ACCEPT | FD_OOB))
@@ -863,11 +894,11 @@ static NSURLSession * sharedSession = nil;
     action = CURL_CSELECT_IN;
 #endif
 
-  curl_multi_socket_action(_multiHandle, socket, action, &_stillRunning);
+  curl_multi_socket_action(internal->_multiHandle, socket, action, &internal->_stillRunning);
   [self _checkForCompletion];
 
-  /* When _stillRunning reaches zero, all transfers are complete/done */
-  if (_stillRunning <= 0)
+  /* When internal->_stillRunning reaches zero, all transfers are complete/done */
+  if (internal->_stillRunning <= 0)
     {
       [self _suspendTimer];
     }
@@ -892,7 +923,7 @@ static NSURLSession * sharedSession = nil;
    * Remove the associated easy handle and release the task if the transfer is
    * done. This completes the life-cycle of a task added to NSURLSession.
    */
-  while ((msg = curl_multi_info_read(_multiHandle, &msgs_left)))
+  while ((msg = curl_multi_info_read(internal->_multiHandle, &msgs_left)))
     {
       if (msg->msg == CURLMSG_DONE)
         {
@@ -962,19 +993,19 @@ static NSURLSession * sharedSession = nil;
     }
 } /* _checkForCompletion */
 
-/* Adds task to _tasks and updates the delegate */
+/* Adds task to internal->_tasks and updates the delegate */
 - (void) _didCreateTask: (NSURLSessionTask *)task
 {
   [self _performSelectorOnWorkThread: @selector(_workAddTask:)
 			      target: self
 			  withObject: task];
 
-  if ([_delegate respondsToSelector: @selector(URLSession:didCreateTask:)])
+  if ([internal->_delegate respondsToSelector: @selector(URLSession:didCreateTask:)])
     {
       NSInvocation	*inv;
       NSURLSession	*session = self;
 
-      inv = GSURLSessionInvocation(_delegate,
+      inv = GSURLSessionInvocation(internal->_delegate,
 	@selector(URLSession:didCreateTask:));
       [inv setArgument: &session atIndex: 2];
       [inv setArgument: &task atIndex: 3];
@@ -984,14 +1015,14 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _workAddTask: (NSURLSessionTask *)task
 {
-  [_tasks addObject: task];
+  [internal->_tasks addObject: task];
 }
 
 #pragma mark - Public API
 
 - (void) finishTasksAndInvalidate
 {
-  if (_isSharedSession)
+  if (internal->_isSharedSession)
     {
       return;
     }
@@ -1003,12 +1034,12 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _workInvalidate
 {
-  _invalidated = YES;
+  internal->_invalidated = YES;
 }
 
 - (void) invalidateAndCancel
 {
-  if (_isSharedSession)
+  if (internal->_isSharedSession)
     {
       return;
     }
@@ -1020,10 +1051,10 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _workInvalidateAndCancel
 {
-  _invalidated = YES;
+  internal->_invalidated = YES;
 
   /* Cancel all tasks */
-  for (NSURLSessionTask * task in _tasks)
+  for (NSURLSessionTask * task in internal->_tasks)
     {
       [task cancel];
     }
@@ -1042,7 +1073,7 @@ static NSURLSession * sharedSession = nil;
   /* We use the session delegate by default. NSURLSessionTaskDelegate
    * is a purely optional protocol.
    */
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
 
   [task _setProperties: GSURLSessionUpdatesDelegate];
 
@@ -1075,7 +1106,7 @@ static NSURLSession * sharedSession = nil;
   /* We use the session delegate by default. NSURLSessionTaskDelegate
    * is a purely optional protocol.
    */
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
   [task
    _setProperties: GSURLSessionUpdatesDelegate | GSURLSessionHasInputStream];
   [task _setBodyStream: stream];
@@ -1100,7 +1131,7 @@ static NSURLSession * sharedSession = nil;
   /* We use the session delegate by default. NSURLSessionTaskDelegate
    * is a purely optional protocol.
    */
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
   [task _setProperties: GSURLSessionUpdatesDelegate];
   [task _enableUploadWithData: bodyData];
 
@@ -1123,7 +1154,7 @@ static NSURLSession * sharedSession = nil;
   /* We use the session delegate by default. NSURLSessionTaskDelegate
    * is a purely optional protocol.
    */
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
   [task
    _setProperties: GSURLSessionUpdatesDelegate | GSURLSessionHasInputStream];
   [task _enableUploadWithSize: 0];
@@ -1146,7 +1177,7 @@ static NSURLSession * sharedSession = nil;
   /* We use the session delegate by default. NSURLSessionTaskDelegate
    * is a purely optional protocol.
    */
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
   [task
    _setProperties: GSURLSessionWritesDataToFile | GSURLSessionUpdatesDelegate];
 
@@ -1181,7 +1212,7 @@ static NSURLSession * sharedSession = nil;
 
 - (void) _workCollectTasksInto: (NSMutableArray *)collected
 {
-  [collected addObjectsFromArray: _tasks];
+  [collected addObjectsFromArray: internal->_tasks];
 }
 
 - (GS_GENERIC_CLASS(NSArray, NSURLSessionTask *) *) tasksOfKind: (Class)aClass
@@ -1243,27 +1274,27 @@ static NSURLSession * sharedSession = nil;
 
 - (NSOperationQueue *) delegateQueue
 {
-  return _delegateQueue;
+  return internal->_delegateQueue;
 }
 
 - (id<NSURLSessionDelegate>) delegate
 {
-  return _delegate;
+  return internal->_delegate;
 }
 
 - (NSURLSessionConfiguration *) configuration
 {
-  return AUTORELEASE([_configuration copy]);
+  return AUTORELEASE([internal->_configuration copy]);
 }
 
 - (NSString *) sessionDescription
 {
-  return _sessionDescription;
+  return internal->_sessionDescription;
 }
 
 - (void) setSessionDescription: (NSString *)sessionDescription
 {
-  ASSIGNCOPY(_sessionDescription, sessionDescription);
+  ASSIGNCOPY(internal->_sessionDescription, sessionDescription);
 }
 
 - (void) dealloc
@@ -1274,37 +1305,38 @@ static NSURLSession * sharedSession = nil;
    * pending timer would retain self and defer dealloc, so none is pending
    * here.
    */
-  if (_workHelper != nil)
+  if (internal->_workHelper != nil)
     {
-      [_workHelper performSelector: @selector(stop)
-                          onThread: _workHelper->thread
+      [internal->_workHelper performSelector: @selector(stop)
+                          onThread: internal->_workHelper->thread
                         withObject: nil
                      waitUntilDone: YES];
-      while (![_workHelper->thread isFinished])
+      while (![internal->_workHelper->thread isFinished])
         {
           [NSThread sleepForTimeInterval: 0.001];
         }
-      RELEASE(_workHelper->thread);
-      RELEASE(_workHelper->port);
-      RELEASE(_workHelper);
+      RELEASE(internal->_workHelper->thread);
+      RELEASE(internal->_workHelper->port);
+      RELEASE(internal->_workHelper);
     }
 
-  RELEASE(_delegateQueue);
-  RELEASE(_delegate);
-  RELEASE(_configuration);
-  RELEASE(_tasks);
-  RELEASE(_certificateBlob);
-  RELEASE(_certificatePath);
+  RELEASE(internal->_delegateQueue);
+  RELEASE(internal->_delegate);
+  RELEASE(internal->_configuration);
+  RELEASE(internal->_tasks);
+  RELEASE(internal->_certificateBlob);
+  RELEASE(internal->_certificatePath);
 
-  curl_multi_cleanup(_multiHandle);
+  curl_multi_cleanup(internal->_multiHandle);
 
 #if	defined(_WIN32)
-  if (_socketForEvent != NULL)
+  if (internal->_socketForEvent != NULL)
     {
-      NSFreeMapTable(_socketForEvent);
+      NSFreeMapTable(internal->_socketForEvent);
     }
 #endif
 
+  GS_DESTROY_INTERNAL(NSURLSession);
   [super dealloc];
 }
 
@@ -1324,7 +1356,7 @@ NSURLSession (NSURLSessionAsynchronousConvenience)
   task = [[NSURLSessionDataTask alloc] initWithSession: self
                                                request: request
                                         taskIdentifier: identifier];
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
   [task _setCompletionHandler: completionHandler];
   [task _enableAutomaticRedirects: YES];
   [task _setProperties: GSURLSessionStoresDataInMemory |
@@ -1358,7 +1390,7 @@ NSURLSession (NSURLSessionAsynchronousConvenience)
   task = [[NSURLSessionUploadTask alloc] initWithSession: self
                                                  request: request
                                           taskIdentifier: identifier];
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
 
   [task _setProperties: GSURLSessionStoresDataInMemory
    | GSURLSessionHasInputStream |
@@ -1385,7 +1417,7 @@ NSURLSession (NSURLSessionAsynchronousConvenience)
   task = [[NSURLSessionUploadTask alloc] initWithSession: self
                                                  request: request
                                           taskIdentifier: identifier];
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
 
   [task _setProperties: GSURLSessionStoresDataInMemory |
    GSURLSessionHasCompletionHandler];
@@ -1411,7 +1443,7 @@ NSURLSession (NSURLSessionAsynchronousConvenience)
                                                    request: request
                                             taskIdentifier: identifier];
 
-  [task setDelegate: (id<NSURLSessionTaskDelegate>)_delegate];
+  [task setDelegate: (id<NSURLSessionTaskDelegate>)internal->_delegate];
 
   [task _setProperties: GSURLSessionWritesDataToFile |
    GSURLSessionHasCompletionHandler];

--- a/Source/NSURLSessionPrivate.h
+++ b/Source/NSURLSessionPrivate.h
@@ -37,10 +37,15 @@
 #import <winsock2.h>
 #endif
 
+@class NSInvocation;
+
 extern NSString * GS_NSURLSESSION_DEBUG_KEY;
 
-/* A block executed on the session work thread. */
-typedef void (^GSURLSessionWorkBlock)(void);
+/* Return an invocation for aSelector on target, with the target and the
+ * selector already set.  Arguments start at index 2.
+ */
+extern NSInvocation *
+GSURLSessionInvocation(id target, SEL aSelector);
 
 /* libcurl asks us to monitor a socket for reading, writing or both
  * (CURL_POLL_INOUT).  We integrate this with the NSRunLoop of the session
@@ -74,10 +79,27 @@ typedef NS_ENUM(NSInteger, GSURLSessionProperties)
 @interface
   NSURLSession(Private)
 
-/* Schedule a block to run on the session work thread's run loop.  If the
- * caller is already on the work thread the block runs immediately.
+/* Send aSelector to target on the session work thread's run loop.  If the
+ * caller is already on the work thread the message is sent immediately.
  */
-- (void)_performOnWorkThread: (GSURLSessionWorkBlock)block;
+- (void)_performSelectorOnWorkThread: (SEL)aSelector
+			      target: (id)target
+			  withObject: (id)anObject;
+
+- (void)_performSelectorOnWorkThread: (SEL)aSelector
+			      target: (id)target
+			  withObject: (id)anObject
+		       waitUntilDone: (BOOL)shouldWait;
+
+/* As above, for a message taking more than a single object argument.  The
+ * arguments are retained if the invocation has to be scheduled.
+ */
+- (void)_performInvocationOnWorkThread: (NSInvocation *)anInvocation;
+
+/* Add anInvocation to the delegate queue, retaining its arguments.  A no-op
+ * if the session has no delegate queue.
+ */
+- (void)_enqueueDelegateInvocation: (NSInvocation *)anInvocation;
 
 -(NSData *)_certificateBlob;
 -(NSString *)_certificatePath;

--- a/Source/NSURLSessionTask.m
+++ b/Source/NSURLSessionTask.m
@@ -32,6 +32,12 @@
 #import "common.h"
 #include <curl/curl.h>
 
+/* Where the compiler has no usable _Atomic, GSAtomic.h supplies a fallback
+ * for it along with gs_atomic_load and gs_atomic_store.  It has to be seen
+ * before the header expands the ivar macro below.
+ */
+#include "GSAtomic.h"
+
 @class NSProgress;
 @class NSURLSession;
 
@@ -52,7 +58,10 @@
   _Atomic(int64_t) _countOfBytesReceived; \
   _Atomic(int64_t) _countOfBytesExpectedToSend; \
   _Atomic(int64_t) _countOfBytesExpectedToReceive; \
-  _Atomic(double)  _priority; \
+  /* Advisory, and only ever read or written by -priority and -setPriority:, \
+   * both of which take a float. \
+   */ \
+  float _priority; \
  \
   NSString *_taskDescription; \
   NSError  *_error; \
@@ -1000,9 +1009,9 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
       internal->_taskIdentifier = identifier;
       internal->_taskData = [[NSMutableDictionary alloc] init];
-      internal->_shouldStopTransfer = NO;
-      internal->_redirectInProgress = NO;
-      internal->_awaitingResponseDisposition = NO;
+      gs_atomic_store(&internal->_shouldStopTransfer, NO);
+      gs_atomic_store(&internal->_redirectInProgress, NO);
+      gs_atomic_store(&internal->_awaitingResponseDisposition, NO);
       internal->_heldCompletionCode = -1;
       internal->_numberOfRedirects = -1;
       internal->_headerCallbackCount = 0;
@@ -1317,19 +1326,19 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) _setCountOfBytesSent: (int64_t)count
 {
-  internal->_countOfBytesSent = count;
+  gs_atomic_store(&internal->_countOfBytesSent, count);
 }
 - (void) _setCountOfBytesReceived: (int64_t)count
 {
-  internal->_countOfBytesReceived = count;
+  gs_atomic_store(&internal->_countOfBytesReceived, count);
 }
 - (void) _setCountOfBytesExpectedToSend: (int64_t)count
 {
-  internal->_countOfBytesExpectedToSend = count;
+  gs_atomic_store(&internal->_countOfBytesExpectedToSend, count);
 }
 - (void) _setCountOfBytesExpectedToReceive: (int64_t)count
 {
-  internal->_countOfBytesExpectedToReceive = count;
+  gs_atomic_store(&internal->_countOfBytesExpectedToReceive, count);
 }
 
 - (NSMutableDictionary *) _taskData
@@ -1353,32 +1362,32 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (BOOL) _shouldStopTransfer
 {
-  return internal->_shouldStopTransfer;
+  return gs_atomic_load(&internal->_shouldStopTransfer);
 }
 
 - (void) _setShouldStopTransfer: (BOOL)flag
 {
-  internal->_shouldStopTransfer = flag;
+  gs_atomic_store(&internal->_shouldStopTransfer, flag);
 }
 
 - (BOOL) _redirectInProgress
 {
-  return internal->_redirectInProgress;
+  return gs_atomic_load(&internal->_redirectInProgress);
 }
 
 - (void) _setRedirectInProgress: (BOOL)flag
 {
-  internal->_redirectInProgress = flag;
+  gs_atomic_store(&internal->_redirectInProgress, flag);
 }
 
 - (BOOL) _awaitingResponseDisposition
 {
-  return internal->_awaitingResponseDisposition;
+  return gs_atomic_load(&internal->_awaitingResponseDisposition);
 }
 
 - (void) _setAwaitingResponseDisposition: (BOOL)flag
 {
-  internal->_awaitingResponseDisposition = flag;
+  gs_atomic_store(&internal->_awaitingResponseDisposition, flag);
 }
 
 /* The delegate replies to URLSession:task:willRedirectToResponse:newRequest:
@@ -1739,7 +1748,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * TODO: Pause the easy handle put do not abort the full transfer!
        * .     What if the handle is currently paused?
        */
-      internal->_shouldStopTransfer = YES;
+      gs_atomic_store(&internal->_shouldStopTransfer, YES);
     }
 }
 - (void) resume
@@ -1778,14 +1787,14 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   /* Unpause the easy handle if previously paused */
   curl_easy_pause(internal->_easyHandle, CURLPAUSE_CONT);
 
-  internal->_shouldStopTransfer = YES;
+  gs_atomic_store(&internal->_shouldStopTransfer, YES);
   internal->_state = NSURLSessionTaskStateCanceling;
 
   /* If the task was awaiting a didReceiveResponse disposition its completion
    * was being held back; resolve that state so the cancellation is delivered
    * (as a cancellation, since internal->_shouldStopTransfer is set) rather than left
    * pending a disposition that will never arrive. */
-  internal->_awaitingResponseDisposition = NO;
+  gs_atomic_store(&internal->_awaitingResponseDisposition, NO);
   [internal->_session _deliverHeldCompletionForTask: self];
 }
 
@@ -1883,27 +1892,27 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (int64_t) countOfBytesClientExpectsToSend
 {
-  return internal->_countOfBytesClientExpectsToSend;
+  return gs_atomic_load(&internal->_countOfBytesClientExpectsToSend);
 }
 - (int64_t) countOfBytesClientExpectsToReceive
 {
-  return internal->_countOfBytesClientExpectsToReceive;
+  return gs_atomic_load(&internal->_countOfBytesClientExpectsToReceive);
 }
 - (int64_t) countOfBytesSent
 {
-  return internal->_countOfBytesSent;
+  return gs_atomic_load(&internal->_countOfBytesSent);
 }
 - (int64_t) countOfBytesReceived
 {
-  return internal->_countOfBytesReceived;
+  return gs_atomic_load(&internal->_countOfBytesReceived);
 }
 - (int64_t) countOfBytesExpectedToSend
 {
-  return internal->_countOfBytesExpectedToSend;
+  return gs_atomic_load(&internal->_countOfBytesExpectedToSend);
 }
 - (int64_t) countOfBytesExpectedToReceive
 {
-  return internal->_countOfBytesExpectedToReceive;
+  return gs_atomic_load(&internal->_countOfBytesExpectedToReceive);
 }
 
 - (NSString *) taskDescription

--- a/Source/NSURLSessionTask.m
+++ b/Source/NSURLSessionTask.m
@@ -1499,6 +1499,10 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
  * these are never reached (see +initialize).
  */
 #if __has_feature(blocks)
+/* These send the deprecated methods deliberately. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 - (void) _askDelegateToRedirectTo: (NSHTTPURLResponse *)response
 		       newRequest: (NSURLRequest *)request
 {
@@ -1536,6 +1540,8 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       [task resumeWithBodyStream: bodyStream];
     }];
 }
+
+#pragma GCC diagnostic pop
 #endif
 
 - (int) _heldCompletionCode

--- a/Source/NSURLSessionTask.m
+++ b/Source/NSURLSessionTask.m
@@ -45,6 +45,8 @@
 #import "Foundation/NSURLResponse.h"
 #import "Foundation/NSHTTPCookie.h"
 #import "Foundation/NSStream.h"
+#import "Foundation/NSInvocation.h"
+#import "Foundation/NSMethodSignature.h"
 
 #import "GNUstepBase/NSDebug+GNUstepBase.h"  /* For NSDebugMLLog */
 #import "GNUstepBase/NSObject+GNUstepBase.h" /* For -[NSObject notImplemented] */
@@ -73,6 +75,22 @@ static SEL didFinishDownloadingToURLSel;
 static SEL didWriteDataSel;
 static SEL needNewBodyStreamSel;
 static SEL willPerformHTTPRedirectionSel;
+
+/* The replacements for the three delegate methods which answer through a
+ * completion handler.  A delegate implementing one of these is sent it
+ * instead, and replies by messaging the task.
+ */
+static SEL taskNeedsNewBodyStreamSel;
+static SEL willRedirectSel;
+static SEL didReceiveResponseNoHandlerSel;
+
+/* A deprecated selector is (SEL)0 where the compiler has no blocks. */
+static inline BOOL
+respondsToDeprecated(id delegate, SEL aSelector)
+{
+  return ((SEL)0 != aSelector && [delegate respondsToSelector: aSelector])
+    ? YES : NO;
+}
 
 static NSString *taskTransferDataKey = @"transferData";
 static NSString *taskTemporaryFileLocationKey = @"tempFileLocation";
@@ -515,8 +533,12 @@ header_callback(char *ptr, size_t size, size_t nitems, void *userdata)
                 statusCode,
                 redirectURL);
 
-              if ([delegate respondsToSelector: willPerformHTTPRedirectionSel])
+              if ([delegate respondsToSelector: willRedirectSel]
+		|| respondsToDeprecated(delegate,
+		  willPerformHTTPRedirectionSel))
                 {
+                  NSInvocation	*inv;
+
                   NSDebugLLog(
                     GS_NSURLSESSION_DEBUG_KEY,
                     @"task=%@ ask delegate for redirection "
@@ -530,68 +552,24 @@ header_callback(char *ptr, size_t size, size_t nitems, void *userdata)
                    * until the delegate resolves the redirect. */
                   [task _setRedirectInProgress: YES];
 
-                  [[session delegateQueue] addOperationWithBlock:^{
-                     void (^completionHandler)(NSURLRequest *) = ^(
-                       NSURLRequest *userRequest) {
-                       /* Changes are performed on the work thread */
-                       [session _performOnWorkThread: ^{
-                           if (NULL == userRequest)
-                           {
-                             /* The delegate refused the redirect.  Remove the
-                              * intercepted transfer (whose completion was held
-                              * back) and deliver a cancellation for it. */
-                             [task _setRedirectInProgress: NO];
-                             [session _cancelTaskFromDelegate: task];
-                             NSDebugLLog(
-                               GS_NSURLSESSION_DEBUG_KEY,
-                               @"task=%@ willPerformHTTPRedirection "
-                               @"completionHandler called with nil "
-                               @"request",
-                               task);
-                           }
-                           else
-                           {
-                             NSString	*newURLString;
-
-                             newURLString = [[userRequest URL] absoluteString];
-
-                             NSDebugLLog(
-                               GS_NSURLSESSION_DEBUG_KEY,
-                               @"task=%@ willPerformHTTPRedirection "
-                               @"delegate completionHandler called "
-                               @"with new URL %@",
-                               task,
-                               newURLString);
-
-                             /* Remove handle for reconfiguration */
-                             [session _removeHandle: handle];
-
-                             /* Reset statistics */
-                             [task _setCountOfBytesReceived: 0];
-                             [task _setCountOfBytesSent: 0];
-                             [task _setCountOfBytesExpectedToReceive: 0];
-                             [task _setCountOfBytesExpectedToSend: 0];
-
-                             [task _setCurrentRequest: userRequest];
-
-                             /* Update URL in easy handle */
-                             curl_easy_setopt(
-                               handle,
-                               CURLOPT_URL,
-                               [newURLString UTF8String]);
-                             curl_easy_pause(handle, CURLPAUSE_CONT);
-
-                             [session _addHandle: handle];
-                           }
-                         }];
-                     };
-
-                     [delegate URLSession: session
-                                            task: task
-                      willPerformHTTPRedirection: response
-                                      newRequest: newRequest
-                               completionHandler: completionHandler];
-                   }];
+                  if ([delegate respondsToSelector: willRedirectSel])
+                    {
+                      inv = GSURLSessionInvocation(delegate, willRedirectSel);
+                      [inv setArgument: &session atIndex: 2];
+                      [inv setArgument: &task atIndex: 3];
+                      [inv setArgument: &response atIndex: 4];
+                      [inv setArgument: &newRequest atIndex: 5];
+                    }
+                  else
+                    {
+                      /* The delegate only has the deprecated method, which
+                       * answers through a block.  Ask the task to send it. */
+                      inv = GSURLSessionInvocation(task,
+			@selector(_askDelegateToRedirectTo:newRequest:));
+                      [inv setArgument: &response atIndex: 2];
+                      [inv setArgument: &newRequest atIndex: 3];
+                    }
+                  [session _enqueueDelegateInvocation: inv];
 
                   [headerFields removeAllObjects];
                   return size * nitems;
@@ -663,44 +641,35 @@ header_callback(char *ptr, size_t size, size_t nitems, void *userdata)
        */
       if ([task _properties] & GSURLSessionUpdatesDelegate
 	&& [task isKindOfClass: dataTaskClass]
-	&& [delegate respondsToSelector: didReceiveResponseSel])
+	&& ([delegate respondsToSelector: didReceiveResponseNoHandlerSel]
+	  || respondsToDeprecated(delegate, didReceiveResponseSel)))
         {
-          /* Pause until the completion handler is called.  libcurl may report
-           * the buffered response as complete before the delegate answers, so
-           * hold that completion back (see -_checkForCompletion) until we know
-           * the disposition. */
+          NSInvocation	*inv;
+
+          /* Pause until the delegate answers.  libcurl may report the
+           * buffered response as complete before that happens, so hold that
+           * completion back (see -_checkForCompletion) until we know the
+           * disposition. */
           [task _setAwaitingResponseDisposition: YES];
           curl_easy_pause(handle, CURLPAUSE_ALL);
 
-          [[session delegateQueue] addOperationWithBlock:^{
-             [delegate URLSession: session
-                         dataTask: (NSURLSessionDataTask *)task
-               didReceiveResponse: response
-                completionHandler:^(
-                NSURLSessionResponseDisposition disposition) {
-                /* FIXME: Implement NSURLSessionResponseBecomeDownload */
-                if (disposition == NSURLSessionResponseCancel)
-		  {
-		    [task _setShouldStopTransfer: YES];
-		    [session _performOnWorkThread: ^{
-			/* Deliver a cancellation (any held completion is
-			 * discarded in favour of it). */
-			[task _setAwaitingResponseDisposition: NO];
-			[session _cancelTaskFromDelegate: task];
-		      }];
-		  }
-                else
-		  {
-		    [session _performOnWorkThread: ^{
-			[task _setAwaitingResponseDisposition: NO];
-			/* Unpause to flush the buffered body, then deliver any
-			 * completion that was held while awaiting the delegate. */
-			curl_easy_pause(handle, CURLPAUSE_CONT);
-			[session _deliverHeldCompletionForTask: task];
-		      }];
-		  }
-              }];
-           }];
+          if ([delegate respondsToSelector: didReceiveResponseNoHandlerSel])
+            {
+              inv = GSURLSessionInvocation(delegate,
+		didReceiveResponseNoHandlerSel);
+              [inv setArgument: &session atIndex: 2];
+              [inv setArgument: &task atIndex: 3];
+              [inv setArgument: &response atIndex: 4];
+            }
+          else
+            {
+              /* The delegate only has the deprecated method, which answers
+               * through a block.  Ask the task to send it. */
+              inv = GSURLSessionInvocation(task,
+		@selector(_askDelegateAboutResponse:));
+              [inv setArgument: &response atIndex: 2];
+            }
+          [session _enqueueDelegateInvocation: inv];
         }
     }
 
@@ -731,18 +700,26 @@ read_callback(char *buffer, size_t size, size_t nitems, void *userdata)
         @"task=%@ requesting new body stream from delegate",
         task);
 
-      if ([delegate respondsToSelector: needNewBodyStreamSel])
+      if ([delegate respondsToSelector: taskNeedsNewBodyStreamSel]
+	|| respondsToDeprecated(delegate, needNewBodyStreamSel))
         {
-          [[[task _session] delegateQueue] addOperationWithBlock:^{
-             [delegate URLSession: session
-                             task: task
-                needNewBodyStream:^(NSInputStream *bodyStream) {
-                /* Add input stream to task data */
-                [taskData setObject: bodyStream forKey: taskInputStreamKey];
-                /* Continue with the transfer */
-                curl_easy_pause([task _easyHandle], CURLPAUSE_CONT);
-              }];
-           }];
+          NSInvocation	*inv;
+
+          if ([delegate respondsToSelector: taskNeedsNewBodyStreamSel])
+            {
+              inv = GSURLSessionInvocation(delegate,
+		taskNeedsNewBodyStreamSel);
+              [inv setArgument: &session atIndex: 2];
+              [inv setArgument: &task atIndex: 3];
+            }
+          else
+            {
+              /* The delegate only has the deprecated method, which answers
+               * through a block.  Ask the task to send it. */
+              inv = GSURLSessionInvocation(task,
+		@selector(_askDelegateForNewBodyStream));
+            }
+          [session _enqueueDelegateInvocation: inv];
 
           return CURL_READFUNC_PAUSE;
         }
@@ -751,7 +728,7 @@ read_callback(char *buffer, size_t size, size_t nitems, void *userdata)
           NSDebugLLog(
             GS_NSURLSESSION_DEBUG_KEY,
             @"task=%@ no input stream was given and delegate does "
-            @"not respond to URLSession:task:needNewBodyStream:",
+            @"not respond to URLSession:taskNeedsNewBodyStream:",
             task);
 
           return CURL_READFUNC_ABORT;
@@ -842,11 +819,13 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       if ([task isKindOfClass: dataTaskClass] &&
           [delegate respondsToSelector: didReceiveDataSel])
         {
-          [[session delegateQueue] addOperationWithBlock:^{
-             [delegate URLSession: session
-                         dataTask: (NSURLSessionDataTask *)task
-                   didReceiveData: dataFragment];
-           }];
+          NSInvocation		*inv;
+
+          inv = GSURLSessionInvocation(delegate, didReceiveDataSel);
+          [inv setArgument: &session atIndex: 2];
+          [inv setArgument: &task atIndex: 3];
+          [inv setArgument: &dataFragment atIndex: 4];
+          [session _enqueueDelegateInvocation: inv];
         }
 
       /* Notify delegate about the download process */
@@ -857,6 +836,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
           int64_t bytesWritten;
           int64_t totalBytesWritten;
           int64_t totalBytesExpectedToReceive;
+          NSInvocation		*inv;
 
           downloadTask = (NSURLSessionDownloadTask *)task;
           bytesWritten = [dataFragment length];
@@ -867,13 +847,13 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
           totalBytesExpectedToReceive =
             [downloadTask countOfBytesExpectedToReceive];
 
-          [[session delegateQueue] addOperationWithBlock:^{
-             [delegate URLSession: session
-                           downloadTask: downloadTask
-                           didWriteData: bytesWritten
-                      totalBytesWritten: totalBytesWritten
-              totalBytesExpectedToWrite: totalBytesExpectedToReceive];
-           }];
+          inv = GSURLSessionInvocation(delegate, didWriteDataSel);
+          [inv setArgument: &session atIndex: 2];
+          [inv setArgument: &downloadTask atIndex: 3];
+          [inv setArgument: &bytesWritten atIndex: 4];
+          [inv setArgument: &totalBytesWritten atIndex: 5];
+          [inv setArgument: &totalBytesExpectedToReceive atIndex: 6];
+          [session _enqueueDelegateInvocation: inv];
         }
     }
 
@@ -924,17 +904,31 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   dataTaskClass = [NSURLSessionDataTask class];
   downloadTaskClass = [NSURLSessionDownloadTask class];
   didReceiveDataSel = @selector(URLSession:dataTask:didReceiveData:);
-  didReceiveResponseSel =
-    @selector(URLSession:dataTask:didReceiveResponse:completionHandler:);
   didCompleteWithErrorSel = @selector(URLSession:task:didCompleteWithError:);
   didFinishDownloadingToURLSel =
     @selector(URLSession:downloadTask:didFinishDownloadingToURL:);
   didWriteDataSel = @selector
     (URLSession:
      downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:);
+  taskNeedsNewBodyStreamSel = @selector(URLSession:taskNeedsNewBodyStream:);
+  willRedirectSel = @selector
+    (URLSession:task:willRedirectToResponse:newRequest:);
+  didReceiveResponseNoHandlerSel =
+    @selector(URLSession:dataTask:didReceiveResponse:);
+
+  /* The deprecated delegate methods answer through a completion handler, so
+   * they are only usable where the compiler can build one to pass. */
+#if __has_feature(blocks)
+  didReceiveResponseSel =
+    @selector(URLSession:dataTask:didReceiveResponse:completionHandler:);
   needNewBodyStreamSel = @selector(URLSession:task:needNewBodyStream:);
   willPerformHTTPRedirectionSel = @selector
     (URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:);
+#else
+  didReceiveResponseSel = (SEL)0;
+  needNewBodyStreamSel = (SEL)0;
+  willPerformHTTPRedirectionSel = (SEL)0;
+#endif
 }
 
 - (instancetype) initWithSession: (NSURLSession *)session
@@ -1151,7 +1145,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       if (nil != storage && [configuration HTTPShouldSetCookies])
         {
           NSDictionary			*cookieHeaders;
-          NSArray<NSHTTPCookie*>	*cookies;
+          GS_GENERIC_CLASS(NSArray, NSHTTPCookie *)	*cookies;
 
           /* No headers were set */
           if (nil == requestHeaders)
@@ -1240,9 +1234,14 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) _setVerbose: (BOOL)flag
 {
-  [_session _performOnWorkThread: ^{
-    curl_easy_setopt(_easyHandle, CURLOPT_VERBOSE, flag ? 1L : 0L);
-  }];
+  [_session _performSelectorOnWorkThread: @selector(_workSetVerbose:)
+				  target: self
+			      withObject: [NSNumber numberWithBool: flag]];
+}
+
+- (void) _workSetVerbose: (NSNumber *)flag
+{
+  curl_easy_setopt(_easyHandle, CURLOPT_VERBOSE, [flag boolValue] ? 1L : 0L);
 }
 
 - (void) _setBodyStream: (NSInputStream *)stream
@@ -1333,6 +1332,154 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   _awaitingResponseDisposition = flag;
 }
+
+/* The delegate replies to URLSession:task:willRedirectToResponse:newRequest:
+ * here.  A nil request refuses the redirect. */
+- (void) resumeWithRedirectRequest: (NSURLRequest *)request
+{
+  [_session _performSelectorOnWorkThread:
+    @selector(_workResumeWithRedirectRequest:)
+				  target: self
+			      withObject: request];
+}
+
+- (void) _workResumeWithRedirectRequest: (NSURLRequest *)userRequest
+{
+  if (nil == userRequest)
+    {
+      /* The delegate refused the redirect.  Remove the intercepted transfer
+       * (whose completion was held back) and deliver a cancellation for it. */
+      [self _setRedirectInProgress: NO];
+      [_session _cancelTaskFromDelegate: self];
+      NSDebugLLog(
+	GS_NSURLSESSION_DEBUG_KEY,
+	@"task=%@ redirect refused by the delegate",
+	self);
+    }
+  else
+    {
+      NSString	*newURLString = [[userRequest URL] absoluteString];
+
+      NSDebugLLog(
+	GS_NSURLSESSION_DEBUG_KEY,
+	@"task=%@ redirect accepted by the delegate with new URL %@",
+	self,
+	newURLString);
+
+      /* Remove handle for reconfiguration */
+      [_session _removeHandle: _easyHandle];
+
+      /* Reset statistics */
+      [self _setCountOfBytesReceived: 0];
+      [self _setCountOfBytesSent: 0];
+      [self _setCountOfBytesExpectedToReceive: 0];
+      [self _setCountOfBytesExpectedToSend: 0];
+
+      [self _setCurrentRequest: userRequest];
+
+      /* Update URL in easy handle */
+      curl_easy_setopt(_easyHandle, CURLOPT_URL, [newURLString UTF8String]);
+      curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+
+      [_session _addHandle: _easyHandle];
+    }
+}
+
+/* The delegate replies to URLSession:dataTask:didReceiveResponse: here. */
+- (void) resumeWithResponseDisposition:
+  (NSURLSessionResponseDisposition)disposition
+{
+  /* FIXME: Implement NSURLSessionResponseBecomeDownload */
+  if (NSURLSessionResponseCancel == disposition)
+    {
+      [self _setShouldStopTransfer: YES];
+      [_session _performSelectorOnWorkThread:
+	@selector(_workCancelForResponseDisposition)
+				      target: self
+				  withObject: nil];
+    }
+  else
+    {
+      [_session _performSelectorOnWorkThread:
+	@selector(_workContinueForResponseDisposition)
+				      target: self
+				  withObject: nil];
+    }
+}
+
+- (void) _workCancelForResponseDisposition
+{
+  /* Deliver a cancellation (any held completion is discarded in favour
+   * of it). */
+  [self _setAwaitingResponseDisposition: NO];
+  [_session _cancelTaskFromDelegate: self];
+}
+
+- (void) _workContinueForResponseDisposition
+{
+  [self _setAwaitingResponseDisposition: NO];
+  /* Unpause to flush the buffered body, then deliver any completion that was
+   * held while awaiting the delegate. */
+  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+  [_session _deliverHeldCompletionForTask: self];
+}
+
+/* The delegate replies to URLSession:taskNeedsNewBodyStream: here. */
+- (void) resumeWithBodyStream: (NSInputStream *)bodyStream
+{
+  if (nil != bodyStream)
+    {
+      [_taskData setObject: bodyStream forKey: taskInputStreamKey];
+    }
+  /* Continue with the transfer */
+  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+}
+
+/* The three bridges below send the deprecated form of a delegate method,
+ * the one which answers through a completion handler, and forward the answer
+ * to the reply method above.  A compiler without blocks cannot build a
+ * handler to pass, so the deprecated selectors are not looked for there and
+ * these are never reached (see +initialize).
+ */
+#if __has_feature(blocks)
+- (void) _askDelegateToRedirectTo: (NSHTTPURLResponse *)response
+		       newRequest: (NSURLRequest *)request
+{
+  NSURLSessionTask	*task = self;
+
+  [[self delegate] URLSession: _session
+			 task: self
+   willPerformHTTPRedirection: response
+		   newRequest: request
+	    completionHandler: ^(NSURLRequest *userRequest) {
+      [task resumeWithRedirectRequest: userRequest];
+    }];
+}
+
+- (void) _askDelegateAboutResponse: (NSURLResponse *)response
+{
+  NSURLSessionDataTask	*task = (NSURLSessionDataTask *)self;
+
+  [(id<NSURLSessionDataDelegate>)[self delegate]
+		   URLSession: _session
+		     dataTask: task
+	   didReceiveResponse: response
+	    completionHandler: ^(NSURLSessionResponseDisposition disposition) {
+      [task resumeWithResponseDisposition: disposition];
+    }];
+}
+
+- (void) _askDelegateForNewBodyStream
+{
+  NSURLSessionTask	*task = self;
+
+  [[self delegate] URLSession: _session
+			 task: self
+	    needNewBodyStream: ^(NSInputStream *bodyStream) {
+      [task resumeWithBodyStream: bodyStream];
+    }];
+}
+#endif
 
 - (int) _heldCompletionCode
 {
@@ -1434,22 +1581,28 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 	&& [_delegate respondsToSelector: didFinishDownloadingToURLSel])
         {
           NSURL	*url = [_taskData objectForKey: taskTemporaryFileLocationKey];
+          NSInvocation		*inv;
+          NSURLSession		*session = _session;
+          NSURLSessionTask	*task = self;
 
-          [[_session delegateQueue] addOperationWithBlock:^{
-             [(id<NSURLSessionDownloadDelegate>) _delegate
-              URLSession: _session
-                           downloadTask: (NSURLSessionDownloadTask *)self
-              didFinishDownloadingToURL: url];
-           }];
+          inv = GSURLSessionInvocation(_delegate, didFinishDownloadingToURLSel);
+          [inv setArgument: &session atIndex: 2];
+          [inv setArgument: &task atIndex: 3];
+          [inv setArgument: &url atIndex: 4];
+          [_session _enqueueDelegateInvocation: inv];
         }
 
       if ([_delegate respondsToSelector: didCompleteWithErrorSel])
         {
-          [[_session delegateQueue] addOperationWithBlock:^{
-             [_delegate URLSession: _session
-                              task: self
-              didCompleteWithError: error];
-           }];
+          NSInvocation		*inv;
+          NSURLSession		*session = _session;
+          NSURLSessionTask	*task = self;
+
+          inv = GSURLSessionInvocation(_delegate, didCompleteWithErrorSel);
+          [inv setArgument: &session atIndex: 2];
+          [inv setArgument: &task atIndex: 3];
+          [inv setArgument: &error atIndex: 4];
+          [_session _enqueueDelegateInvocation: inv];
         }
     }
 
@@ -1463,12 +1616,18 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       NSURLSessionDataTask	*dataTask;
       NSData 			*data;
 
+      NSInvocation	*inv;
+      NSURLResponse	*response = _response;
+
       dataTask = (NSURLSessionDataTask *)self;
       data = [_taskData objectForKey: taskTransferDataKey];
 
-      [[_session delegateQueue] addOperationWithBlock:^{
-         [dataTask _completionHandler](data, _response, error);
-       }];
+      inv = GSURLSessionInvocation(dataTask,
+	@selector(_callDataCompletionHandlerWithData:response:error:));
+      [inv setArgument: &data atIndex: 2];
+      [inv setArgument: &response atIndex: 3];
+      [inv setArgument: &error atIndex: 4];
+      [_session _enqueueDelegateInvocation: inv];
     }
   else if ((_properties & GSURLSessionWritesDataToFile)
     && (_properties & GSURLSessionHasCompletionHandler)
@@ -1477,12 +1636,18 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       NSURLSessionDownloadTask	*downloadTask;
       NSURL			*tempFile;
 
+      NSInvocation	*inv;
+      NSURLResponse	*response = _response;
+
       downloadTask = (NSURLSessionDownloadTask *)self;
       tempFile = [_taskData objectForKey: taskTemporaryFileLocationKey];
 
-      [[_session delegateQueue] addOperationWithBlock:^{
-         [downloadTask _completionHandler](tempFile, _response, error);
-       }];
+      inv = GSURLSessionInvocation(downloadTask,
+	@selector(_callDownloadCompletionHandlerWithURL:response:error:));
+      [inv setArgument: &tempFile atIndex: 2];
+      [inv setArgument: &response atIndex: 3];
+      [inv setArgument: &error atIndex: 4];
+      [_session _enqueueDelegateInvocation: inv];
     }
 
   RELEASE(_session);
@@ -1555,20 +1720,25 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
    * URLSession:task:didCompleteWithError: is called after receiving
    * CURLMSG_DONE in -[NSURLSessionTask _checkForCompletion].
    */
-  [_session _performOnWorkThread: ^{
-    /* Unpause the easy handle if previously paused */
-    curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+  [_session _performSelectorOnWorkThread: @selector(_workCancel)
+				  target: self
+			      withObject: nil];
+}
 
-    _shouldStopTransfer = YES;
-    _state = NSURLSessionTaskStateCanceling;
+- (void) _workCancel
+{
+  /* Unpause the easy handle if previously paused */
+  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
 
-    /* If the task was awaiting a didReceiveResponse disposition its completion
-     * was being held back; resolve that state so the cancellation is delivered
-     * (as a cancellation, since _shouldStopTransfer is set) rather than left
-     * pending a disposition that will never arrive. */
-    _awaitingResponseDisposition = NO;
-    [_session _deliverHeldCompletionForTask: self];
-  }];
+  _shouldStopTransfer = YES;
+  _state = NSURLSessionTaskStateCanceling;
+
+  /* If the task was awaiting a didReceiveResponse disposition its completion
+   * was being held back; resolve that state so the cancellation is delivered
+   * (as a cancellation, since _shouldStopTransfer is set) rather than left
+   * pending a disposition that will never arrive. */
+  _awaitingResponseDisposition = NO;
+  [_session _deliverHeldCompletionForTask: self];
 }
 
 - (float) priority
@@ -1733,12 +1903,29 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) _setCompletionHandler: (GSNSURLSessionDataCompletionHandler)handler
 {
-  _completionHandler = _Block_copy(handler);
+  if (NULL != handler)
+    {
+      _completionHandler = Block_copy(handler);
+    }
+}
+
+/* Called on the delegate queue so that the handler runs there, as it did
+ * when the queue was given a block to run. */
+- (void) _callDataCompletionHandlerWithData: (NSData *)data
+				   response: (NSURLResponse *)response
+				      error: (NSError *)error
+{
+  GSNSURLSessionDataCompletionHandler	handler = [self _completionHandler];
+
+  CALL_BLOCK(handler, data, response, error);
 }
 
 - (void) dealloc
 {
-  _Block_release(_completionHandler);
+  if (NULL != _completionHandler)
+    {
+      Block_release(_completionHandler);
+    }
   [super dealloc];
 }
 
@@ -1756,7 +1943,21 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) _setCompletionHandler: (GSNSURLSessionDownloadCompletionHandler)handler
 {
-  _completionHandler = _Block_copy(handler);
+  if (NULL != handler)
+    {
+      _completionHandler = Block_copy(handler);
+    }
+}
+
+/* Called on the delegate queue so that the handler runs there, as it did
+ * when the queue was given a block to run. */
+- (void) _callDownloadCompletionHandlerWithURL: (NSURL *)location
+				      response: (NSURLResponse *)response
+					 error: (NSError *)error
+{
+  GSNSURLSessionDownloadCompletionHandler handler = [self _completionHandler];
+
+  CALL_BLOCK(handler, location, response, error);
 }
 
 - (int64_t) _countOfBytesWritten
@@ -1771,7 +1972,10 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) dealloc
 {
-  _Block_release(_completionHandler);
+  if (NULL != _completionHandler)
+    {
+      Block_release(_completionHandler);
+    }
   [super dealloc];
 }
 

--- a/Source/NSURLSessionTask.m
+++ b/Source/NSURLSessionTask.m
@@ -26,6 +26,72 @@
  * Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
  */
 
+/* The ivar macro below is expanded by Foundation/NSURLSession.h, so the
+ * types it names have to be known before that header is imported.
+ */
+#import "common.h"
+#include <curl/curl.h>
+
+@class NSProgress;
+@class NSURLSession;
+
+#define	GS_NSURLSessionTask_IVARS \
+  NSUInteger    _taskIdentifier; \
+  NSURLRequest *_originalRequest; \
+ \
+  id<NSURLSessionTaskDelegate> _delegate; \
+  NSURLSessionTaskState        _state; \
+  NSURLRequest                *_currentRequest; \
+  NSURLResponse               *_response; \
+  NSProgress                  *_progress; \
+  NSDate                      *_earliestBeginDate; \
+ \
+  _Atomic(int64_t) _countOfBytesClientExpectsToSend; \
+  _Atomic(int64_t) _countOfBytesClientExpectsToReceive; \
+  _Atomic(int64_t) _countOfBytesSent; \
+  _Atomic(int64_t) _countOfBytesReceived; \
+  _Atomic(int64_t) _countOfBytesExpectedToSend; \
+  _Atomic(int64_t) _countOfBytesExpectedToReceive; \
+  _Atomic(double)  _priority; \
+ \
+  NSString *_taskDescription; \
+  NSError  *_error; \
+ \
+  _Atomic(BOOL) _shouldStopTransfer; \
+ \
+  /* Set while an intercepted 3xx response is being handled by the delegate \
+   * (or automatically) and the easy handle is about to be re-added for the \
+   * new location.  libcurl reports the intercepted response as a completed \
+   * transfer (CURLOPT_FOLLOWLOCATION is off), so completion must be held \
+   * back until the redirect resolves; otherwise the task delivers a spurious \
+   * early -URLSession:task:didCompleteWithError:. */ \
+  _Atomic(BOOL) _redirectInProgress; \
+ \
+  /* Set while the handle is paused waiting for the delegate to answer \
+   * -URLSession:dataTask:didReceiveResponse:completionHandler:.  libcurl can \
+   * report the already-buffered response as complete before the delegate \
+   * answers, so completion is held back (its CURLcode saved in \
+   * _heldCompletionCode) and delivered once the disposition is known. */ \
+  _Atomic(BOOL) _awaitingResponseDisposition; \
+  /* The CURLcode of a completion held back while _awaitingResponseDisposition, \
+   * or -1 if none has been held. */ \
+  int _heldCompletionCode; \
+ \
+  /* Opaque value for storing task specific properties */ \
+  NSInteger _properties; \
+ \
+  /* Internal task data */ \
+  NSMutableDictionary	*_taskData; \
+  NSInteger 		_numberOfRedirects; \
+  NSInteger 		_headerCallbackCount; \
+  NSUInteger 		_suspendCount; \
+ \
+  char _curlErrorBuffer[CURL_ERROR_SIZE]; \
+  struct curl_slist	*_headerList; \
+ \
+  CURL			*_easyHandle; \
+  NSURLSession 		*_session;
+
 #import "NSURLSessionPrivate.h"
 #include <curl/curl.h>
 #import "NSURLSessionTaskPrivate.h"
@@ -52,6 +118,11 @@
 #import "GNUstepBase/NSObject+GNUstepBase.h" /* For -[NSObject notImplemented] */
 
 #import "GSURLPrivate.h"
+
+#define	GSInternal	NSURLSessionTaskInternal
+#include "GSInternal.h"
+GS_PRIVATE_INTERNAL(NSURLSessionTask)
+
 
 @interface _GSInsensitiveDictionary : NSDictionary
 @end
@@ -862,42 +933,6 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 } /* write_callback */
 
 @implementation NSURLSessionTask
-{
-  _Atomic(BOOL) _shouldStopTransfer;
-
-  /* Set while an intercepted 3xx response is being handled by the delegate
-   * (or automatically) and the easy handle is about to be re-added for the
-   * new location.  libcurl reports the intercepted response as a completed
-   * transfer (CURLOPT_FOLLOWLOCATION is off), so completion must be held
-   * back until the redirect resolves; otherwise the task delivers a spurious
-   * early -URLSession:task:didCompleteWithError:. */
-  _Atomic(BOOL) _redirectInProgress;
-
-  /* Set while the handle is paused waiting for the delegate to answer
-   * -URLSession:dataTask:didReceiveResponse:completionHandler:.  libcurl can
-   * report the already-buffered response as complete before the delegate
-   * answers, so completion is held back (its CURLcode saved in
-   * _heldCompletionCode) and delivered once the disposition is known. */
-  _Atomic(BOOL) _awaitingResponseDisposition;
-  /* The CURLcode of a completion held back while _awaitingResponseDisposition,
-   * or -1 if none has been held. */
-  int _heldCompletionCode;
-
-  /* Opaque value for storing task specific properties */
-  NSInteger _properties;
-
-  /* Internal task data */
-  NSMutableDictionary	*_taskData;
-  NSInteger 		_numberOfRedirects;
-  NSInteger 		_headerCallbackCount;
-  NSUInteger 		_suspendCount;
-
-  char _curlErrorBuffer[CURL_ERROR_SIZE];
-  struct curl_slist	*_headerList;
-
-  CURL			*_easyHandle;
-  NSURLSession 		*_session;
-}
 
 + (void) initialize
 {
@@ -931,6 +966,17 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 #endif
 }
 
+/* -copyWithZone: makes its copy with a plain -init, so the internal ivars
+ * have to be created here too. */
+- (instancetype) init
+{
+  if (nil != (self = [super init]))
+    {
+      GS_CREATE_INTERNAL(NSURLSessionTask);
+    }
+  return self;
+}
+
 - (instancetype) initWithSession: (NSURLSession *)session
   request: (NSURLRequest *)request
   taskIdentifier: (NSUInteger)identifier
@@ -950,22 +996,24 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       _GSMutableInsensitiveDictionary	*requestHeaders = nil;
       _GSMutableInsensitiveDictionary	*configHeaders = nil;
 
-      _taskIdentifier = identifier;
-      _taskData = [[NSMutableDictionary alloc] init];
-      _shouldStopTransfer = NO;
-      _redirectInProgress = NO;
-      _awaitingResponseDisposition = NO;
-      _heldCompletionCode = -1;
-      _numberOfRedirects = -1;
-      _headerCallbackCount = 0;
+      GS_CREATE_INTERNAL(NSURLSessionTask);
 
-      ASSIGNCOPY(_originalRequest, request);
-      ASSIGNCOPY(_currentRequest, request);
+      internal->_taskIdentifier = identifier;
+      internal->_taskData = [[NSMutableDictionary alloc] init];
+      internal->_shouldStopTransfer = NO;
+      internal->_redirectInProgress = NO;
+      internal->_awaitingResponseDisposition = NO;
+      internal->_heldCompletionCode = -1;
+      internal->_numberOfRedirects = -1;
+      internal->_headerCallbackCount = 0;
 
-      httpMethod = [[_originalRequest HTTPMethod] lowercaseString];
-      url = [_originalRequest URL];
+      ASSIGNCOPY(internal->_originalRequest, request);
+      ASSIGNCOPY(internal->_currentRequest, request);
+
+      httpMethod = [[internal->_originalRequest HTTPMethod] lowercaseString];
+      url = [internal->_originalRequest URL];
       requestHeaders
-	= AUTORELEASE([[_originalRequest _insensitiveHeaders] mutableCopy]);
+	= AUTORELEASE([[internal->_originalRequest _insensitiveHeaders] mutableCopy]);
       configuration = [session configuration];
 
       /* Only retain the session once the -resume method is called
@@ -973,60 +1021,60 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * task has completed. This avoids a retain loop causing
        * session and tasks to be leaked.
        */
-      _session = session;
-      _suspendCount = 0;
-      _state = NSURLSessionTaskStateSuspended;
-      _curlErrorBuffer[0] = '\0';
+      internal->_session = session;
+      internal->_suspendCount = 0;
+      internal->_state = NSURLSessionTaskStateSuspended;
+      internal->_curlErrorBuffer[0] = '\0';
 
       /* Configure initial task data
        */
-      [_taskData setObject: [NSMutableDictionary dictionary]
+      [internal->_taskData setObject: [NSMutableDictionary dictionary]
 		    forKey: @"headers"];
 
       /* Easy Handle Configuration
        */
-      _easyHandle = curl_easy_init();
+      internal->_easyHandle = curl_easy_init();
 
       if ([@"head" isEqualToString: httpMethod])
         {
-          curl_easy_setopt(_easyHandle, CURLOPT_NOBODY, 1L);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_NOBODY, 1L);
         }
 
       /* Setup upload data if a HTTPBody or HTTPBodyStream is present in the
        * URLRequest
        */
-      if (nil != [_originalRequest HTTPBody])
+      if (nil != [internal->_originalRequest HTTPBody])
         {
-          NSData	*body = [_originalRequest HTTPBody];
+          NSData	*body = [internal->_originalRequest HTTPBody];
 
-          curl_easy_setopt(_easyHandle, CURLOPT_UPLOAD, 1L);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_UPLOAD, 1L);
           curl_easy_setopt(
-            _easyHandle,
+            internal->_easyHandle,
             CURLOPT_POSTFIELDSIZE_LARGE,
             (curl_off_t)[body length]);
-          curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDS, [body bytes]);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDS, [body bytes]);
         }
-      else if (nil != [_originalRequest HTTPBodyStream])
+      else if (nil != [internal->_originalRequest HTTPBodyStream])
         {
-          NSInputStream	*stream = [_originalRequest HTTPBodyStream];
+          NSInputStream	*stream = [internal->_originalRequest HTTPBodyStream];
 
-          [_taskData setObject: stream forKey: taskInputStreamKey];
+          [internal->_taskData setObject: stream forKey: taskInputStreamKey];
 
-          curl_easy_setopt(_easyHandle, CURLOPT_READFUNCTION, read_callback);
-          curl_easy_setopt(_easyHandle, CURLOPT_READDATA, self);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_READFUNCTION, read_callback);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_READDATA, self);
 
-          curl_easy_setopt(_easyHandle, CURLOPT_UPLOAD, 1L);
-          curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDSIZE, (curl_off_t)-1);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_UPLOAD, 1L);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDSIZE, (curl_off_t)-1);
         }
 
       /* Configure HTTP method and URL */
       curl_easy_setopt(
-        _easyHandle,
+        internal->_easyHandle,
         CURLOPT_CUSTOMREQUEST,
-        [[_originalRequest HTTPMethod] UTF8String]);
+        [[internal->_originalRequest HTTPMethod] UTF8String]);
 
       curl_easy_setopt(
-        _easyHandle,
+        internal->_easyHandle,
         CURLOPT_URL,
         [[url absoluteString] UTF8String]);
 
@@ -1037,8 +1085,8 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * This is directly mapped to -[NSURLSessionDataDelegate
        * URLSession:dataTask:didReceiveData:].
        */
-      curl_easy_setopt(_easyHandle, CURLOPT_WRITEFUNCTION, write_callback);
-      curl_easy_setopt(_easyHandle, CURLOPT_WRITEDATA, self);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_WRITEFUNCTION, write_callback);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_WRITEDATA, self);
 
       /* Retrieve the header data
        *
@@ -1046,26 +1094,26 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * - URLSession:dataTask:didReceiveResponse:completionHandler:
        * we can notify it about the header response.
        */
-      curl_easy_setopt(_easyHandle, CURLOPT_HEADERFUNCTION, header_callback);
-      curl_easy_setopt(_easyHandle, CURLOPT_HEADERDATA, self);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_HEADERFUNCTION, header_callback);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_HEADERDATA, self);
 
-      curl_easy_setopt(_easyHandle, CURLOPT_ERRORBUFFER, _curlErrorBuffer);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_ERRORBUFFER, internal->_curlErrorBuffer);
 
       /* The task is now associated with the easy handle and can be accessed
        * using curl_easy_getinfo with CURLINFO_PRIVATE.
        */
-      curl_easy_setopt(_easyHandle, CURLOPT_PRIVATE, self);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_PRIVATE, self);
 
       /* Disable libcurl's build-in progress reporting */
-      curl_easy_setopt(_easyHandle, CURLOPT_NOPROGRESS, 0L);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_NOPROGRESS, 0L);
       /* Specifiy our own progress function with the user pointer being the
        * current object
        */
       curl_easy_setopt(
-        _easyHandle,
+        internal->_easyHandle,
         CURLOPT_XFERINFOFUNCTION,
         progress_callback);
-      curl_easy_setopt(_easyHandle, CURLOPT_XFERINFODATA, self);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_XFERINFODATA, self);
 
       /* Do not Follow redirects by default
        *
@@ -1073,17 +1121,17 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * for redirect notification. We have implemented our own redirection
        * system in header_callback.
        */
-      curl_easy_setopt(_easyHandle, CURLOPT_FOLLOWLOCATION, 0L);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_FOLLOWLOCATION, 0L);
 
       /* Set timeout in connect phase */
       curl_easy_setopt(
-        _easyHandle,
+        internal->_easyHandle,
         CURLOPT_CONNECTTIMEOUT,
         (NSInteger)[request timeoutInterval]);
 
       /* Set overall timeout */
       curl_easy_setopt(
-        _easyHandle,
+        internal->_easyHandle,
         CURLOPT_TIMEOUT,
         (curl_off_t)[configuration timeoutIntervalForResource]);
 
@@ -1092,14 +1140,14 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
         {
 #if CURL_AT_LEAST_VERSION(7, 66, 0)
           curl_easy_setopt(
-            _easyHandle,
+            internal->_easyHandle,
             CURLOPT_HTTP_VERSION,
             CURL_HTTP_VERSION_3);
 #endif
         }
 
       /* Configure the custom CA certificate if available */
-      if (nil != (certificateBlob = [_session _certificateBlob]))
+      if (nil != (certificateBlob = [internal->_session _certificateBlob]))
         {
 // CURLOPT_CAINFO_BLOB was added in 7.77.0
 #if LIBCURL_VERSION_NUM >= 0x074D00
@@ -1111,12 +1159,12 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
            * end of transfer. */
           blob.flags = CURL_BLOB_NOCOPY;
 
-          curl_easy_setopt(_easyHandle, CURLOPT_CAINFO_BLOB, &blob);
+          curl_easy_setopt(internal->_easyHandle, CURLOPT_CAINFO_BLOB, &blob);
 #else
           curl_easy_setopt(
-            _easyHandle,
+            internal->_easyHandle,
             CURLOPT_CAINFO,
-            [_session _certificatePath]);
+            [internal->_session _certificatePath]);
 #endif
         }
 
@@ -1172,9 +1220,9 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
           headerLine = [NSString stringWithFormat: @"%@: %@", key, object];
 
           /* We have removed all reserved headers in NSURLRequest */
-          _headerList = curl_slist_append(_headerList, [headerLine UTF8String]);
+          internal->_headerList = curl_slist_append(internal->_headerList, [headerLine UTF8String]);
         }
-      curl_easy_setopt(_easyHandle, CURLOPT_HTTPHEADER, _headerList);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_HTTPHEADER, internal->_headerList);
       LEAVE_POOL
     }
 
@@ -1183,161 +1231,161 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) _enableAutomaticRedirects: (BOOL)flag
 {
-  curl_easy_setopt(_easyHandle, CURLOPT_FOLLOWLOCATION, flag ? 1L : 0L);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_FOLLOWLOCATION, flag ? 1L : 0L);
 }
 
 - (void) _enableUploadWithData: (NSData *)data
 {
-  curl_easy_setopt(_easyHandle, CURLOPT_UPLOAD, 1L);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_UPLOAD, 1L);
 
   /* Retain data */
-  [_taskData setObject: data forKey: taskUploadData];
+  [internal->_taskData setObject: data forKey: taskUploadData];
 
-  curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDSIZE_LARGE,
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDSIZE_LARGE,
     (curl_off_t)[data length]);
-  curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDS, [data bytes]);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDS, [data bytes]);
 
   /* The method is overwritten by CURLOPT_UPLOAD. Change it back. */
   curl_easy_setopt(
-    _easyHandle,
+    internal->_easyHandle,
     CURLOPT_CUSTOMREQUEST,
-    [[_originalRequest HTTPMethod] UTF8String]);
+    [[internal->_originalRequest HTTPMethod] UTF8String]);
 }
 
 - (void) _enableUploadWithSize: (NSInteger)size
 {
-  curl_easy_setopt(_easyHandle, CURLOPT_UPLOAD, 1L);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_UPLOAD, 1L);
 
-  curl_easy_setopt(_easyHandle, CURLOPT_READFUNCTION, read_callback);
-  curl_easy_setopt(_easyHandle, CURLOPT_READDATA, self);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_READFUNCTION, read_callback);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_READDATA, self);
 
   if (size > 0)
     {
-      curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDSIZE_LARGE, size);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDSIZE_LARGE, size);
     }
   else
     {
-      curl_easy_setopt(_easyHandle, CURLOPT_POSTFIELDSIZE, (curl_off_t)-1);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_POSTFIELDSIZE, (curl_off_t)-1);
     }
 
   /* The method is overwritten by CURLOPT_UPLOAD. Change it back. */
   curl_easy_setopt(
-    _easyHandle,
+    internal->_easyHandle,
     CURLOPT_CUSTOMREQUEST,
-    [[_originalRequest HTTPMethod] UTF8String]);
+    [[internal->_originalRequest HTTPMethod] UTF8String]);
 } /* _enableUploadWithSize */
 
 - (CURL *) _easyHandle
 {
-  return _easyHandle;
+  return internal->_easyHandle;
 }
 
 - (void) _setVerbose: (BOOL)flag
 {
-  [_session _performSelectorOnWorkThread: @selector(_workSetVerbose:)
+  [internal->_session _performSelectorOnWorkThread: @selector(_workSetVerbose:)
 				  target: self
 			      withObject: [NSNumber numberWithBool: flag]];
 }
 
 - (void) _workSetVerbose: (NSNumber *)flag
 {
-  curl_easy_setopt(_easyHandle, CURLOPT_VERBOSE, [flag boolValue] ? 1L : 0L);
+  curl_easy_setopt(internal->_easyHandle, CURLOPT_VERBOSE, [flag boolValue] ? 1L : 0L);
 }
 
 - (void) _setBodyStream: (NSInputStream *)stream
 {
-  [_taskData setObject: stream forKey: taskInputStreamKey];
+  [internal->_taskData setObject: stream forKey: taskInputStreamKey];
 }
 
 - (void) _setOriginalRequest: (NSURLRequest *)request
 {
-  ASSIGNCOPY(_originalRequest, request);
+  ASSIGNCOPY(internal->_originalRequest, request);
 }
 
 - (void) _setCurrentRequest: (NSURLRequest *)request
 {
-  ASSIGNCOPY(_currentRequest, request);
+  ASSIGNCOPY(internal->_currentRequest, request);
 }
 
 - (void) _setResponse: (NSURLResponse *)response
 {
-  NSURLResponse	*oldResponse = _response;
+  NSURLResponse	*oldResponse = internal->_response;
 
-  _response = [response retain];
+  internal->_response = [response retain];
   [oldResponse release];
 }
 
 - (void) _setCountOfBytesSent: (int64_t)count
 {
-  _countOfBytesSent = count;
+  internal->_countOfBytesSent = count;
 }
 - (void) _setCountOfBytesReceived: (int64_t)count
 {
-  _countOfBytesReceived = count;
+  internal->_countOfBytesReceived = count;
 }
 - (void) _setCountOfBytesExpectedToSend: (int64_t)count
 {
-  _countOfBytesExpectedToSend = count;
+  internal->_countOfBytesExpectedToSend = count;
 }
 - (void) _setCountOfBytesExpectedToReceive: (int64_t)count
 {
-  _countOfBytesExpectedToReceive = count;
+  internal->_countOfBytesExpectedToReceive = count;
 }
 
 - (NSMutableDictionary *) _taskData
 {
-  return _taskData;
+  return internal->_taskData;
 }
 
 - (NSInteger) _properties
 {
-  return _properties;
+  return internal->_properties;
 }
 - (void) _setProperties: (NSInteger)properties
 {
-  _properties = properties;
+  internal->_properties = properties;
 }
 
 - (NSURLSession *) _session
 {
-  return _session;
+  return internal->_session;
 }
 
 - (BOOL) _shouldStopTransfer
 {
-  return _shouldStopTransfer;
+  return internal->_shouldStopTransfer;
 }
 
 - (void) _setShouldStopTransfer: (BOOL)flag
 {
-  _shouldStopTransfer = flag;
+  internal->_shouldStopTransfer = flag;
 }
 
 - (BOOL) _redirectInProgress
 {
-  return _redirectInProgress;
+  return internal->_redirectInProgress;
 }
 
 - (void) _setRedirectInProgress: (BOOL)flag
 {
-  _redirectInProgress = flag;
+  internal->_redirectInProgress = flag;
 }
 
 - (BOOL) _awaitingResponseDisposition
 {
-  return _awaitingResponseDisposition;
+  return internal->_awaitingResponseDisposition;
 }
 
 - (void) _setAwaitingResponseDisposition: (BOOL)flag
 {
-  _awaitingResponseDisposition = flag;
+  internal->_awaitingResponseDisposition = flag;
 }
 
 /* The delegate replies to URLSession:task:willRedirectToResponse:newRequest:
  * here.  A nil request refuses the redirect. */
 - (void) resumeWithRedirectRequest: (NSURLRequest *)request
 {
-  [_session _performSelectorOnWorkThread:
+  [internal->_session _performSelectorOnWorkThread:
     @selector(_workResumeWithRedirectRequest:)
 				  target: self
 			      withObject: request];
@@ -1350,7 +1398,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       /* The delegate refused the redirect.  Remove the intercepted transfer
        * (whose completion was held back) and deliver a cancellation for it. */
       [self _setRedirectInProgress: NO];
-      [_session _cancelTaskFromDelegate: self];
+      [internal->_session _cancelTaskFromDelegate: self];
       NSDebugLLog(
 	GS_NSURLSESSION_DEBUG_KEY,
 	@"task=%@ redirect refused by the delegate",
@@ -1367,7 +1415,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 	newURLString);
 
       /* Remove handle for reconfiguration */
-      [_session _removeHandle: _easyHandle];
+      [internal->_session _removeHandle: internal->_easyHandle];
 
       /* Reset statistics */
       [self _setCountOfBytesReceived: 0];
@@ -1378,10 +1426,10 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       [self _setCurrentRequest: userRequest];
 
       /* Update URL in easy handle */
-      curl_easy_setopt(_easyHandle, CURLOPT_URL, [newURLString UTF8String]);
-      curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+      curl_easy_setopt(internal->_easyHandle, CURLOPT_URL, [newURLString UTF8String]);
+      curl_easy_pause(internal->_easyHandle, CURLPAUSE_CONT);
 
-      [_session _addHandle: _easyHandle];
+      [internal->_session _addHandle: internal->_easyHandle];
     }
 }
 
@@ -1393,14 +1441,14 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   if (NSURLSessionResponseCancel == disposition)
     {
       [self _setShouldStopTransfer: YES];
-      [_session _performSelectorOnWorkThread:
+      [internal->_session _performSelectorOnWorkThread:
 	@selector(_workCancelForResponseDisposition)
 				      target: self
 				  withObject: nil];
     }
   else
     {
-      [_session _performSelectorOnWorkThread:
+      [internal->_session _performSelectorOnWorkThread:
 	@selector(_workContinueForResponseDisposition)
 				      target: self
 				  withObject: nil];
@@ -1412,7 +1460,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   /* Deliver a cancellation (any held completion is discarded in favour
    * of it). */
   [self _setAwaitingResponseDisposition: NO];
-  [_session _cancelTaskFromDelegate: self];
+  [internal->_session _cancelTaskFromDelegate: self];
 }
 
 - (void) _workContinueForResponseDisposition
@@ -1420,8 +1468,8 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   [self _setAwaitingResponseDisposition: NO];
   /* Unpause to flush the buffered body, then deliver any completion that was
    * held while awaiting the delegate. */
-  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
-  [_session _deliverHeldCompletionForTask: self];
+  curl_easy_pause(internal->_easyHandle, CURLPAUSE_CONT);
+  [internal->_session _deliverHeldCompletionForTask: self];
 }
 
 /* The delegate replies to URLSession:taskNeedsNewBodyStream: here. */
@@ -1429,10 +1477,10 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   if (nil != bodyStream)
     {
-      [_taskData setObject: bodyStream forKey: taskInputStreamKey];
+      [internal->_taskData setObject: bodyStream forKey: taskInputStreamKey];
     }
   /* Continue with the transfer */
-  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+  curl_easy_pause(internal->_easyHandle, CURLPAUSE_CONT);
 }
 
 /* The three bridges below send the deprecated form of a delegate method,
@@ -1447,7 +1495,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   NSURLSessionTask	*task = self;
 
-  [[self delegate] URLSession: _session
+  [[self delegate] URLSession: internal->_session
 			 task: self
    willPerformHTTPRedirection: response
 		   newRequest: request
@@ -1461,7 +1509,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   NSURLSessionDataTask	*task = (NSURLSessionDataTask *)self;
 
   [(id<NSURLSessionDataDelegate>)[self delegate]
-		   URLSession: _session
+		   URLSession: internal->_session
 		     dataTask: task
 	   didReceiveResponse: response
 	    completionHandler: ^(NSURLSessionResponseDisposition disposition) {
@@ -1473,7 +1521,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   NSURLSessionTask	*task = self;
 
-  [[self delegate] URLSession: _session
+  [[self delegate] URLSession: internal->_session
 			 task: self
 	    needNewBodyStream: ^(NSInputStream *bodyStream) {
       [task resumeWithBodyStream: bodyStream];
@@ -1483,30 +1531,30 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (int) _heldCompletionCode
 {
-  return _heldCompletionCode;
+  return internal->_heldCompletionCode;
 }
 
 - (void) _setHeldCompletionCode: (int)code
 {
-  _heldCompletionCode = code;
+  internal->_heldCompletionCode = code;
 }
 
 - (NSInteger) _numberOfRedirects
 {
-  return _numberOfRedirects;
+  return internal->_numberOfRedirects;
 }
 - (void) _setNumberOfRedirects: (NSInteger)redirects
 {
-  _numberOfRedirects = redirects;
+  internal->_numberOfRedirects = redirects;
 }
 
 - (NSInteger) _headerCallbackCount
 {
-  return _headerCallbackCount;
+  return internal->_headerCallbackCount;
 }
 - (void) _setHeaderCallbackCount: (NSInteger)count
 {
-  _headerCallbackCount = count;
+  internal->_headerCallbackCount = count;
 }
 
 /* Creates a temporary file and opens a file handle for writing */
@@ -1522,7 +1570,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   path = [path stringByAppendingPathComponent: [[NSUUID UUID] UUIDString]];
 
   url = [NSURL fileURLWithPath: path];
-  [_taskData setObject: url forKey: taskTemporaryFileLocationKey];
+  [internal->_taskData setObject: url forKey: taskTemporaryFileLocationKey];
 
   if (![mgr createFileAtPath: path contents: nil attributes: nil])
     {
@@ -1543,7 +1591,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
     }
 
   handle = [NSFileHandle fileHandleForWritingAtPath: path];
-  [_taskData setObject: handle forKey: taskTemporaryFileHandleKey];
+  [internal->_taskData setObject: handle forKey: taskTemporaryFileHandleKey];
 
   return handle;
 } /* _createTemporaryFileHandleWithError */
@@ -1562,95 +1610,95 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
       code = CURLE_ABORTED_BY_CALLBACK;
     }
 
-  error = errorForCURLcode(_easyHandle, code, _curlErrorBuffer);
+  error = errorForCURLcode(internal->_easyHandle, code, internal->_curlErrorBuffer);
 
-  if (_properties & GSURLSessionWritesDataToFile)
+  if (internal->_properties & GSURLSessionWritesDataToFile)
     {
       NSFileHandle	*handle;
 
       if (nil !=
-          (handle = [_taskData objectForKey: taskTemporaryFileHandleKey]))
+          (handle = [internal->_taskData objectForKey: taskTemporaryFileHandleKey]))
         {
           [handle closeFile];
         }
     }
 
-  if (_properties & GSURLSessionUpdatesDelegate)
+  if (internal->_properties & GSURLSessionUpdatesDelegate)
     {
-      if (_properties & GSURLSessionWritesDataToFile
-	&& [_delegate respondsToSelector: didFinishDownloadingToURLSel])
+      if (internal->_properties & GSURLSessionWritesDataToFile
+	&& [internal->_delegate respondsToSelector: didFinishDownloadingToURLSel])
         {
-          NSURL	*url = [_taskData objectForKey: taskTemporaryFileLocationKey];
+          NSURL	*url = [internal->_taskData objectForKey: taskTemporaryFileLocationKey];
           NSInvocation		*inv;
-          NSURLSession		*session = _session;
+          NSURLSession		*session = internal->_session;
           NSURLSessionTask	*task = self;
 
-          inv = GSURLSessionInvocation(_delegate, didFinishDownloadingToURLSel);
+          inv = GSURLSessionInvocation(internal->_delegate, didFinishDownloadingToURLSel);
           [inv setArgument: &session atIndex: 2];
           [inv setArgument: &task atIndex: 3];
           [inv setArgument: &url atIndex: 4];
-          [_session _enqueueDelegateInvocation: inv];
+          [internal->_session _enqueueDelegateInvocation: inv];
         }
 
-      if ([_delegate respondsToSelector: didCompleteWithErrorSel])
+      if ([internal->_delegate respondsToSelector: didCompleteWithErrorSel])
         {
           NSInvocation		*inv;
-          NSURLSession		*session = _session;
+          NSURLSession		*session = internal->_session;
           NSURLSessionTask	*task = self;
 
-          inv = GSURLSessionInvocation(_delegate, didCompleteWithErrorSel);
+          inv = GSURLSessionInvocation(internal->_delegate, didCompleteWithErrorSel);
           [inv setArgument: &session atIndex: 2];
           [inv setArgument: &task atIndex: 3];
           [inv setArgument: &error atIndex: 4];
-          [_session _enqueueDelegateInvocation: inv];
+          [internal->_session _enqueueDelegateInvocation: inv];
         }
     }
 
   /* NSURLSessionUploadTask is a subclass of a NSURLSessionDataTask with the
    * same completion handler signature. It thus follows the same code path.
    */
-  if ((_properties & GSURLSessionStoresDataInMemory)
-    && (_properties & GSURLSessionHasCompletionHandler)
+  if ((internal->_properties & GSURLSessionStoresDataInMemory)
+    && (internal->_properties & GSURLSessionHasCompletionHandler)
     && [self isKindOfClass: dataTaskClass])
     {
       NSURLSessionDataTask	*dataTask;
       NSData 			*data;
 
       NSInvocation	*inv;
-      NSURLResponse	*response = _response;
+      NSURLResponse	*response = internal->_response;
 
       dataTask = (NSURLSessionDataTask *)self;
-      data = [_taskData objectForKey: taskTransferDataKey];
+      data = [internal->_taskData objectForKey: taskTransferDataKey];
 
       inv = GSURLSessionInvocation(dataTask,
 	@selector(_callDataCompletionHandlerWithData:response:error:));
       [inv setArgument: &data atIndex: 2];
       [inv setArgument: &response atIndex: 3];
       [inv setArgument: &error atIndex: 4];
-      [_session _enqueueDelegateInvocation: inv];
+      [internal->_session _enqueueDelegateInvocation: inv];
     }
-  else if ((_properties & GSURLSessionWritesDataToFile)
-    && (_properties & GSURLSessionHasCompletionHandler)
+  else if ((internal->_properties & GSURLSessionWritesDataToFile)
+    && (internal->_properties & GSURLSessionHasCompletionHandler)
     && [self isKindOfClass: downloadTaskClass])
     {
       NSURLSessionDownloadTask	*downloadTask;
       NSURL			*tempFile;
 
       NSInvocation	*inv;
-      NSURLResponse	*response = _response;
+      NSURLResponse	*response = internal->_response;
 
       downloadTask = (NSURLSessionDownloadTask *)self;
-      tempFile = [_taskData objectForKey: taskTemporaryFileLocationKey];
+      tempFile = [internal->_taskData objectForKey: taskTemporaryFileLocationKey];
 
       inv = GSURLSessionInvocation(downloadTask,
 	@selector(_callDownloadCompletionHandlerWithURL:response:error:));
       [inv setArgument: &tempFile atIndex: 2];
       [inv setArgument: &response atIndex: 3];
       [inv setArgument: &error atIndex: 4];
-      [_session _enqueueDelegateInvocation: inv];
+      [internal->_session _enqueueDelegateInvocation: inv];
     }
 
-  RELEASE(_session);
+  RELEASE(internal->_session);
 } /* _transferFinishedWithCode */
 
 /* Called in header_callback */
@@ -1660,8 +1708,8 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   NSArray 			*cookies;
   NSURLSessionConfiguration 	*config;
 
-  config = [_session configuration];
-  url = [_currentRequest URL];
+  config = [internal->_session configuration];
+  url = [internal->_currentRequest URL];
 
   /* FIXME: Implement NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain */
   if (NSHTTPCookieAcceptPolicyNever != [config HTTPCookieAcceptPolicy]
@@ -1682,8 +1730,8 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (void) suspend
 {
-  _suspendCount += 1;
-  if (_suspendCount == 1)
+  internal->_suspendCount += 1;
+  if (internal->_suspendCount == 1)
     {
       /* If there is an active transfer associated with this task, it will be
        * aborted in the next libcurl progress_callback.
@@ -1691,26 +1739,26 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
        * TODO: Pause the easy handle put do not abort the full transfer!
        * .     What if the handle is currently paused?
        */
-      _shouldStopTransfer = YES;
+      internal->_shouldStopTransfer = YES;
     }
 }
 - (void) resume
 {
   /* Only resume a transfer if the task is not suspended and in suspended state
    */
-  if (_suspendCount == 0 && [self state] == NSURLSessionTaskStateSuspended)
+  if (internal->_suspendCount == 0 && [self state] == NSURLSessionTaskStateSuspended)
     {
       /*
        * Properly retain the session to keep a reference
        * to the task. This ensures correct API behaviour.
        */
-      RETAIN(_session);
+      RETAIN(internal->_session);
 
-      _state = NSURLSessionTaskStateRunning;
-      [_session _resumeTask: self];
+      internal->_state = NSURLSessionTaskStateRunning;
+      [internal->_session _resumeTask: self];
       return;
     }
-  _suspendCount -= 1;
+  internal->_suspendCount -= 1;
 }
 - (void) cancel
 {
@@ -1720,7 +1768,7 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
    * URLSession:task:didCompleteWithError: is called after receiving
    * CURLMSG_DONE in -[NSURLSessionTask _checkForCompletion].
    */
-  [_session _performSelectorOnWorkThread: @selector(_workCancel)
+  [internal->_session _performSelectorOnWorkThread: @selector(_workCancel)
 				  target: self
 			      withObject: nil];
 }
@@ -1728,26 +1776,26 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 - (void) _workCancel
 {
   /* Unpause the easy handle if previously paused */
-  curl_easy_pause(_easyHandle, CURLPAUSE_CONT);
+  curl_easy_pause(internal->_easyHandle, CURLPAUSE_CONT);
 
-  _shouldStopTransfer = YES;
-  _state = NSURLSessionTaskStateCanceling;
+  internal->_shouldStopTransfer = YES;
+  internal->_state = NSURLSessionTaskStateCanceling;
 
   /* If the task was awaiting a didReceiveResponse disposition its completion
    * was being held back; resolve that state so the cancellation is delivered
-   * (as a cancellation, since _shouldStopTransfer is set) rather than left
+   * (as a cancellation, since internal->_shouldStopTransfer is set) rather than left
    * pending a disposition that will never arrive. */
-  _awaitingResponseDisposition = NO;
-  [_session _deliverHeldCompletionForTask: self];
+  internal->_awaitingResponseDisposition = NO;
+  [internal->_session _deliverHeldCompletionForTask: self];
 }
 
 - (float) priority
 {
-  return _priority;
+  return internal->_priority;
 }
 - (void) setPriority: (float)priority
 {
-  _priority = priority;
+  internal->_priority = priority;
 }
 
 - (id) copyWithZone: (NSZone *)zone
@@ -1756,15 +1804,15 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
   if (copy)
     {
-      copy->_originalRequest = [_originalRequest copyWithZone: zone];
-      copy->_currentRequest = [_currentRequest copyWithZone: zone];
-      copy->_response = [_response copyWithZone: zone];
+      GSIVar(copy, _originalRequest) = [internal->_originalRequest copyWithZone: zone];
+      GSIVar(copy, _currentRequest) = [internal->_currentRequest copyWithZone: zone];
+      GSIVar(copy, _response) = [internal->_response copyWithZone: zone];
       /* FIXME: Seems like copyWithZone: is not implemented for NSProgress */
-      copy->_progress = [_progress copy];
-      copy->_earliestBeginDate = [_earliestBeginDate copyWithZone: zone];
-      copy->_taskDescription = [_taskDescription copyWithZone: zone];
-      copy->_taskData = [_taskData copyWithZone: zone];
-      copy->_easyHandle = curl_easy_duphandle(_easyHandle);
+      GSIVar(copy, _progress) = [internal->_progress copy];
+      GSIVar(copy, _earliestBeginDate) = [internal->_earliestBeginDate copyWithZone: zone];
+      GSIVar(copy, _taskDescription) = [internal->_taskDescription copyWithZone: zone];
+      GSIVar(copy, _taskData) = [internal->_taskData copyWithZone: zone];
+      GSIVar(copy, _easyHandle) = curl_easy_duphandle(internal->_easyHandle);
     }
 
   return copy;
@@ -1774,100 +1822,100 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 - (NSUInteger) taskIdentifier
 {
-  return _taskIdentifier;
+  return internal->_taskIdentifier;
 }
 
 - (NSURLRequest *) originalRequest
 {
-  return AUTORELEASE([_originalRequest copy]);
+  return AUTORELEASE([internal->_originalRequest copy]);
 }
 
 - (NSURLRequest *) currentRequest
 {
-  return AUTORELEASE([_currentRequest copy]);
+  return AUTORELEASE([internal->_currentRequest copy]);
 }
 
 - (NSURLResponse *) response
 {
-  return AUTORELEASE([_response copy]);
+  return AUTORELEASE([internal->_response copy]);
 }
 
 - (NSURLSessionTaskState) state
 {
-  return _state;
+  return internal->_state;
 }
 
 - (NSProgress *) progress
 {
-  return _progress;
+  return internal->_progress;
 }
 
 - (NSError *) error
 {
-  return _error;
+  return internal->_error;
 }
 
 - (id<NSURLSessionTaskDelegate>) delegate
 {
-  return _delegate;
+  return internal->_delegate;
 }
 
 - (void) setDelegate: (id<NSURLSessionTaskDelegate>)delegate
 {
-  id<NSURLSessionTaskDelegate> oldDelegate = _delegate;
+  id<NSURLSessionTaskDelegate> oldDelegate = internal->_delegate;
 
-  _delegate = RETAIN(delegate);
+  internal->_delegate = RETAIN(delegate);
   RELEASE(oldDelegate);
 }
 
 - (NSDate *) earliestBeginDate
 {
-  return _earliestBeginDate;
+  return internal->_earliestBeginDate;
 }
 
 - (void) setEarliestBeginDate: (NSDate *)date
 {
-  NSDate	*oldDate = _earliestBeginDate;
+  NSDate	*oldDate = internal->_earliestBeginDate;
 
-  _earliestBeginDate = RETAIN(date);
+  internal->_earliestBeginDate = RETAIN(date);
   RELEASE(oldDate);
 }
 
 - (int64_t) countOfBytesClientExpectsToSend
 {
-  return _countOfBytesClientExpectsToSend;
+  return internal->_countOfBytesClientExpectsToSend;
 }
 - (int64_t) countOfBytesClientExpectsToReceive
 {
-  return _countOfBytesClientExpectsToReceive;
+  return internal->_countOfBytesClientExpectsToReceive;
 }
 - (int64_t) countOfBytesSent
 {
-  return _countOfBytesSent;
+  return internal->_countOfBytesSent;
 }
 - (int64_t) countOfBytesReceived
 {
-  return _countOfBytesReceived;
+  return internal->_countOfBytesReceived;
 }
 - (int64_t) countOfBytesExpectedToSend
 {
-  return _countOfBytesExpectedToSend;
+  return internal->_countOfBytesExpectedToSend;
 }
 - (int64_t) countOfBytesExpectedToReceive
 {
-  return _countOfBytesExpectedToReceive;
+  return internal->_countOfBytesExpectedToReceive;
 }
 
 - (NSString *) taskDescription
 {
-  return _taskDescription;
+  return internal->_taskDescription;
 }
 
 - (void) setTaskDescription: (NSString *)description
 {
-  NSString	*oldDescription = _taskDescription;
+  NSString	*oldDescription = internal->_taskDescription;
 
-  _taskDescription = [description copy];
+  internal->_taskDescription = [description copy];
   RELEASE(oldDescription);
 }
 
@@ -1878,17 +1926,18 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
    *
    * It is save to release the curl handle here.
    */
-  curl_easy_cleanup(_easyHandle);
-  curl_slist_free_all(_headerList);
+  curl_easy_cleanup(internal->_easyHandle);
+  curl_slist_free_all(internal->_headerList);
 
-  RELEASE(_originalRequest);
-  RELEASE(_currentRequest);
-  RELEASE(_response);
-  RELEASE(_progress);
-  RELEASE(_earliestBeginDate);
-  RELEASE(_taskDescription);
-  RELEASE(_taskData);
+  RELEASE(internal->_originalRequest);
+  RELEASE(internal->_currentRequest);
+  RELEASE(internal->_response);
+  RELEASE(internal->_progress);
+  RELEASE(internal->_earliestBeginDate);
+  RELEASE(internal->_taskDescription);
+  RELEASE(internal->_taskData);
 
+  GS_DESTROY_INTERNAL(NSURLSessionTask);
   [super dealloc];
 }
 

--- a/Tests/base/NSURLSession/GNUmakefile.preamble
+++ b/Tests/base/NSURLSession/GNUmakefile.preamble
@@ -1,8 +1,9 @@
 
 include $(GNUSTEP_MAKEFILES)/common.make
 
-ifeq ($(the_library_combo), ng-gnu-gnu)
+# The tests load the server from this bundle, so it is needed wherever they
+# run.  It was built only for ng-gnu-gnu while NSURLSession was built only
+# there; the tests abort loading it otherwise.
 SUBPROJECTS = Helpers
 
 include $(GNUSTEP_MAKEFILES)/aggregate.make
-endif

--- a/Tests/base/NSURLSession/Helpers/GNUmakefile
+++ b/Tests/base/NSURLSession/Helpers/GNUmakefile
@@ -10,7 +10,8 @@ ifeq ($(GNUSTEP_TARGET_OS), windows)
 HTTPServer_OBJC_LIBS += -lws2_32
 endif
 
-HTTPServer_OBJCFLAGS += -fobjc-arc
+# Built with the same memory rules as the rest of the tests, so that a
+# compiler without -fobjc-arc can build it too.
 #HTTPServer_RESOURCE_FILES += key.pem certificate.pem
 HTTPServer_PRINCIPAL_CLASS = HTTPServer
 

--- a/Tests/base/NSURLSession/Helpers/HTTPServer.h
+++ b/Tests/base/NSURLSession/Helpers/HTTPServer.h
@@ -2,29 +2,62 @@
 #import <Foundation/NSObject.h>
 #import <Foundation/NSURLRequest.h>
 #import <Foundation/NSURLResponse.h>
+#import <GNUstepBase/GSBlocks.h>
 
-typedef NSData * (^RequestHandlerBlock)(NSURLRequest *);
+DEFINE_BLOCK_TYPE(RequestHandlerBlock, NSData *, NSURLRequest *);
 
 @interface Route : NSObject
+{
+  NSString	     *_method;
+  NSURL		     *_url;
+  NSData	     *_response;
+  id		      _target;
+  SEL		      _selector;
+  RequestHandlerBlock _block;
+}
 
+/* A route answering with a fixed response. */
++ (instancetype)routeWithURL:(NSURL *)url
+                      method:(NSString *)method
+                    response:(NSData *)response;
+
+/* A route answering by sending aSelector to target with the request.  The
+ * method returns the response data.
+ */
++ (instancetype)routeWithURL:(NSURL *)url
+                      method:(NSString *)method
+                      target:(id)target
+                    selector:(SEL)aSelector;
+
+/* As above, for a caller whose compiler has blocks. */
 + (instancetype)routeWithURL:(NSURL *)url
                       method:(NSString *)method
                      handler:(RequestHandlerBlock)block;
 
 - (NSString *)method;
 - (NSURL *)url;
-- (RequestHandlerBlock)block;
+
+/* The response for request, from whichever of the three the route was
+ * created with.
+ */
+- (NSData *)responseForRequest:(NSURLRequest *)request;
 
 - (BOOL)acceptsURL:(NSURL *)url method:(NSString *)method;
 
 @end
 
 @interface HTTPServer : NSObject
-- initWithPort:(NSInteger)port routes:(NSArray<Route *> *)routes;
+{
+  volatile BOOL	    _stop;
+  int		    _socket;
+  NSInteger	    _port;
+  NSArray	   *_routes;
+}
+- initWithPort:(NSInteger)port routes:(NSArray *)routes;
 
 - (NSInteger)port;
 - (void)resume;
 - (void)suspend;
 
-- (void)setRoutes:(NSArray<Route *> *)routes;
+- (void)setRoutes:(NSArray *)routes;
 @end

--- a/Tests/base/NSURLSession/Helpers/HTTPServer.m
+++ b/Tests/base/NSURLSession/Helpers/HTTPServer.m
@@ -15,50 +15,30 @@
 
 #import "HTTPServer.h"
 
-@interface
-NSString (ServerAdditions)
-- (void)enumerateLinesUsingBlock2:
-  (void (^)(NSString *line, NSUInteger lineEndIndex, BOOL *stop))block;
-@end
-
-@implementation
-NSString (ServerAdditions)
-
-- (void)enumerateLinesUsingBlock2:
-  (void (^)(NSString *line, NSUInteger lineEndIndex, BOOL *stop))block
+/* Line by line over an ASCII header block.  On entry *lineStart is where to
+ * read from; on return it is where the next line begins and *lineEnd is the
+ * index just past the line just read.  Returns nil once the string is spent.
+ */
+static NSString *
+nextLine(NSString *s, NSUInteger *lineStart, NSUInteger *lineEnd)
 {
-  NSUInteger length;
-  NSUInteger lineStart, lineEnd, contentsEnd;
-  NSRange    currentLocationRange;
-  BOOL       stop;
+  NSUInteger	start = *lineStart;
+  NSUInteger	end = 0;
+  NSUInteger	contentsEnd = 0;
 
-  length = [self length];
-  lineStart = lineEnd = contentsEnd = 0;
-  stop = NO;
-
-  // Enumerate through the string line by line
-  while (lineStart < length && !stop)
+  if (start >= [s length])
     {
-      NSString *line;
-      NSRange   lineRange;
-
-      currentLocationRange = NSMakeRange(lineStart, 0);
-      [self getLineStart:&lineStart
-                     end:&lineEnd
-             contentsEnd:&contentsEnd
-                forRange:currentLocationRange];
-
-      lineRange = NSMakeRange(lineStart, contentsEnd - lineStart);
-      line = [self substringWithRange:lineRange];
-
-      // Execute the block
-      block(line, lineEnd, &stop);
-
-      // Move to the next line
-      lineStart = lineEnd;
+      return nil;
     }
+  [s getLineStart:&start
+              end:&end
+      contentsEnd:&contentsEnd
+         forRange:NSMakeRange(start, 0)];
+
+  *lineStart = end;
+  *lineEnd = end;
+  return [s substringWithRange:NSMakeRange(start, contentsEnd - start)];
 }
-@end
 
 /* The length of the complete request at the front of data, or 0 when the whole
  * request has not arrived yet.  A request is complete once the blank line
@@ -68,10 +48,13 @@ NSString (ServerAdditions)
 static NSUInteger
 requestLength(NSData *data)
 {
-  NSRange            end;
-  NSString          *headers;
-  NSUInteger         bodyStart;
-  __block NSUInteger contentLength = 0;
+  NSRange     end;
+  NSString   *headers;
+  NSString   *line;
+  NSUInteger  bodyStart;
+  NSUInteger  contentLength = 0;
+  NSUInteger  lineStart = 0;
+  NSUInteger  lineEnd = 0;
 
   end = [data rangeOfData:[NSData dataWithBytes:"\r\n\r\n" length:4]
                   options:0
@@ -85,19 +68,20 @@ requestLength(NSData *data)
   headers = [[NSString alloc]
     initWithData:[data subdataWithRange:NSMakeRange(0, end.location)]
         encoding:NSASCIIStringEncoding];
-  [headers enumerateLinesUsingBlock2:^(NSString  *line,
-                                       NSUInteger lineEndIndex, BOOL *stop) {
-    NSRange range = [line rangeOfString:@":"];
 
-    if (NSNotFound != range.location
-        && NSOrderedSame == [[line substringToIndex:range.location]
-             caseInsensitiveCompare:@"Content-Length"])
-      {
-        contentLength = (NSUInteger)
-          [[line substringFromIndex:range.location + 1] integerValue];
-        *stop = YES;
-      }
-  }];
+  while ((line = nextLine(headers, &lineStart, &lineEnd)) != nil)
+    {
+      NSRange range = [line rangeOfString:@":"];
+
+      if (NSNotFound != range.location
+          && NSOrderedSame == [[line substringToIndex:range.location]
+               caseInsensitiveCompare:@"Content-Length"])
+        {
+          contentLength = (NSUInteger)
+            [[line substringFromIndex:range.location + 1] integerValue];
+          break;
+        }
+    }
 
   if ([data length] < bodyStart + contentLength)
     {
@@ -108,21 +92,41 @@ requestLength(NSData *data)
 }
 
 @implementation Route
+
++ (instancetype)routeWithURL:(NSURL *)url
+                      method:(NSString *)method
+                    response:(NSData *)response
 {
-  NSString           *_method;
-  NSURL              *_url;
-  RequestHandlerBlock _block;
+  Route *r = [[Route alloc] initWithURL:url method:method];
+
+  r->_response = response;
+  return r;
 }
+
++ (instancetype)routeWithURL:(NSURL *)url
+                      method:(NSString *)method
+                      target:(id)target
+                    selector:(SEL)aSelector
+{
+  Route *r = [[Route alloc] initWithURL:url method:method];
+
+  r->_target = target;
+  r->_selector = aSelector;
+  return r;
+}
+
 + (instancetype)routeWithURL:(NSURL *)url
                       method:(NSString *)method
                      handler:(RequestHandlerBlock)block
 {
-  return [[Route alloc] initWithURL:url method:method handler:block];
+  Route *r = [[Route alloc] initWithURL:url method:method];
+
+  r->_block = block;
+  return r;
 }
 
 - (instancetype)initWithURL:(NSURL *)url
                      method:(NSString *)method
-                    handler:(RequestHandlerBlock)block
 {
   self = [super init];
 
@@ -130,7 +134,6 @@ requestLength(NSData *data)
     {
       _url = url;
       _method = method;
-      _block = block;
     }
 
   return self;
@@ -144,9 +147,18 @@ requestLength(NSData *data)
 {
   return _url;
 }
-- (RequestHandlerBlock)block
+
+- (NSData *)responseForRequest:(NSURLRequest *)request
 {
-  return _block;
+  if (nil != _target)
+    {
+      return [_target performSelector:_selector withObject:request];
+    }
+  if (nil != _response)
+    {
+      return _response;
+    }
+  return CALL_BLOCK_RET(_block, NSData *, request);
 }
 
 - (BOOL)acceptsURL:(NSURL *)url method:(NSString *)method
@@ -157,14 +169,8 @@ requestLength(NSData *data)
 @end /* Route */
 
 @implementation HTTPServer
-{
-  _Atomic(BOOL)     _stop;
-  int               _socket;
-  NSInteger         _port;
-  NSArray<Route *> *_routes;
-}
 
-- initWithPort:(NSInteger)port routes:(NSArray<Route *> *)routes
+- initWithPort:(NSInteger)port routes:(NSArray *)routes
 {
   self = [super init];
   if (!self)
@@ -335,9 +341,13 @@ requestLength(NSData *data)
   NSScanner *scanner;
   Route     *selectedRoute = nil;
 
-  __block NSString            *firstLine = nil;
-  __block NSMutableURLRequest *request = [NSMutableURLRequest new];
-  __block NSUInteger           headerEndIndex = 1;
+  NSString            *firstLine = nil;
+  NSMutableURLRequest *request = [NSMutableURLRequest new];
+  NSUInteger           headerEndIndex = 1;
+  NSUInteger           lineStart = 0;
+  NSUInteger           lineEnd = 0;
+  NSString            *line;
+  NSCharacterSet      *set = [NSCharacterSet whitespaceCharacterSet];
 
   reqString = [[NSString alloc] initWithData:reqData
                                     encoding:NSUTF8StringEncoding];
@@ -349,42 +359,39 @@ requestLength(NSData *data)
    *                    [ message-body ]
    * Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
    */
-  [reqString enumerateLinesUsingBlock2:^(NSString  *line,
-                                         NSUInteger lineEndIndex, BOOL *stop) {
-    NSRange         range;
-    NSString       *key, *value;
-    NSCharacterSet *set;
+  while ((line = nextLine(reqString, &lineStart, &lineEnd)) != nil)
+    {
+      NSRange   range;
+      NSString *key, *value;
 
-    set = [NSCharacterSet whitespaceCharacterSet];
+      /* Parse Request Line */
+      if (nil == firstLine)
+        {
+          firstLine = [line stringByTrimmingCharactersInSet:set];
+          continue;
+        }
 
-    /* Parse Request Line */
-    if (nil == firstLine)
-      {
-        firstLine = [line stringByTrimmingCharactersInSet:set];
-        return;
-      }
+      /* Reached end of message header. Stop. */
+      if ([line length] == 0)
+        {
+          headerEndIndex = lineEnd;
+          break;
+        }
 
-    /* Reached end of message header. Stop. */
-    if ([line length] == 0)
-      {
-        *stop = YES;
-        headerEndIndex = lineEndIndex;
-      }
+      range = [line rangeOfString:@":"];
+      /* Ignore this line */
+      if (NSNotFound == range.location)
+        {
+          continue;
+        }
 
-    range = [line rangeOfString:@":"];
-    /* Ignore this line */
-    if (NSNotFound == range.location)
-      {
-        return;
-      }
+      key = [[line substringToIndex:range.location]
+        stringByTrimmingCharactersInSet:set];
+      value = [[line substringFromIndex:range.location + 1]
+        stringByTrimmingCharactersInSet:set];
 
-    key = [[line substringToIndex:range.location]
-      stringByTrimmingCharactersInSet:set];
-    value = [[line substringFromIndex:range.location + 1]
-      stringByTrimmingCharactersInSet:set];
-
-    [request addValue:value forHTTPHeaderField:key];
-  }];
+      [request addValue:value forHTTPHeaderField:key];
+    }
 
   /* Calculate remaining body range */
   bodyRange = NSMakeRange(headerEndIndex, [reqData length] - headerEndIndex);
@@ -414,7 +421,7 @@ requestLength(NSData *data)
   NSData *responseData;
   if (selectedRoute)
     {
-      responseData = [selectedRoute block]([request copy]);
+      responseData = [selectedRoute responseForRequest:[request copy]];
     }
   else
     {
@@ -425,7 +432,7 @@ requestLength(NSData *data)
   send(sock, [responseData bytes], [responseData length], 0);
 }
 
-- (void)setRoutes:(NSArray<Route *> *)routes
+- (void)setRoutes:(NSArray *)routes
 {
   _routes = [routes copy];
 }

--- a/Tests/base/NSURLSession/Helpers/HTTPServer.m
+++ b/Tests/base/NSURLSession/Helpers/HTTPServer.m
@@ -14,6 +14,7 @@
 #endif
 
 #import "HTTPServer.h"
+#import "GNUstepBase/GNUstep.h"
 
 /* Line by line over an ASCII header block.  On entry *lineStart is where to
  * read from; on return it is where the next line begins and *lineEnd is the
@@ -99,8 +100,8 @@ requestLength(NSData *data)
 {
   Route *r = [[Route alloc] initWithURL:url method:method];
 
-  r->_response = response;
-  return r;
+  ASSIGN(r->_response, response);
+  return AUTORELEASE(r);
 }
 
 + (instancetype)routeWithURL:(NSURL *)url
@@ -110,9 +111,9 @@ requestLength(NSData *data)
 {
   Route *r = [[Route alloc] initWithURL:url method:method];
 
-  r->_target = target;
+  ASSIGN(r->_target, target);
   r->_selector = aSelector;
-  return r;
+  return AUTORELEASE(r);
 }
 
 + (instancetype)routeWithURL:(NSURL *)url
@@ -122,7 +123,7 @@ requestLength(NSData *data)
   Route *r = [[Route alloc] initWithURL:url method:method];
 
   r->_block = block;
-  return r;
+  return AUTORELEASE(r);
 }
 
 - (instancetype)initWithURL:(NSURL *)url
@@ -132,8 +133,8 @@ requestLength(NSData *data)
 
   if (self)
     {
-      _url = url;
-      _method = method;
+      ASSIGN(_url, url);
+      ASSIGN(_method, method);
     }
 
   return self;
@@ -164,6 +165,15 @@ requestLength(NSData *data)
 - (BOOL)acceptsURL:(NSURL *)url method:(NSString *)method
 {
   return [[_url path] isEqualTo:[url path]];
+}
+
+- (void)dealloc
+{
+  RELEASE(_url);
+  RELEASE(_method);
+  RELEASE(_response);
+  RELEASE(_target);
+  [super dealloc];
 }
 
 @end /* Route */
@@ -248,8 +258,8 @@ requestLength(NSData *data)
 {
   while (!_stop)
     {
-      @autoreleasepool
-        {
+      {
+  CREATE_AUTORELEASE_POOL(arp);
           struct sockaddr_in	clientAddr;
           socklen_t      	sin_size = sizeof(struct sockaddr_in);
           int                	clientSocket;
@@ -270,7 +280,8 @@ requestLength(NSData *data)
                                    toTarget: self
                                  withObject: [NSNumber numberWithInt:
                                    clientSocket]];
-        }
+  DESTROY(arp);
+}
     }
 }
 
@@ -285,8 +296,8 @@ requestLength(NSData *data)
     {
       BOOL done = NO;
 
-      @autoreleasepool
-        {
+      {
+  CREATE_AUTORELEASE_POOL(arp);
           char      buffer[4096];
           NSInteger bytesRead = recv(clientSocket, buffer, sizeof(buffer), 0);
 
@@ -321,7 +332,8 @@ requestLength(NSData *data)
                 }
               done = YES;
             }
-        }
+  DESTROY(arp);
+}
 
       if (done)
         {
@@ -459,6 +471,7 @@ requestLength(NSData *data)
 
 - (void)dealloc
 {
+  RELEASE(_routes);
   close(_socket);
 #ifdef _WIN32
   WSACleanup();

--- a/Tests/base/NSURLSession/NSRunLoop+TimeOutAdditions.h
+++ b/Tests/base/NSURLSession/NSRunLoop+TimeOutAdditions.h
@@ -3,24 +3,27 @@
 
 @interface
 NSRunLoop (TimeOutAdditions)
-- (void)runForSeconds:(NSTimeInterval)seconds conditionBlock:(BOOL (^)())block;
+/* Run the run loop for a short slice.  Returns NO once deadline has passed,
+ * so a caller waits with
+ *
+ *   while (<still waiting> && [rl runSliceUntil: deadline]) ;
+ *
+ * which states the condition without needing a block.
+ */
+- (BOOL)runSliceUntil:(NSDate *)deadline;
 @end
 
 @implementation
 NSRunLoop (TimeOutAdditions)
-- (void)runForSeconds:(NSTimeInterval)seconds conditionBlock:(BOOL (^)())block
+- (BOOL)runSliceUntil:(NSDate *)deadline
 {
-  NSDate        *startDate = [NSDate date];
-  NSTimeInterval endTime = [startDate timeIntervalSince1970] + seconds;
-  NSTimeInterval interval = 0.1; // Interval to check the condition
-
-  while (block() && [[NSDate date] timeIntervalSince1970] < endTime)
+  if ([deadline timeIntervalSinceNow] <= 0.0)
     {
-      @autoreleasepool
-      {
-        [[NSRunLoop currentRunLoop]
-          runUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
-      }
+      return NO;
     }
+  ENTER_POOL
+  [self runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+  LEAVE_POOL
+  return YES;
 }
 @end

--- a/Tests/base/NSURLSession/URLManager.h
+++ b/Tests/base/NSURLSession/URLManager.h
@@ -139,7 +139,7 @@ DEFINE_BLOCK_TYPE(URLManagerCheckBlock, void, URLManager *);
 
 - (void)URLSession:(NSURLSession *)session
                   task:(NSURLSessionTask *)task
-  didCompleteWithError:(nullable NSError *)error
+  didCompleteWithError:(NSError * _Nullable)error
 {
   ASSIGN(currentSession, session);
   ASSIGN(didCompleteTask, task);

--- a/Tests/base/NSURLSession/URLManager.h
+++ b/Tests/base/NSURLSession/URLManager.h
@@ -1,15 +1,18 @@
 #import <Foundation/NSURLSession.h>
 #import <Foundation/NSData.h>
+#import <GNUstepBase/GSBlocks.h>
 
 @class URLManager;
 
-typedef void (^URLManagerCheckBlock)(URLManager *);
+DEFINE_BLOCK_TYPE(URLManagerCheckBlock, void, URLManager *);
 
 @interface URLManager
   : NSObject <NSURLSessionDataDelegate, NSURLSessionTaskDelegate,
               NSURLSessionDelegate, NSURLSessionDownloadDelegate>
 {
   URLManagerCheckBlock _checkBlock;
+  id                   _checkTarget;
+  SEL                  _checkSelector;
 
 @public
   NSURLSession                   *currentSession;
@@ -55,6 +58,11 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 
 - (void)setCheckBlock:(URLManagerCheckBlock)block;
 
+/* The check to run once the expected number of tasks has completed, stated
+ * without a block.  aSelector takes the URLManager.
+ */
+- (void)setCheckTarget:(id)target selector:(SEL)aSelector;
+
 @end
 
 @implementation URLManager
@@ -73,7 +81,17 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 
 - (void)setCheckBlock:(URLManagerCheckBlock)block
 {
-  _checkBlock = _Block_copy(block);
+  if (NULL != block)
+    {
+      _checkBlock = Block_copy(block);
+    }
+}
+
+- (void)setCheckTarget:(id)target selector:(SEL)aSelector
+{
+  /* The check runs later, from a delegate callback, so the target is held. */
+  ASSIGN(_checkTarget, target);
+  _checkSelector = aSelector;
 }
 
 #pragma mark - Session Lifecycle
@@ -98,10 +116,9 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 #pragma mark - Task Updates
 
 - (void)URLSession:(NSURLSession *)session
-                        task:(NSURLSessionTask *)task
-  willPerformHTTPRedirection:(NSHTTPURLResponse *)response
-                  newRequest:(NSURLRequest *)request
-           completionHandler:(void (^)(NSURLRequest *))completionHandler
+                    task:(NSURLSessionTask *)task
+  willRedirectToResponse:(NSHTTPURLResponse *)response
+              newRequest:(NSURLRequest *)request
 {
   ASSIGN(currentSession, session);
   ASSIGN(httpRedirectionTask, task);
@@ -110,11 +127,11 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 
   if (cancelRedirect)
     {
-      completionHandler(NULL);
+      [task resumeWithRedirectRequest:nil];
     }
   else
     {
-      completionHandler(request);
+      [task resumeWithRedirectRequest:request];
     }
 
   httpRedirectionCount += 1;
@@ -129,10 +146,16 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
   ASSIGN(didCompleteError, error);
 
   didCompleteCount += 1;
-  if (didCompleteCount == numberOfExpectedTasksBeforeCheck
-      && _checkBlock != NULL)
+  if (didCompleteCount == numberOfExpectedTasksBeforeCheck)
     {
-      _checkBlock(self);
+      if (nil != _checkTarget)
+        {
+          [_checkTarget performSelector:_checkSelector withObject:self];
+        }
+      else
+        {
+          CALL_BLOCK(_checkBlock, self);
+        }
     }
 }
 
@@ -141,8 +164,6 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 - (void)URLSession:(NSURLSession *)session
             dataTask:(NSURLSessionDataTask *)dataTask
   didReceiveResponse:(NSURLResponse *)response
-   completionHandler:
-     (void (^)(NSURLSessionResponseDisposition))completionHandler
 {
   ASSIGN(currentSession, session);
   ASSIGN(didReceiveResponseTask, dataTask);
@@ -150,7 +171,7 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
 
   didReceiveResponseCount += 1;
 
-  completionHandler(responseAnswer);
+  [dataTask resumeWithResponseDisposition:responseAnswer];
 }
 
 - (void)URLSession:(NSURLSession *)session
@@ -217,7 +238,11 @@ typedef void (^URLManagerCheckBlock)(URLManager *);
   RELEASE(didReceiveDataTask);
   RELEASE(accumulatedData);
 
-  _Block_release(_checkBlock);
+  RELEASE(_checkTarget);
+  if (NULL != _checkBlock)
+    {
+      Block_release(_checkBlock);
+    }
   [super dealloc];
 }
 

--- a/Tests/base/NSURLSession/portableDelegateTests.m
+++ b/Tests/base/NSURLSession/portableDelegateTests.m
@@ -1,0 +1,297 @@
+#import <Foundation/Foundation.h>
+
+#if defined(__OBJC__) && defined(__clang__) && defined(_MSC_VER)
+id __work_around_clang_bug3 = @"__unused__";
+#endif
+
+/* Not run under MSVC, for the same reason as simpleTaskTests.m. */
+#if GS_HAVE_NSURLSESSION && !defined(_MSC_VER)
+
+#import "Helpers/HTTPServer.h"
+#import "Testing.h"
+
+/* The delegate here implements only the methods which take no completion
+ * handler, and answers them by messaging the task.  Nothing in this file
+ * sends a delegate method a block.
+ */
+
+static NSInteger	testTimeOut = 30;
+
+@interface PortableDelegate : NSObject
+{
+@public
+  NSInteger	 redirectCount;
+  NSInteger	 responseCount;
+  NSInteger	 completeCount;
+  NSMutableData *received;
+  NSError	*completionError;
+  BOOL		 refuseRedirect;
+  BOOL		 cancelResponse;
+}
+@end
+
+@implementation PortableDelegate
+
+- (instancetype) init
+{
+  self = [super init];
+  if (self != nil)
+    {
+      received = [[NSMutableData alloc] init];
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(received);
+  RELEASE(completionError);
+  [super dealloc];
+}
+
+- (void) URLSession: (NSURLSession *)session
+	       task: (NSURLSessionTask *)task
+     willRedirectToResponse: (NSHTTPURLResponse *)response
+	 newRequest: (NSURLRequest *)request
+{
+  redirectCount += 1;
+  if (refuseRedirect)
+    {
+      [task resumeWithRedirectRequest: nil];
+    }
+  else
+    {
+      [task resumeWithRedirectRequest: request];
+    }
+}
+
+- (void) URLSession: (NSURLSession *)session
+	   dataTask: (NSURLSessionDataTask *)dataTask
+ didReceiveResponse: (NSURLResponse *)response
+{
+  responseCount += 1;
+  if (cancelResponse)
+    {
+      [dataTask resumeWithResponseDisposition: NSURLSessionResponseCancel];
+    }
+  else
+    {
+      [dataTask resumeWithResponseDisposition: NSURLSessionResponseAllow];
+    }
+}
+
+- (void) URLSession: (NSURLSession *)session
+	   dataTask: (NSURLSessionDataTask *)dataTask
+     didReceiveData: (NSData *)data
+{
+  [received appendData: data];
+}
+
+- (void) URLSession: (NSURLSession *)session
+	       task: (NSURLSessionTask *)task
+didCompleteWithError: (NSError *)error
+{
+  ASSIGN(completionError, error);
+  completeCount += 1;
+}
+
+@end
+
+static NSArray *
+buildRoutes(Class routeClass, NSURL *baseURL)
+{
+  Route		*ok;
+  Route		*redirect;
+  NSString	*redirectText;
+
+  ok = [routeClass routeWithURL: [NSURL URLWithString: @"/contentOK"]
+			 method: @"GET"
+		       response:
+    [@"HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World!"
+      dataUsingEncoding: NSASCIIStringEncoding]];
+
+  redirectText = [NSString stringWithFormat:
+    @"HTTP/1.1 307 Temporary Redirect\r\nLocation: %@\r\n"
+    @"Content-Length: 0\r\n\r\n",
+    [baseURL URLByAppendingPathComponent: @"contentOK"]];
+  redirect = [routeClass routeWithURL: [NSURL URLWithString: @"/redirectToOK"]
+			       method: @"GET"
+			     response:
+    [redirectText dataUsingEncoding: NSASCIIStringEncoding]];
+
+  return [NSArray arrayWithObjects: ok, redirect, nil];
+}
+
+/* Run the run loop until the delegate has reported a completion, or the
+ * timeout expires.  Written without a block so that this file needs none. */
+static void
+waitForCompletion(PortableDelegate *mgr)
+{
+  NSDate	*end;
+
+  end = [NSDate dateWithTimeIntervalSinceNow: testTimeOut];
+  while (mgr->completeCount == 0 && [end timeIntervalSinceNow] > 0.0)
+    {
+      [[NSRunLoop currentRunLoop]
+	runUntilDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]];
+    }
+}
+
+static NSURLSession *
+sessionFor(PortableDelegate *mgr, NSOperationQueue *queue)
+{
+  return [NSURLSession
+    sessionWithConfiguration: [NSURLSessionConfiguration
+      defaultSessionConfiguration]
+		    delegate: (id)mgr
+	       delegateQueue: queue];
+}
+
+int
+main(int argc, char *argv[])
+{
+  NSAutoreleasePool	*pool = [NSAutoreleasePool new];
+  HTTPServer		*server;
+  NSOperationQueue	*queue;
+  NSURL			*baseURL;
+  NSBundle		*bundle;
+  NSString		*helperPath;
+  Class			 httpServerClass;
+  Class			 routeClass;
+
+  /* The helpers live in a bundle loaded at run time, so the classes are
+   * looked up rather than linked. */
+  helperPath = [[[NSFileManager defaultManager] currentDirectoryPath]
+    stringByAppendingString: @"/Helpers/HTTPServer.bundle"];
+  bundle = [NSBundle bundleWithPath: helperPath];
+  if (![bundle load])
+    {
+      [NSException raise: NSInternalInconsistencyException
+		  format: @"failed to load HTTPServer.bundle"];
+    }
+  httpServerClass = [bundle principalClass];
+  routeClass = [bundle classNamed: @"Route"];
+
+  server = [[httpServerClass alloc] initWithPort: 0 routes: nil];
+  queue = [[NSOperationQueue alloc] init];
+  [queue setMaxConcurrentOperationCount: 1];
+
+  baseURL = [NSURL URLWithString:
+    [NSString stringWithFormat: @"http://127.0.0.1:%ld", (long)[server port]]];
+  [server setRoutes: buildRoutes(routeClass, baseURL)];
+  [server resume];
+
+  START_SET("redirect answered through the task")
+    PortableDelegate	*mgr = AUTORELEASE([PortableDelegate new]);
+    NSURLSession	*session = sessionFor(mgr, queue);
+    NSURLSessionDataTask *task;
+    NSString		*body;
+
+    task = [session dataTaskWithURL:
+      [baseURL URLByAppendingPathComponent: @"redirectToOK"]];
+    [task resume];
+    waitForCompletion(mgr);
+
+    PASS(1 == mgr->redirectCount,
+      "the handler-less redirect method is sent once");
+    PASS(1 == mgr->completeCount, "the task completes");
+    PASS(nil == mgr->completionError, "the redirected transfer has no error");
+    body = AUTORELEASE([[NSString alloc] initWithData: mgr->received
+					     encoding: NSASCIIStringEncoding]);
+    PASS_EQUAL(body, @"Hello World!",
+      "resumeWithRedirectRequest: follows the redirect and the body arrives");
+    [session invalidateAndCancel];
+  END_SET("redirect answered through the task")
+
+  START_SET("redirect refused through the task")
+    PortableDelegate	*mgr = AUTORELEASE([PortableDelegate new]);
+    NSURLSession	*session;
+    NSURLSessionDataTask *task;
+
+    mgr->refuseRedirect = YES;
+    session = sessionFor(mgr, queue);
+    task = [session dataTaskWithURL:
+      [baseURL URLByAppendingPathComponent: @"redirectToOK"]];
+    [task resume];
+    waitForCompletion(mgr);
+
+    PASS(1 == mgr->redirectCount, "the redirect method is sent once");
+    PASS(1 == mgr->completeCount, "the refused task completes");
+    PASS(0 == [mgr->received length],
+      "resumeWithRedirectRequest: nil delivers no body");
+    [session invalidateAndCancel];
+  END_SET("redirect refused through the task")
+
+  START_SET("response disposition answered through the task")
+    PortableDelegate	*mgr = AUTORELEASE([PortableDelegate new]);
+    NSURLSession	*session = sessionFor(mgr, queue);
+    NSURLSessionDataTask *task;
+    NSString		*body;
+
+    task = [session dataTaskWithURL:
+      [baseURL URLByAppendingPathComponent: @"contentOK"]];
+    [task resume];
+    waitForCompletion(mgr);
+
+    PASS(1 == mgr->responseCount,
+      "the handler-less didReceiveResponse method is sent once");
+    body = AUTORELEASE([[NSString alloc] initWithData: mgr->received
+					     encoding: NSASCIIStringEncoding]);
+    PASS_EQUAL(body, @"Hello World!",
+      "resumeWithResponseDisposition: allow delivers the body");
+    [session invalidateAndCancel];
+  END_SET("response disposition answered through the task")
+
+  START_SET("response disposition cancel through the task")
+    PortableDelegate	*mgr = AUTORELEASE([PortableDelegate new]);
+    NSURLSession	*session;
+    NSURLSessionDataTask *task;
+
+    mgr->cancelResponse = YES;
+    session = sessionFor(mgr, queue);
+    task = [session dataTaskWithURL:
+      [baseURL URLByAppendingPathComponent: @"contentOK"]];
+    [task resume];
+    waitForCompletion(mgr);
+
+    PASS(1 == mgr->responseCount, "didReceiveResponse is sent once");
+    PASS(1 == mgr->completeCount, "the cancelled task completes");
+    PASS(nil != mgr->completionError,
+      "resumeWithResponseDisposition: cancel completes with an error");
+    [session invalidateAndCancel];
+  END_SET("response disposition cancel through the task")
+
+  START_SET("allTasks and tasksOfKind:")
+    PortableDelegate	*mgr = AUTORELEASE([PortableDelegate new]);
+    NSURLSession	*session = sessionFor(mgr, queue);
+    NSURLSessionDataTask *task;
+    NSArray		*all;
+
+    task = [session dataTaskWithURL:
+      [baseURL URLByAppendingPathComponent: @"contentOK"]];
+    all = [session allTasks];
+    PASS(1 == [all count], "allTasks reports the task the session holds");
+    PASS([all containsObject: task], "allTasks contains the created task");
+    PASS_EQUAL([session tasksOfKind: [NSURLSessionDataTask class]], all,
+      "tasksOfKind: matches a data task");
+    PASS(0 == [[session tasksOfKind: [NSURLSessionDownloadTask class]] count],
+      "tasksOfKind: rejects a class the session holds none of");
+    [session invalidateAndCancel];
+  END_SET("allTasks and tasksOfKind:")
+
+  [server suspend];
+  RELEASE(server);
+  RELEASE(queue);
+  RELEASE(pool);
+  return 0;
+}
+
+#else
+
+int
+main(int argc, char *argv[])
+{
+  return 0;
+}
+
+#endif /* GS_HAVE_NSURLSESSION */

--- a/Tests/base/NSURLSession/simpleTaskTests.m
+++ b/Tests/base/NSURLSession/simpleTaskTests.m
@@ -21,7 +21,8 @@ static NSTimeInterval expectedCountOfTasksToComplete = 0;
 
 /* Accessed in delegate on different thread.
  */
-static _Atomic(NSInteger) currentCountOfCompletedTasks = 0;
+/* Updated under countLock. */
+static volatile NSInteger currentCountOfCompletedTasks = 0;
 static NSLock            *countLock;
 
 /* All sessions share this single serial delegate queue so that delegate and
@@ -92,7 +93,7 @@ asciiData(NSString *s)
   return [s dataUsingEncoding:NSASCIIStringEncoding];
 }
 
-static NSArray<Route *> *
+static NSArray *
 createRoutes(Class routeClass, NSURL *baseURL)
 {
   Route *routeOKWithContent;
@@ -161,10 +162,9 @@ createRoutes(Class routeClass, NSURL *baseURL)
           @" ing\r\nFolded-Header-TAB: Test\r\n\ting\r\n\r\nHello "
           @"World!")];
 
-  return @[
+  return [NSArray arrayWithObjects:
     routeOKWithContent, routeTmpRedirectToOK, routeTmpRelativeRedirectToOK,
-    routeSetCookiesOK, routeFoldedHeaders, routeIncorrectlyFoldedHeaders
-  ];
+    routeSetCookiesOK, routeFoldedHeaders, routeIncorrectlyFoldedHeaders, nil];
 }
 
 @interface URLManagerCheck : NSObject
@@ -203,7 +203,7 @@ createRoutes(Class routeClass, NSURL *baseURL)
     NSURLResponse           *response = mgr->didReceiveResponse;
     NSError                 *error = mgr->didCompleteError;
     NSString                *string;
-    NSArray<NSHTTPCookie *> *cookieArray;
+    NSArray                 *cookieArray;
     NSDate                  *date;
     NSInteger                count = 0;
 
@@ -706,6 +706,7 @@ testParallelDataTransfer(NSURL *baseURL)
   const char                *prefix = "<DataTransfer>";
 
   NSInteger numberOfParallelTasks = 10;
+  NSInteger i;
 
   /* URL Delegate Setup */
   mgr = [URLManager new];
@@ -724,7 +725,7 @@ testParallelDataTransfer(NSURL *baseURL)
   check->numberOfParallelTasks = numberOfParallelTasks;
   [mgr setCheckTarget:check selector:@selector(checkParallel:)];
 
-  for (NSInteger i = 0; i < numberOfParallelTasks; i++)
+  for (i = 0; i < numberOfParallelTasks; i++)
     {
       NSURLSessionDataTask *task;
 
@@ -948,8 +949,8 @@ testSessionTeardownWithoutInvalidate(NSURL *baseURL)
 
   for (i = 0; i < 5; i++)
     {
-      @autoreleasepool
       {
+  CREATE_AUTORELEASE_POOL(arp);
         NSURLSessionConfiguration *configuration;
         NSURLSession              *session;
         TeardownDelegate          *delegate;
@@ -971,7 +972,8 @@ testSessionTeardownWithoutInvalidate(NSURL *baseURL)
           ;
         /* Draining the pool releases the session; its -dealloc stops and
          * joins the work thread. */
-      }
+  DESTROY(arp);
+}
     }
 
   PASS(YES, "%s sessions torn down without invalidate did not hang or crash",
@@ -981,8 +983,8 @@ testSessionTeardownWithoutInvalidate(NSURL *baseURL)
 int
 main(int argc, char *argv[])
 {
-  @autoreleasepool
   {
+  CREATE_AUTORELEASE_POOL(arp);
     NSBundle      *bundle;
     NSString      *helperPath;
     NSURL         *baseURL;
@@ -993,15 +995,15 @@ main(int argc, char *argv[])
     Class httpServerClass;
     Class routeClass;
 
-    requestCookieProperties = @{
-      NSHTTPCookieName : @"RequestCookie",
-      NSHTTPCookieValue : @"1234",
-      NSHTTPCookieDomain : @"127.0.0.1",
-      NSHTTPCookiePath : @"/",
-      NSHTTPCookieExpires :
-        [NSDate dateWithString:@"2100-06-09 12:18:14 +0000"],
-      NSHTTPCookieSecure : @NO,
-    };
+    requestCookieProperties = [NSDictionary dictionaryWithObjectsAndKeys:
+      @"RequestCookie", NSHTTPCookieName,
+      @"1234", NSHTTPCookieValue,
+      @"127.0.0.1", NSHTTPCookieDomain,
+      @"/", NSHTTPCookiePath,
+      [NSDate dateWithString:@"2100-06-09 12:18:14 +0000"],
+        NSHTTPCookieExpires,
+      [NSNumber numberWithBool:NO], NSHTTPCookieSecure,
+      nil];
 
     fm = [NSFileManager defaultManager];
     helperPath = [[fm currentDirectoryPath]
@@ -1085,7 +1087,8 @@ main(int argc, char *argv[])
 
     [server release];
     [countLock release];
-  }
+  DESTROY(arp);
+}
   return 0;
 }
 

--- a/Tests/base/NSURLSession/simpleTaskTests.m
+++ b/Tests/base/NSURLSession/simpleTaskTests.m
@@ -37,6 +37,61 @@ static NSURLSession     *sharedTestSession;
 
 static NSDictionary *requestCookieProperties;
 
+/* Records that a transfer finished, for the teardown test, which only needs
+ * to know when to let the session go. */
+@interface TeardownDelegate : NSObject
+{
+@public
+  BOOL finished;
+}
+@end
+
+@implementation TeardownDelegate
+- (void)URLSession:(NSURLSession *)session
+                  task:(NSURLSessionTask *)task
+  didCompleteWithError:(NSError *)error
+{
+  finished = YES;
+}
+@end
+
+/* The cookie route is the only one whose answer depends on the request, so it
+ * is the only one needing a target rather than a fixed response. */
+@interface CookieRoute : NSObject
+- (NSData *)responseForRequest:(NSURLRequest *)req;
+@end
+
+@implementation CookieRoute
+- (NSData *)responseForRequest:(NSURLRequest *)req
+{
+  NSString *httpResponse;
+  NSString *cookie;
+
+  httpResponse = @"HTTP/1.1 200 OK\r\n"
+                  "Content-Type: text/html; charset=UTF-8\r\n"
+                  "Set-Cookie: sessionId=abc123; Expires=Wed, 09 Jun "
+                  "2100 10:18:14 GMT; Path=/\r\n"
+                  "Content-Length: 13\r\n"
+                  "\r\n"
+                  "Hello, world!";
+
+  cookie = [[req allHTTPHeaderFields] objectForKey:@"Cookie"];
+  PASS(cookie != nil, "Cookie field is not nil");
+  PASS([cookie containsString:@"RequestCookie=1234"],
+       "cookie contains request cookie");
+
+  return [httpResponse dataUsingEncoding:NSASCIIStringEncoding];
+}
+@end
+
+static CookieRoute *cookieRoute;
+
+static NSData *
+asciiData(NSString *s)
+{
+  return [s dataUsingEncoding:NSASCIIStringEncoding];
+}
+
 static NSArray<Route *> *
 createRoutes(Class routeClass, NSURL *baseURL)
 {
@@ -65,95 +120,46 @@ createRoutes(Class routeClass, NSURL *baseURL)
   routeOKWithContent = [routeClass
     routeWithURL:routeOKWithContentURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData *response;
-
-           response =
-             [@"HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World!"
-               dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
+        response:asciiData(
+          @"HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World!")];
 
   routeTmpRedirectToOK = [routeClass
     routeWithURL:routeTmpRedirectToOKURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData   *response;
-           NSString *responseString;
-
-           responseString = [NSString
-             stringWithFormat:@"HTTP/1.1 307 Temporary Redirect\r\nLocation: "
-                              @"%@\r\nContent-Length: 0\r\n\r\n",
-                              [baseURL
-                                URLByAppendingPathComponent:@"contentOK"]];
-
-           response = [responseString dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
+        response:asciiData([NSString
+          stringWithFormat:@"HTTP/1.1 307 Temporary Redirect\r\nLocation: "
+                           @"%@\r\nContent-Length: 0\r\n\r\n",
+                           [baseURL URLByAppendingPathComponent:@"contentOK"]])];
 
   routeTmpRelativeRedirectToOK = [routeClass
     routeWithURL:routeTmpRelativeRedirectToOKURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData   *response;
-           NSString *responseString;
+        response:asciiData(
+          @"HTTP/1.1 307 Temporary Redirect\r\nLocation: "
+          @"contentOK\r\nContent-Length: 0\r\n\r\n")];
 
-           responseString = [NSString
-             stringWithFormat:@"HTTP/1.1 307 Temporary Redirect\r\nLocation: "
-                              @"contentOK\r\nContent-Length: 0\r\n\r\n"];
-
-           response = [responseString dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
-
+  cookieRoute = [CookieRoute new];
   routeSetCookiesOK = [routeClass
     routeWithURL:routeSetCookiesOKURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData   *response;
-           NSString *httpResponse;
-
-           httpResponse = @"HTTP/1.1 200 OK\r\n"
-                           "Content-Type: text/html; charset=UTF-8\r\n"
-                           "Set-Cookie: sessionId=abc123; Expires=Wed, 09 Jun "
-                           "2100 10:18:14 GMT; Path=/\r\n"
-                           "Content-Length: 13\r\n"
-                           "\r\n"
-                           "Hello, world!";
-
-           NSString *cookie = [req allHTTPHeaderFields][@"Cookie"];
-           PASS(cookie != nil, "Cookie field is not nil");
-           PASS([cookie containsString:@"RequestCookie=1234"],
-                "cookie contains request cookie");
-
-           response = [httpResponse dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
+          target:cookieRoute
+        selector:@selector(responseForRequest:)];
 
   routeFoldedHeaders = [routeClass
     routeWithURL:routeFoldedHeadersURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData *response;
-
-           response =
-             [@"HTTP/1.1 200 OK\r\nContent-Length: 12\r\nFolded-Header-SP: "
-              @"Test\r\n ing\r\nFolded-Header-TAB: Test\r\n\ting\r\n\r\nHello "
-              @"World!" dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
+        response:asciiData(
+          @"HTTP/1.1 200 OK\r\nContent-Length: 12\r\nFolded-Header-SP: "
+          @"Test\r\n ing\r\nFolded-Header-TAB: Test\r\n\ting\r\n\r\nHello "
+          @"World!")];
 
   routeIncorrectlyFoldedHeaders = [routeClass
     routeWithURL:routeIncorrectlyFoldedHeadersURL
           method:@"GET"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData *response;
-
-           response = [@"HTTP/1.1 200 OK\r\n"
-                       @" ing\r\nFolded-Header-TAB: Test\r\n\ting\r\n\r\nHello "
-                       @"World!" dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
+        response:asciiData(
+          @"HTTP/1.1 200 OK\r\n"
+          @" ing\r\nFolded-Header-TAB: Test\r\n\ting\r\n\r\nHello "
+          @"World!")];
 
   return @[
     routeOKWithContent, routeTmpRedirectToOK, routeTmpRelativeRedirectToOK,
@@ -161,12 +167,146 @@ createRoutes(Class routeClass, NSURL *baseURL)
   ];
 }
 
-/* Block needs to be released */
-static URLManagerCheckBlock
-downloadCheckBlock(const char *prefix, NSURLSession *session,
-                   NSURLSessionTask *task)
+@interface URLManagerCheck : NSObject
 {
-  return _Block_copy(^(URLManager *mgr) {
+@public
+  const char          *prefix;
+  NSURLSession        *session;
+  NSURLSessionTask    *task;
+  NSInteger            numberOfParallelTasks;
+  NSHTTPCookieStorage *cookies;
+  NSURL               *url;
+  NSHTTPCookie        *requestCookie;
+}
++ (instancetype) checkWithPrefix: (const char *)aPrefix
+                         session: (NSURLSession *)aSession
+                            task: (NSURLSessionTask *)aTask;
+@end
+
+@implementation URLManagerCheck
+
++ (instancetype) checkWithPrefix: (const char *)aPrefix
+                         session: (NSURLSession *)aSession
+                            task: (NSURLSessionTask *)aTask
+{
+  URLManagerCheck *c = AUTORELEASE([URLManagerCheck new]);
+
+  c->prefix = aPrefix;
+  c->session = aSession;
+  c->task = aTask;
+  return c;
+}
+
+- (void) checkCookies: (URLManager *)mgr
+{
+    NSData                  *data = mgr->accumulatedData;
+    NSURLResponse           *response = mgr->didReceiveResponse;
+    NSError                 *error = mgr->didCompleteError;
+    NSString                *string;
+    NSArray<NSHTTPCookie *> *cookieArray;
+    NSDate                  *date;
+    NSInteger                count = 0;
+
+    PASS(nil != data, "%s data in completion handler is not nil", prefix);
+    PASS(nil != response, "%s response is not nil", prefix);
+    PASS([response isKindOfClass:[NSHTTPURLResponse class]],
+         "%s response is an NSHTTPURLResponse", prefix);
+    PASS(nil == error, "%s error is nil", prefix);
+
+    string = [[NSString alloc] initWithData:data
+                                   encoding:NSASCIIStringEncoding];
+    PASS_EQUAL(string, @"Hello, world!", "%s received data is correct",
+               prefix);
+
+    cookieArray = [cookies cookiesForURL:url];
+
+    for (NSHTTPCookie *ck in cookieArray)
+      {
+        if ([[ck name] isEqualToString:@"RequestCookie"])
+          {
+            PASS_EQUAL(ck, requestCookie, "RequestCookie is correct");
+            count += 1;
+          }
+        else if ([[ck name] isEqualToString:@"sessionId"])
+          {
+            date = [NSDate dateWithString:@"2100-06-09 10:18:14 +0000"];
+            PASS_EQUAL([ck name], @"sessionId", "Cookie name is correct");
+            PASS_EQUAL([ck value], @"abc123", "Cookie value is correct");
+            PASS([ck version] == 0, "Correct cookie version");
+            PASS([date isEqual:[ck expiresDate]],
+                 "Cookie expiresDate is correct");
+            count += 1;
+          }
+      }
+    PASS(count == 2, "Found both cookies");
+
+    [string release];
+
+    [countLock lock];
+    currentCountOfCompletedTasks += 1;
+    [countLock unlock];
+}
+
+- (void) checkFoldedHeaders: (URLManager *)mgr
+{
+    NSData            *data = mgr->accumulatedData;
+    NSURLResponse     *response = mgr->didReceiveResponse;
+    NSError           *error = mgr->didCompleteError;
+    NSHTTPURLResponse *urlResponse = (NSHTTPURLResponse *) response;
+    NSString          *string;
+    NSDictionary      *headerDict;
+
+    headerDict = [urlResponse allHeaderFields];
+
+    PASS(nil != data, "%s data in completion handler is not nil", prefix);
+    PASS(nil != response, "%s response is not nil", prefix);
+    PASS([response isKindOfClass:[NSHTTPURLResponse class]],
+         "%s response is an NSHTTPURLResponse", prefix);
+    PASS(nil == error, "%s error is nil", prefix);
+
+    string = [[NSString alloc] initWithData:data
+                                   encoding:NSASCIIStringEncoding];
+    PASS_EQUAL(string, @"Hello World!", "%s received data is correct",
+               prefix);
+
+    /* RFC 7230 (3.2.4): a folded header is unfolded by replacing the fold
+     * with a single SP, so both the space- and tab-folded values become
+     * "Test ing".  This holds whether libcurl passes the raw folded lines
+     * (older libcurl) or unfolds them itself (newer libcurl). */
+    PASS_EQUAL([headerDict objectForKey:@"Folded-Header-SP"], @"Test ing",
+               "Folded header with continuation space is parsed correctly");
+    PASS_EQUAL([headerDict objectForKey:@"Folded-Header-TAB"], @"Test ing",
+               "Folded header with continuation tab is parsed correctly");
+
+    [string release];
+
+    [countLock lock];
+    currentCountOfCompletedTasks += 1;
+    [countLock unlock];
+}
+
+- (void) checkParallel: (URLManager *)mgr
+{
+    PASS_EQUAL(mgr->currentSession, session,
+               "%s URLManager Session is equal to session", prefix);
+
+    /* Check URLSession:didCreateTask: callback */
+    PASS(mgr->didCreateTaskCount == numberOfParallelTasks,
+         "%s didCreateTask: Count is correct", prefix);
+
+    /* Check URLSession:task:didCompleteWithError: */
+    PASS(nil == mgr->didCompleteError,
+         "%s didCompleteWithError: No error occurred", prefix)
+    PASS(mgr->didCompleteCount == numberOfParallelTasks,
+         "%s didCompleteWithError: Count is correct", prefix);
+
+    [countLock lock];
+    currentCountOfCompletedTasks += numberOfParallelTasks;
+    [countLock unlock];
+}
+
+- (void) checkDownload: (URLManager *)mgr
+{
     NSURL         *location;
     NSData        *data;
     NSString      *string;
@@ -222,14 +362,10 @@ downloadCheckBlock(const char *prefix, NSURLSession *session,
     [countLock lock];
     currentCountOfCompletedTasks += 1;
     [countLock unlock];
-  });
 }
 
-static URLManagerCheckBlock
-dataCheckBlock(const char *prefix, NSURLSession *session,
-               NSURLSessionTask *task)
+- (void) checkData: (URLManager *)mgr
 {
-  return _Block_copy(^(URLManager *mgr) {
     PASS_EQUAL(mgr->currentSession, session,
                "%s URLManager Session is equal to session", prefix);
 
@@ -263,15 +399,10 @@ dataCheckBlock(const char *prefix, NSURLSession *session,
     [countLock lock];
     currentCountOfCompletedTasks += 1;
     [countLock unlock];
-  });
 }
 
-/* Block needs to be released */
-static URLManagerCheckBlock
-dataCheckBlockFailedRequest(const char *prefix, NSURLSession *session,
-                            NSURLSessionTask *task)
+- (void) checkFailedRequest: (URLManager *)mgr
 {
-  return _Block_copy(^(URLManager *mgr) {
     PASS_EQUAL(mgr->currentSession, session,
                "%s URLManager Session is equal to session", prefix);
 
@@ -310,8 +441,11 @@ dataCheckBlockFailedRequest(const char *prefix, NSURLSession *session,
     [countLock lock];
     currentCountOfCompletedTasks += 1;
     [countLock unlock];
-  });
 }
+
+@end
+
+
 
 /* Creates a downloadTaskWithURL: with the /contentOK route.
  *
@@ -324,7 +458,7 @@ testSimpleDownloadTransfer(NSURL *baseURL)
   NSURLSessionConfiguration *configuration;
   NSURLSessionDownloadTask  *task;
   URLManager                *mgr;
-  URLManagerCheckBlock       block;
+  URLManagerCheck           *check;
   const char                *prefix = "<DownloadTransfer>";
 
   NSURL *contentOKURL;
@@ -345,10 +479,11 @@ testSimpleDownloadTransfer(NSURL *baseURL)
   task = [session downloadTaskWithURL:contentOKURL];
   PASS(nil != task, "%s Session created a valid download task", prefix);
 
-  /* Setup Check Block */
-  block = downloadCheckBlock(prefix, session, task);
-  [mgr setCheckBlock:block];
-  _Block_release(block);
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkDownload:)];
 
   [task resume];
 
@@ -362,7 +497,7 @@ testDownloadTransferWithRedirect(NSURL *baseURL)
   NSURLSessionConfiguration *configuration;
   NSURLSessionDownloadTask  *task;
   URLManager                *mgr;
-  URLManagerCheckBlock       block;
+  URLManagerCheck           *check;
   const char                *prefix = "<DownloadTransferWithRedirect>";
 
   NSURL *contentOKURL;
@@ -383,16 +518,20 @@ testDownloadTransferWithRedirect(NSURL *baseURL)
   task = [session downloadTaskWithURL:contentOKURL];
   PASS(nil != task, "%s Session created a valid download task", prefix);
 
-  /* Setup Check Block */
-  block = downloadCheckBlock(prefix, session, task);
-  [mgr setCheckBlock:block];
-  _Block_release(block);
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkDownload:)];
 
   [task resume];
 
   return mgr;
 }
 
+/* Tests the completion handler API, so it needs a compiler with
+ * blocks.  The same transfer is covered without one above. */
+#if __has_feature(blocks)
 /* This should use the build in redirection system from libcurl */
 static void
 testDataTransferWithRedirectAndBlock(NSURL *baseURL)
@@ -431,6 +570,7 @@ testDataTransferWithRedirectAndBlock(NSURL *baseURL)
 
   [task resume];
 }
+#endif
 
 static void
 testDataTransferWithCanceledRedirect(NSURL *baseURL)
@@ -439,7 +579,7 @@ testDataTransferWithCanceledRedirect(NSURL *baseURL)
   NSURLSessionConfiguration *configuration;
   NSURLSessionDataTask      *task;
   URLManager                *mgr;
-  URLManagerCheckBlock       block;
+  URLManagerCheck           *check;
   const char                *prefix = "<DataTransferWithCanceledRedirect>";
 
   NSURL *contentOKURL;
@@ -460,10 +600,11 @@ testDataTransferWithCanceledRedirect(NSURL *baseURL)
   task = [session dataTaskWithURL:contentOKURL];
   PASS(nil != task, "%s Session created a valid download task", prefix);
 
-  /* Setup Check Block */
-  block = dataCheckBlockFailedRequest(prefix, session, task);
-  [mgr setCheckBlock:block];
-  _Block_release(block);
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkFailedRequest:)];
 
   [task resume];
 }
@@ -476,7 +617,7 @@ testDataTransferWithRelativeRedirect(NSURL *baseURL)
   NSURLSessionDataTask      *task;
   NSURL                     *url;
   URLManager                *mgr;
-  URLManagerCheckBlock       block;
+  URLManagerCheck           *check;
   const char                *prefix = "<DataTransferWithRelativeRedirect>";
 
   /* URL Delegate Setup */
@@ -494,14 +635,18 @@ testDataTransferWithRelativeRedirect(NSURL *baseURL)
   task = [session dataTaskWithURL:url];
   PASS(nil != task, "%s Session created a valid download task", prefix);
 
-  /* Setup Check Block */
-  block = dataCheckBlock(prefix, session, task);
-  [mgr setCheckBlock:block];
-  _Block_release(block);
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkData:)];
 
   [task resume];
 }
 
+/* Tests the completion handler API, so it needs a compiler with
+ * blocks.  The same transfer is covered without one above. */
+#if __has_feature(blocks)
 static void
 testDownloadTransferWithBlock(NSURL *baseURL)
 {
@@ -548,6 +693,7 @@ testDownloadTransferWithBlock(NSURL *baseURL)
 
   [task resume];
 }
+#endif
 
 static URLManager *
 testParallelDataTransfer(NSURL *baseURL)
@@ -555,6 +701,7 @@ testParallelDataTransfer(NSURL *baseURL)
   NSURLSession              *session;
   NSURLSessionConfiguration *configuration;
   URLManager                *mgr;
+  URLManagerCheck           *check;
   NSURL                     *url;
   const char                *prefix = "<DataTransfer>";
 
@@ -572,25 +719,10 @@ testParallelDataTransfer(NSURL *baseURL)
                                           delegate:mgr
                                      delegateQueue:serialDelegateQueue];
 
-  /* Setup Check Block */
-  [mgr setCheckBlock:^(URLManager *mgr) {
-    PASS_EQUAL(mgr->currentSession, session,
-               "%s URLManager Session is equal to session", prefix);
-
-    /* Check URLSession:didCreateTask: callback */
-    PASS(mgr->didCreateTaskCount == numberOfParallelTasks,
-         "%s didCreateTask: Count is correct", prefix);
-
-    /* Check URLSession:task:didCompleteWithError: */
-    PASS(nil == mgr->didCompleteError,
-         "%s didCompleteWithError: No error occurred", prefix)
-    PASS(mgr->didCompleteCount == numberOfParallelTasks,
-         "%s didCompleteWithError: Count is correct", prefix);
-
-    [countLock lock];
-    currentCountOfCompletedTasks += numberOfParallelTasks;
-    [countLock unlock];
-  }];
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix session:session task:nil];
+  check->numberOfParallelTasks = numberOfParallelTasks;
+  [mgr setCheckTarget:check selector:@selector(checkParallel:)];
 
   for (NSInteger i = 0; i < numberOfParallelTasks; i++)
     {
@@ -603,6 +735,9 @@ testParallelDataTransfer(NSURL *baseURL)
   return mgr;
 }
 
+/* Tests the completion handler API, so it needs a compiler with
+ * blocks.  The same transfer is covered without one above. */
+#if __has_feature(blocks)
 static void
 testDataTaskWithBlock(NSURL *baseURL)
 {
@@ -640,6 +775,7 @@ testDataTaskWithBlock(NSURL *baseURL)
 
   [task resume];
 }
+#endif
 
 static void
 testDataTaskWithCookies(NSURL *baseURL)
@@ -650,6 +786,8 @@ testDataTaskWithCookies(NSURL *baseURL)
   NSURL                     *url;
   NSHTTPCookieStorage       *cookies;
   NSHTTPCookie              *requestCookie;
+  URLManager                *mgr;
+  URLManagerCheck           *check;
 
   expectedCountOfTasksToComplete += 1;
 
@@ -664,55 +802,20 @@ testDataTaskWithCookies(NSURL *baseURL)
   [config setHTTPCookieStorage:cookies];
   [config setHTTPShouldSetCookies:YES];
 
-  session = [NSURLSession sessionWithConfiguration:config];
-  task = [session
-      dataTaskWithURL:url
-    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-      NSString                *string;
-      NSArray<NSHTTPCookie *> *cookieArray;
-      NSDate                  *date;
-      const char              *prefix = "<DataTaskWithCookies>";
+  mgr = [URLManager new];
+  mgr->numberOfExpectedTasksBeforeCheck = 1;
+  session = [NSURLSession sessionWithConfiguration:config
+                                          delegate:mgr
+                                     delegateQueue:serialDelegateQueue];
+  task = [session dataTaskWithURL:url];
 
-      PASS(nil != data, "%s data in completion handler is not nil", prefix);
-      PASS(nil != response, "%s response is not nil", prefix);
-      PASS([response isKindOfClass:[NSHTTPURLResponse class]],
-           "%s response is an NSHTTPURLResponse", prefix);
-      PASS(nil == error, "%s error is nil", prefix);
-
-      string = [[NSString alloc] initWithData:data
-                                     encoding:NSASCIIStringEncoding];
-      PASS_EQUAL(string, @"Hello, world!", "%s received data is correct",
-                 prefix);
-
-      cookieArray = [cookies cookiesForURL:url];
-
-      NSInteger count = 0;
-      for (NSHTTPCookie *ck in cookieArray)
-        {
-          if ([[ck name] isEqualToString:@"RequestCookie"])
-            {
-              PASS_EQUAL(ck, requestCookie, "RequestCookie is correct");
-              count += 1;
-            }
-          else if ([[ck name] isEqualToString:@"sessionId"])
-            {
-              date = [NSDate dateWithString:@"2100-06-09 10:18:14 +0000"];
-              PASS_EQUAL([ck name], @"sessionId", "Cookie name is correct");
-              PASS_EQUAL([ck value], @"abc123", "Cookie value is correct");
-              PASS([ck version] == 0, "Correct cookie version");
-              PASS([date isEqual:[ck expiresDate]],
-                   "Cookie expiresDate is correct");
-              count += 1;
-            }
-        }
-      PASS(count == 2, "Found both cookies");
-
-      [string release];
-
-      [countLock lock];
-      currentCountOfCompletedTasks += 1;
-      [countLock unlock];
-    }];
+  check = [URLManagerCheck checkWithPrefix:"<DataTaskWithCookies>"
+                                   session:session
+                                      task:task];
+  check->cookies = cookies;
+  check->url = url;
+  check->requestCookie = requestCookie;
+  [mgr setCheckTarget:check selector:@selector(checkCookies:)];
 
   [task resume];
 }
@@ -724,47 +827,25 @@ foldedHeaderDataTaskTest(NSURL *baseURL)
   NSURLSession         *session;
   NSURLSessionDataTask *task;
   NSURL                *url;
+  URLManager           *mgr;
+  URLManagerCheck      *check;
 
   expectedCountOfTasksToComplete += 1;
 
   url = [baseURL URLByAppendingPathComponent:@"foldedHeaders"];
-  session = sharedTestSession;
-  task = [session
-      dataTaskWithURL:url
-    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-      NSHTTPURLResponse *urlResponse = (NSHTTPURLResponse *) response;
-      NSString          *string;
-      NSDictionary      *headerDict;
-      const char        *prefix = "<DataTaskWithFoldedHeaders>";
+  mgr = [URLManager new];
+  mgr->numberOfExpectedTasksBeforeCheck = 1;
+  session = [NSURLSession
+    sessionWithConfiguration:[NSURLSessionConfiguration
+      defaultSessionConfiguration]
+                    delegate:mgr
+               delegateQueue:serialDelegateQueue];
+  task = [session dataTaskWithURL:url];
 
-      headerDict = [urlResponse allHeaderFields];
-
-      PASS(nil != data, "%s data in completion handler is not nil", prefix);
-      PASS(nil != response, "%s response is not nil", prefix);
-      PASS([response isKindOfClass:[NSHTTPURLResponse class]],
-           "%s response is an NSHTTPURLResponse", prefix);
-      PASS(nil == error, "%s error is nil", prefix);
-
-      string = [[NSString alloc] initWithData:data
-                                     encoding:NSASCIIStringEncoding];
-      PASS_EQUAL(string, @"Hello World!", "%s received data is correct",
-                 prefix);
-
-      /* RFC 7230 (3.2.4): a folded header is unfolded by replacing the fold
-       * with a single SP, so both the space- and tab-folded values become
-       * "Test ing".  This holds whether libcurl passes the raw folded lines
-       * (older libcurl) or unfolds them itself (newer libcurl). */
-      PASS_EQUAL([headerDict objectForKey:@"Folded-Header-SP"], @"Test ing",
-                 "Folded header with continuation space is parsed correctly");
-      PASS_EQUAL([headerDict objectForKey:@"Folded-Header-TAB"], @"Test ing",
-                 "Folded header with continuation tab is parsed correctly");
-
-      [string release];
-
-      [countLock lock];
-      currentCountOfCompletedTasks += 1;
-      [countLock unlock];
-    }];
+  check = [URLManagerCheck checkWithPrefix:"<DataTaskWithFoldedHeaders>"
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkFoldedHeaders:)];
 
   [task resume];
 }
@@ -777,7 +858,7 @@ testAbortAfterDidReceiveResponse(NSURL *baseURL)
   NSURLSessionConfiguration *configuration;
   NSURLSessionDataTask      *task;
   URLManager                *mgr;
-  URLManagerCheckBlock       block;
+  URLManagerCheck           *check;
   const char                *prefix = "<AbortAfterDidReceiveResponseTest>";
 
   NSURL *contentOKURL;
@@ -799,10 +880,11 @@ testAbortAfterDidReceiveResponse(NSURL *baseURL)
   task = [session dataTaskWithURL:contentOKURL];
   PASS(nil != task, "%s Session created a valid download task", prefix);
 
-  /* Setup Check Block */
-  block = dataCheckBlockFailedRequest(prefix, session, task);
-  [mgr setCheckBlock:block];
-  _Block_release(block);
+  /* Setup Check */
+  check = [URLManagerCheck checkWithPrefix:prefix
+                                   session:session
+                                      task:task];
+  [mgr setCheckTarget:check selector:@selector(checkFailedRequest:)];
 
   [task resume];
 }
@@ -819,6 +901,7 @@ testInvalidateAndCancel(NSURL *baseURL)
   NSURL                     *contentOKURL;
   NSInteger                  i;
   const char                *prefix = "<InvalidateAndCancel>";
+  NSDate                    *deadline;
 
   mgr = [URLManager new];
   contentOKURL = [baseURL URLByAppendingPathComponent:@"contentOK"];
@@ -838,11 +921,10 @@ testInvalidateAndCancel(NSURL *baseURL)
   [session invalidateAndCancel];
 
   /* Wait until the delegate is told the session became invalid. */
-  [[NSRunLoop currentRunLoop]
-     runForSeconds:testTimeOut
-    conditionBlock:^BOOL(void) {
-      return mgr->didBecomeInvalidCount == 0;
-    }];
+  deadline = [NSDate dateWithTimeIntervalSinceNow:testTimeOut];
+  while (mgr->didBecomeInvalidCount == 0
+    && [[NSRunLoop currentRunLoop] runSliceUntil:deadline])
+    ;
 
   PASS(mgr->didBecomeInvalidCount == 1,
        "%s didBecomeInvalidWithError: was sent once after invalidateAndCancel",
@@ -858,6 +940,7 @@ static void
 testSessionTeardownWithoutInvalidate(NSURL *baseURL)
 {
   NSURL      *contentOKURL;
+  NSDate     *deadline;
   NSInteger   i;
   const char *prefix = "<TeardownWithoutInvalidate>";
 
@@ -869,26 +952,23 @@ testSessionTeardownWithoutInvalidate(NSURL *baseURL)
       {
         NSURLSessionConfiguration *configuration;
         NSURLSession              *session;
-        __block BOOL               finished = NO;
+        TeardownDelegate          *delegate;
 
+        delegate = AUTORELEASE([TeardownDelegate new]);
         configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         /* Lifecycle tests use their own delegate queue: they wait on their own
          * run loop and do not emit test output from the callback, so they need
          * not share the serial output queue (and must not block on it). */
         session = [NSURLSession sessionWithConfiguration:configuration
-                                                delegate:nil
+                                                delegate:delegate
                                            delegateQueue:nil];
 
-        [[session dataTaskWithURL:contentOKURL
-              completionHandler:^(NSData *d, NSURLResponse *r, NSError *e) {
-                finished = YES;
-              }] resume];
+        [[session dataTaskWithURL:contentOKURL] resume];
 
-        [[NSRunLoop currentRunLoop]
-           runForSeconds:testTimeOut
-          conditionBlock:^BOOL(void) {
-            return finished == NO;
-          }];
+        deadline = [NSDate dateWithTimeIntervalSinceNow:testTimeOut];
+        while (delegate->finished == NO
+          && [[NSRunLoop currentRunLoop] runSliceUntil:deadline])
+          ;
         /* Draining the pool releases the session; its -dealloc stops and
          * joins the work thread. */
       }
@@ -908,6 +988,7 @@ main(int argc, char *argv[])
     NSURL         *baseURL;
     NSFileManager *fm;
     HTTPServer    *server;
+    NSDate        *deadline;
 
     Class httpServerClass;
     Class routeClass;
@@ -965,10 +1046,14 @@ main(int argc, char *argv[])
 
     // Call Test Functions here
     testSimpleDownloadTransfer(baseURL);
+#if __has_feature(blocks)
     testDownloadTransferWithBlock(baseURL);
+#endif
 
     testParallelDataTransfer(baseURL);
+#if __has_feature(blocks)
     testDataTaskWithBlock(baseURL);
+#endif
     testDataTaskWithCookies(baseURL);
 
     // Testing Header Line Unfolding
@@ -976,7 +1061,9 @@ main(int argc, char *argv[])
 
     // Redirects
     testDownloadTransferWithRedirect(baseURL);
+#if __has_feature(blocks)
     testDataTransferWithRedirectAndBlock(baseURL);
+#endif
     testDataTransferWithCanceledRedirect(baseURL);
     testDataTransferWithRelativeRedirect(baseURL);
 
@@ -987,11 +1074,10 @@ main(int argc, char *argv[])
     testInvalidateAndCancel(baseURL);
     testSessionTeardownWithoutInvalidate(baseURL);
 
-    [[NSRunLoop currentRunLoop]
-       runForSeconds:testTimeOut
-      conditionBlock:^BOOL(void) {
-        return expectedCountOfTasksToComplete != currentCountOfCompletedTasks;
-      }];
+    deadline = [NSDate dateWithTimeIntervalSinceNow:testTimeOut];
+    while (expectedCountOfTasksToComplete != currentCountOfCompletedTasks
+      && [[NSRunLoop currentRunLoop] runSliceUntil:deadline])
+      ;
 
     [server suspend];
     PASS(expectedCountOfTasksToComplete == currentCountOfCompletedTasks,

--- a/Tests/base/NSURLSession/uploadTaskTests.m
+++ b/Tests/base/NSURLSession/uploadTaskTests.m
@@ -25,7 +25,8 @@ static NSTimeInterval expectedCountOfTasksToComplete = 0;
 
 /* Accessed in delegate on different thread.
  */
-static _Atomic(NSInteger) currentCountOfCompletedTasks = 0;
+/* Updated under countLock. */
+static volatile NSInteger currentCountOfCompletedTasks = 0;
 static NSLock            *countLock;
 
 /* Expected Content */
@@ -56,7 +57,7 @@ static NSData   *largeBodyContent;
 
 static LargeUploadRoute *largeUploadRoute;
 
-static NSArray<Route *> *
+static NSArray *
 createRoutes(Class routeClass)
 {
   Route *routeOKWithContent;
@@ -81,7 +82,8 @@ createRoutes(Class routeClass)
           target:largeUploadRoute
         selector:@selector(responseForRequest:)];
 
-  return @[ routeOKWithContent, routeLargeUpload ];
+  return [NSArray arrayWithObjects:
+    routeOKWithContent, routeLargeUpload, nil];
 }
 
 #if __has_feature(blocks)
@@ -137,14 +139,14 @@ testLargeUploadWithBlock(NSURL *baseURL)
 int
 main(int argc, char *argv[])
 {
-  @autoreleasepool
   {
+  CREATE_AUTORELEASE_POOL(arp);
     NSBundle         *bundle;
     NSString         *helperPath;
     NSString         *currentDirectory;
     NSURL            *baseURL;
     NSFileManager    *fm;
-    NSArray<Route *> *routes;
+    NSArray          *routes;
     HTTPServer       *server;
     NSDate           *deadline;
 
@@ -204,7 +206,8 @@ main(int argc, char *argv[])
 
     [server release];
     [countLock release];
-  }
+  DESTROY(arp);
+}
   return 0;
 }
 

--- a/Tests/base/NSURLSession/uploadTaskTests.m
+++ b/Tests/base/NSURLSession/uploadTaskTests.m
@@ -14,8 +14,10 @@ id __work_around_clang_bug2 = @"__unused__";
 #import "URLManager.h"
 #import "Testing.h"
 
-typedef void (^dataCompletionHandler)(NSData *data, NSURLResponse *response,
-                                      NSError *error);
+#if __has_feature(blocks)
+DEFINE_BLOCK_TYPE(dataCompletionHandler, void,
+  NSData *, NSURLResponse *, NSError *);
+#endif
 
 /* Timeout in Seconds */
 static NSInteger      testTimeOut = 60;
@@ -29,6 +31,30 @@ static NSLock            *countLock;
 /* Expected Content */
 static NSString *largeBodyPath;
 static NSData   *largeBodyContent;
+
+/* The large upload route checks the request, so it needs a target rather
+ * than a fixed response. */
+@interface LargeUploadRoute : NSObject
+- (NSData *)responseForRequest:(NSURLRequest *)req;
+@end
+
+@implementation LargeUploadRoute
+- (NSData *)responseForRequest:(NSURLRequest *)req
+{
+  PASS_EQUAL([req valueForHTTPHeaderField:@"Request-Key"],
+             @"Request-Value",
+             "Request contains user-specific header line");
+  PASS_EQUAL([req valueForHTTPHeaderField:@"Content-Type"],
+             @"text/plain",
+             "Request contains the correct Content-Type");
+  PASS_EQUAL([req HTTPBody], largeBodyContent, "HTTPBody is correct");
+
+  return [@"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nHeader-Key: "
+          @"Header-Value\r\n\r\n" dataUsingEncoding:NSASCIIStringEncoding];
+}
+@end
+
+static LargeUploadRoute *largeUploadRoute;
 
 static NSArray<Route *> *
 createRoutes(Class routeClass)
@@ -44,39 +70,21 @@ createRoutes(Class routeClass)
   routeOKWithContent = [routeClass
     routeWithURL:routeOKWithContentURL
           method:@"POST"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData *response;
+        response:
+      [@"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nHeader-Key: "
+       @"Header-Value\r\n\r\n" dataUsingEncoding:NSASCIIStringEncoding]];
 
-           response =
-             [@"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nHeader-Key: "
-              @"Header-Value\r\n\r\n" dataUsingEncoding:NSASCIIStringEncoding];
-           return response;
-         }];
-
+  largeUploadRoute = [LargeUploadRoute new];
   routeLargeUpload = [routeClass
     routeWithURL:routeLargeUploadURL
           method:@"POST"
-         handler:^NSData *(NSURLRequest *req) {
-           NSData *response;
-
-           PASS_EQUAL([req valueForHTTPHeaderField:@"Request-Key"],
-                      @"Request-Value",
-                      "Request contains user-specific header line");
-           PASS_EQUAL([req valueForHTTPHeaderField:@"Content-Type"],
-                      @"text/plain",
-                      "Request contains the correct Content-Type");
-           PASS_EQUAL([req HTTPBody], largeBodyContent, "HTTPBody is correct");
-
-           response =
-             [@"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nHeader-Key: "
-              @"Header-Value\r\n\r\n" dataUsingEncoding:NSASCIIStringEncoding];
-
-           return response;
-         }];
+          target:largeUploadRoute
+        selector:@selector(responseForRequest:)];
 
   return @[ routeOKWithContent, routeLargeUpload ];
 }
 
+#if __has_feature(blocks)
 static void
 testLargeUploadWithBlock(NSURL *baseURL)
 {
@@ -124,6 +132,7 @@ testLargeUploadWithBlock(NSURL *baseURL)
   [dataTask resume];
   [uploadTask resume];
 }
+#endif
 
 int
 main(int argc, char *argv[])
@@ -137,6 +146,7 @@ main(int argc, char *argv[])
     NSFileManager    *fm;
     NSArray<Route *> *routes;
     HTTPServer       *server;
+    NSDate           *deadline;
 
     Class httpServerClass;
     Class routeClass;
@@ -179,13 +189,14 @@ main(int argc, char *argv[])
     [server resume];
 
     /* Call Test Functions here! */
+#if __has_feature(blocks)
     testLargeUploadWithBlock(baseURL);
+#endif
 
-    [[NSRunLoop currentRunLoop]
-       runForSeconds:testTimeOut
-      conditionBlock:^BOOL(void) {
-        return expectedCountOfTasksToComplete != currentCountOfCompletedTasks;
-      }];
+    deadline = [NSDate dateWithTimeIntervalSinceNow:testTimeOut];
+    while (expectedCountOfTasksToComplete != currentCountOfCompletedTasks
+      && [[NSRunLoop currentRunLoop] runSliceUntil:deadline])
+      ;
 
     [server suspend];
     PASS(expectedCountOfTasksToComplete == currentCountOfCompletedTasks,

--- a/configure
+++ b/configure
@@ -15750,7 +15750,7 @@ fi
 # Check dependencies of NSURLSession API
 #--------------------------------------------------------------------
 nsurlsessiondefault=no
-if test "$OBJC_RUNTIME_LIB" = "ng" -a $HAVE_BLOCKS = 1 -a $HAVE_LIBCURL = 1; then
+if test $HAVE_LIBCURL = 1; then
   nsurlsessiondefault=yes
 fi
 
@@ -15765,12 +15765,6 @@ esac
 fi
 
 if test $enable_nsurlsession = yes; then
-  if test "$OBJC_RUNTIME_LIB" != "ng"; then
-    as_fn_error $? "Missing ng runtime (needed for NSURLSession). To build without NSURLSession support, please run configure again with the --disable-nsurlsession option." "$LINENO" 5
-  fi
-  if test $HAVE_BLOCKS = 0; then
-    as_fn_error $? "Missing blocks support (needed for NSURLSession).  To build without NSURLSession support, please run configure again with the --disable-nsurlsession option." "$LINENO" 5
-  fi
   if test $HAVE_LIBCURL = 0; then
     as_fn_error $? "Missing libcurl (needed for NSURLSession). To build without NSURLSession support, please run configure again with the --disable-nsurlsession option." "$LINENO" 5
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -3920,7 +3920,7 @@ AC_SUBST(HAVE_LIBCURL)
 # Check dependencies of NSURLSession API
 #--------------------------------------------------------------------
 nsurlsessiondefault=no
-if test "$OBJC_RUNTIME_LIB" = "ng" -a $HAVE_BLOCKS = 1 -a $HAVE_LIBCURL = 1; then
+if test $HAVE_LIBCURL = 1; then
   nsurlsessiondefault=yes
 fi
 
@@ -3930,12 +3930,6 @@ AC_ARG_ENABLE(nsurlsession,
   [Disable support for NSURLSession])],,
   enable_nsurlsession=$nsurlsessiondefault)
 if test $enable_nsurlsession = yes; then
-  if test "$OBJC_RUNTIME_LIB" != "ng"; then
-    AC_MSG_ERROR([Missing ng runtime (needed for NSURLSession). To build without NSURLSession support, please run configure again with the --disable-nsurlsession option.])
-  fi
-  if test $HAVE_BLOCKS = 0; then
-    AC_MSG_ERROR([Missing blocks support (needed for NSURLSession).  To build without NSURLSession support, please run configure again with the --disable-nsurlsession option.])
-  fi
   if test $HAVE_LIBCURL = 0; then
     AC_MSG_ERROR([Missing libcurl (needed for NSURLSession). To build without NSURLSession support, please run configure again with the --disable-nsurlsession option.])
   fi


### PR DESCRIPTION
Closes #482.  Three things stopped NSURLSession building with gcc.

The implementation created 25 block literals. 11 scheduled work on the session
work thread and 11 a delegate message on the delegate queue; those go through a
selector or an NSInvocation now. The other 3 built a completion handler for a
delegate method, so the delegate replies by messaging the task instead, with
resumeWithRedirectRequest:, resumeWithResponseDisposition: and
resumeWithBodyStream:.

The instance variables inside the @implementation blocks need the non-fragile
ABI, so both classes hold them through GSInternal.h now.

gcc has no _Atomic in Objective-C, so the counters and flags go through
GSAtomic.h. Its native branch uses clang builtins and MinGW gcc was reaching
it, so that branch now tests for clang as well.

allTasks and tasksOfKind: replace the two getTasks methods. Those, and the
three delegate methods taking a handler, carry GS_DEPRECATED. The convenience
methods creating a task with a handler have no replacement of their own, so
they keep working as they are.

The tests no longer use blocks outside the 4 covering the handler API. They
pass 133 assertions with clang and 102 with gcc.
