### PR TITLE
Various emscripten compatibility fixes

### DIFF
--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -1063,7 +1063,11 @@ static id gs_weak_load(id obj)
       }
 #else /* HAVE_SIGACTION */
       {
+#if defined(__EMSCRIPTEN__)
+	void	(*handler)(int);
+#else
 	void	(*handler)(NSInteger);
+#endif
 
 	handler = signal(SIGPIPE, SIG_IGN);
 	if (handler != SIG_DFL)

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -39,7 +39,8 @@
 
 // Dummy implementatation
 // cleaner than IFDEF'ing the code everywhere
-#ifndef HAVE_PTHREAD_SPIN_LOCK
+#if !defined(HAVE_PTHREAD_SPIN_LOCK) && \
+    (!defined(__EMSCRIPTEN__) || !defined(__DEFINED_pthread_spinlock_t))
 typedef volatile int pthread_spinlock_t;
 int pthread_spin_init(pthread_spinlock_t *lock, int pshared)
 {
@@ -84,7 +85,7 @@ int pthread_spin_destroy(pthread_spinlock_t *lock)
 {
   return 0;
 }
-#endif /* HAVE_PTHREAD_SPIN_LOCK */
+#endif /* fallback spin-lock implementation */
 
 /** Structure for holding lock information for a thread.
  */
@@ -1154,6 +1155,8 @@ unregisterActiveThread(NSThread *thread)
 
   // Convert [-20, 19] to [0.0, 1.0] range
   pri = 1 - (priority + 20) / 39.0;
+#elif defined(__EMSCRIPTEN__)
+  return pri;
 #elif defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && (_POSIX_THREAD_PRIORITY_SCHEDULING > 0)
   int res;
   int policy;

--- a/Source/inet_ntop.m
+++ b/Source/inet_ntop.m
@@ -45,6 +45,12 @@
 #define WSAAPI
 #endif
 
+#if defined(__EMSCRIPTEN__)
+#define GS_INET_NTOP_SIZE socklen_t
+#else
+#define GS_INET_NTOP_SIZE size_t
+#endif
+
 
 /*
  * WARNING: Don't even consider trying to compile this on a system where
@@ -64,7 +70,7 @@ static  __attribute__((unused)) const char *inet_ntop6(const u_char *src, char *
  */
 const char *
 WSAAPI
-inet_ntop(int af, const void *src, char *dst, size_t size)
+inet_ntop(int af, const void *src, char *dst, GS_INET_NTOP_SIZE size)
 {
         switch (af) {
         case AF_INET:
@@ -79,6 +85,8 @@ inet_ntop(int af, const void *src, char *dst, size_t size)
         }
         /* NOTREACHED */
 }
+
+#undef GS_INET_NTOP_SIZE
 
 /* const char *
  * inet_ntop4(src, dst, size)


### PR DESCRIPTION
This PR contains a few compatibility fixes:

- Fix the Emscripten signal() handler type in NSObject.m. Emscripten declares handlers using int, while NSInteger causes an incompatible function-pointer type.

- Avoid redefining pthread_spinlock_t in NSThread.m when Emscripten’s pthread headers already provide it.

- Emscripten defines POSIX scheduling macros, but leaves the implementation stubbed. We should just return zero instead of following the POSIX branch

- Emscripten declares `inet_ntop` with `socklen_t` instead of `size_t`. Given this code is 30 years old and the manpages say it should be `socklen_t`, the current declaration might be wrong I think? For now this change only affects emscripten.