### PR TITLE
Uppercase, lowercase, now functions support in NSExpression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2026-08-20  Artyom Shalkhakov  <artyom.shalkhakov@gmail.com>
 
+	* Source/NSPredicate.m(parseFunctionalExpression): Accept the
+	colon form of a function call OS X writes in format strings, as
+	in "uppercase:(name)"; the colon becomes part of the function
+	name.
+	* Tests/base/NSPredicate/functionNames.m: Test it, and that
+	"now()" parses.
+
+2026-08-20  Artyom Shalkhakov  <artyom.shalkhakov@gmail.com>
+
 	* Source/NSPredicate.m: Implement the uppercase:, lowercase: and
 	now functions of NSExpression, named as OS X names them.
 	* Tests/base/NSPredicate/functionNames.m: Test them.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 2026-08-20  Artyom Shalkhakov  <artyom.shalkhakov@gmail.com>
 
+	* Source/NSPredicate.m: Hand the variadic arguments of
+	[NSExpression+expressionWithFormat:] to the predicate scanner, the
+	way [NSPredicate+predicateWithFormat:] always has, instead of
+	formatting them into the string before parsing it.  A string
+	argument now substitutes for %@ as the constant it is; formatted
+	into the string it would parse as a key path.  The walk which
+	consumes one typed argument per conversion moves to a function the
+	two entry points share.
+	* Tests/base/NSPredicate/functionNames.m: Substitute %@ and %K
+	arguments into expression formats and check what they parse as.
+
+2026-08-20  Artyom Shalkhakov  <artyom.shalkhakov@gmail.com>
+
 	* Source/NSPredicate.m(parseFunctionalExpression): Accept the
 	colon form of a function call OS X writes in format strings, as
 	in "uppercase:(name)"; the colon becomes part of the function

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-08-20  Artyom Shalkhakov  <artyom.shalkhakov@gmail.com>
+
+	* Source/NSPredicate.m: Implement the uppercase:, lowercase: and
+	now functions of NSExpression, named as OS X names them.
+	* Tests/base/NSPredicate/functionNames.m: Test them.
+
 2026-08-19  Wolfgang Lux  <wolfgang.lux@gmail.com>
 
 	* Source/NSString.m(rangeOfComposedCharacterSequencesForRange:):

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -3278,7 +3278,22 @@ do { \
   return nil;
 }
 
-// add arithmetic functions: average, median, mode, stddev, sqrt, log, ln, exp, floor, ceiling, abs, trunc, random, randomn, now
+- (id) _eval_uppercase: (NSArray *)expressions
+{
+  return [[expressions objectAtIndex: 0] uppercaseString];
+}
+
+- (id) _eval_lowercase: (NSArray *)expressions
+{
+  return [[expressions objectAtIndex: 0] lowercaseString];
+}
+
+- (id) _eval_now: (NSArray *)expressions
+{
+  return [NSDate date];
+}
+
+// add arithmetic functions: average, median, mode, stddev, sqrt, log, ln, exp, floor, ceiling, abs, trunc, random, randomn
 
 @end
 

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -4020,16 +4020,26 @@ do { \
     
   while (YES)
     {
-      if ([self scanString: @"(" intoString: NULL])
-        { 
-          // function - this parser allows for (max)(a, b, c) to be properly 
-          // recognized and even (%K)(a, b, c) if %K evaluates to "max"
-          NSMutableArray *args = [NSMutableArray arrayWithCapacity: 5];
+      BOOL colonCall = NO;
 
-          if (![left keyPath])
+      if ([self scanString: @"(" intoString: NULL]
+        || (colonCall = [self scanString: @":(" intoString: NULL]))
+        {
+          // function - this parser allows for (max)(a, b, c) to be properly
+          // recognized and even (%K)(a, b, c) if %K evaluates to "max".
+          // The name may take its trailing colon as OS X writes it, as in
+          // uppercase:(name); the colon becomes part of the function name.
+          NSMutableArray *args = [NSMutableArray arrayWithCapacity: 5];
+          NSString *name = [left keyPath];
+
+          if (!name)
             {
-              [NSException raise: NSInvalidArgumentException 
+              [NSException raise: NSInvalidArgumentException
                           format: @"Invalid function identifier: %@", left];
+            }
+          if (colonCall)
+            {
+              name = [name stringByAppendingString: @":"];
             }
 
           if (![self scanString: @")" intoString: NULL])
@@ -4045,11 +4055,11 @@ do { \
 
               if (![self scanString: @")" intoString: NULL])
                 {
-                  [NSException raise: NSInvalidArgumentException 
+                  [NSException raise: NSInvalidArgumentException
                               format: @"Missing ) in function arguments"];
                 }
             }
-          left = [NSExpression expressionForFunction: [left keyPath] 
+          left = [NSExpression expressionForFunction: name
                                            arguments: args];
         }
       else if ([self scanString: @"[" intoString: NULL])

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -332,11 +332,14 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
   return p;
 }
 
-+ (NSPredicate *) predicateWithFormat: (NSString *)format
-                            arguments: (va_list)args
+/* Walks a format string, consuming one typed variadic argument for each
+ * conversion specification and collecting them for the scanner, which
+ * substitutes them while parsing (%@ as a constant, %K as a key path).
+ * Text inside quoted literals is passed over without consuming anything.
+ */
+static NSMutableArray *
+argumentsFromFormat(NSString *format, va_list args)
 {
-  GSPredicateScanner	*s;
-  NSPredicate		*p;
   const char            *ptr = [format UTF8String];
   NSMutableArray        *arr = [NSMutableArray arrayWithCapacity: 10];
 
@@ -458,6 +461,16 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
             }
         }
     }
+  return arr;
+}
+
++ (NSPredicate *) predicateWithFormat: (NSString *)format
+                            arguments: (va_list)args
+{
+  GSPredicateScanner	*s;
+  NSPredicate		*p;
+  NSMutableArray        *arr = argumentsFromFormat(format, args);
+
   s = AUTORELEASE([[GSPredicateScanner alloc] initWithString: format
 							args: arr]);
   p = [s parse];
@@ -2024,11 +2037,16 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 + (NSExpression *) expressionWithFormat: (NSString *)format
 			      arguments: (va_list)args
 {
-  NSString *expString = AUTORELEASE([[NSString alloc] initWithFormat: format
-							   arguments: args]);
+  /* The arguments are handed to the scanner and substituted where the
+   * format references them, %@ becoming a constant expression and %K a
+   * key path, as they are for a predicate format.  (Formatting them
+   * into the string and parsing the result would lose what they were:
+   * a string substituted for %@ would parse as a key path.)
+   */
+  NSMutableArray *arr = argumentsFromFormat(format, args);
   GSPredicateScanner *scanner = AUTORELEASE([[GSPredicateScanner alloc]
-					      initWithString: expString
-							args: nil]);
+					      initWithString: format
+							args: arr]);
   return [scanner parseExpression];
 }
 

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -5,6 +5,7 @@
 */
 #import <Foundation/NSArray.h>
 #import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
 #import <Foundation/NSDate.h>
 #import <Foundation/NSExpression.h>
 #import <Foundation/NSPredicate.h>
@@ -98,6 +99,23 @@ main(int argc, char **argv)
   PASS([[e expressionValueWithObject: nil context: nil]
            isKindOfClass: [NSDate class]],
        "now() parses in a format string");
+
+  e = [NSExpression expressionWithFormat: @"%@", @"Hello"];
+  PASS([e expressionType] == NSConstantValueExpressionType
+    && [[e constantValue] isEqual: @"Hello"],
+       "a string given for %%@ substitutes as a constant, not a key path");
+
+  e = [NSExpression expressionWithFormat: @"uppercase:(%@)", @"Hello"];
+  PASS_EQUAL([e function], @"uppercase:",
+       "a %%@ argument parses inside a function call");
+  PASS_EQUAL([e expressionValueWithObject: nil context: nil], @"HELLO",
+       "and the substituted constant is what the function receives");
+
+  e = [NSExpression expressionWithFormat: @"uppercase:(%K)", @"name"];
+  PASS_EQUAL([e expressionValueWithObject:
+    [NSDictionary dictionaryWithObject: @"Hello" forKey: @"name"]
+                                  context: nil], @"HELLO",
+       "a %%K argument substitutes as a key path");
 
   {
     BOOL raised = NO;

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -5,11 +5,21 @@
 */
 #import <Foundation/NSArray.h>
 #import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDate.h>
 #import <Foundation/NSExpression.h>
 #import <Foundation/NSPredicate.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSValue.h>
 #import "ObjectTesting.h"
+
+static NSExpression *
+functionOfString(NSString *name, NSString *string)
+{
+  return [NSExpression expressionForFunction: name
+                                   arguments:
+    [NSArray arrayWithObject:
+      [NSExpression expressionForConstantValue: string]]];
+}
 
 static NSExpression *
 functionOf(NSString *name, NSArray *numbers)
@@ -59,6 +69,24 @@ main(int argc, char **argv)
   e = functionOf(@"min:", numbers);
   PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 1.0,
        "so does min");
+
+  e = functionOfString(@"uppercase:", @"Hello");
+  PASS_EQUAL([e expressionValueWithObject: nil context: nil], @"HELLO",
+       "uppercase: uppercases its argument");
+
+  e = functionOfString(@"lowercase:", @"Hello");
+  PASS_EQUAL([e expressionValueWithObject: nil context: nil], @"hello",
+       "lowercase: lowercases its argument");
+
+  e = [NSExpression expressionForFunction: @"now" arguments: [NSArray array]];
+  {
+    id value = [e expressionValueWithObject: nil context: nil];
+
+    PASS([value isKindOfClass: [NSDate class]]
+      && [value timeIntervalSinceNow] > -60.0
+      && [value timeIntervalSinceNow] < 60.0,
+      "now returns the current date");
+  }
 
   {
     BOOL raised = NO;

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -88,6 +88,17 @@ main(int argc, char **argv)
       "now returns the current date");
   }
 
+  e = [NSExpression expressionWithFormat: @"uppercase:('Hello')"];
+  PASS_EQUAL([e function], @"uppercase:",
+       "the colon form of a call parses as a function");
+  PASS_EQUAL([e expressionValueWithObject: nil context: nil], @"HELLO",
+       "and the parsed function evaluates");
+
+  e = [NSExpression expressionWithFormat: @"now()"];
+  PASS([[e expressionValueWithObject: nil context: nil]
+           isKindOfClass: [NSDate class]],
+       "now() parses in a format string");
+
   {
     BOOL raised = NO;
 


### PR DESCRIPTION
This is to fix #770.

I'm willing to assign copyright to FSF.

GNUstep's format parser turns a `%@` substitution into a key-path expression instead of a constant, so `expressionWithFormat:@"uppercase:(%@)", @"Hello"` evaluates the argument as key path `"Hello"` and dies with `"Tried to add nil to array"`. This is fixed.