### PR TITLE
KVO: skip observers removed during change delivery

### DIFF
--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -1271,6 +1271,7 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
 
 /* One observer call, held until every lock has been dropped. */
 typedef struct {
+  _NSKVOKeyObserver     *keyObserver;
   _NSKVOKeypathObserver *keypathObserver;
   NSMutableDictionary   *change;
 } GSKVOPendingNotification;
@@ -1326,10 +1327,13 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
            * observed object would otherwise deadlock against a thread taking
            * the same two objects in the other order.  The delivery is counted
            * so that a willChange elsewhere does not refill the dictionary
-           * while it is being read.  Holding the key path observer holds the
-           * observer, the key path and the context with it.
+           * while it is being read.  The key observer is held as well so
+           * that a removal by an earlier delivery below can be detected:
+           * the key path observer does not retain its observer, which may
+           * be deallocated as soon as it has been removed.
            */
           [keypathObserver beginDelivery];
+          pending[count].keyObserver = [keyObserver retain];
           pending[count].keypathObserver = [keypathObserver retain];
           pending[count].change = [keypathObserver.pendingChange retain];
           count++;
@@ -1341,16 +1345,25 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
 
   for (index = 0; index < count; index++)
     {
+      _NSKVOKeyObserver     *keyObserver = pending[index].keyObserver;
       _NSKVOKeypathObserver *keypathObserver = pending[index].keypathObserver;
 
-      [keypathObserver.observer
-        observeValueForKeyPath: keypathObserver.keypath
-                      ofObject: keypathObserver.object
-                        change: pending[index].change
-                       context: keypathObserver.context];
+      /* An earlier delivery in this loop may have removed this observer,
+       * which the key path observer does not retain, so the observer may
+       * already be deallocated.  Removal also guarantees that no further
+       * notifications are delivered, so skip it either way. */
+      if (!keyObserver.isRemoved)
+        {
+          [keypathObserver.observer
+            observeValueForKeyPath: keypathObserver.keypath
+                          ofObject: keypathObserver.object
+                            change: pending[index].change
+                           context: keypathObserver.context];
+        }
       [keypathObserver endDelivery];
       [pending[index].change release];
       [keypathObserver release];
+      [keyObserver release];
     }
   if (pending != held)
     {

--- a/Tests/base/NSKVOSupport/removalDuringDelivery.m
+++ b/Tests/base/NSKVOSupport/removalDuringDelivery.m
@@ -1,0 +1,100 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSKeyValueObserving.h>
+#import <Foundation/NSString.h>
+
+/* An observer may be removed, and then deallocated, from inside another
+ * observer's -observeValueForKeyPath:... for the same change.  The key path
+ * observer does not retain its observer, so once removed and deallocated it
+ * must not be messaged for the change still being delivered — removal
+ * guarantees that no further notifications arrive.
+ */
+
+@interface Subject : NSObject
+{
+  int _value;
+}
+@end
+
+@implementation Subject
+- (int) value { return _value; }
+- (void) setValue: (int)v { _value = v; }
+@end
+
+static int victimNotifications = 0;
+
+@interface Victim : NSObject
+@end
+
+@implementation Victim
+- (void) observeValueForKeyPath: (NSString *)keyPath
+		       ofObject: (id)object
+			 change: (NSDictionary *)change
+			context: (void *)context
+{
+  victimNotifications++;
+}
+@end
+
+/* Removes and releases the victim while a change is being delivered. */
+@interface Remover : NSObject
+{
+@public
+  Subject *subject;
+  Victim  *victim;
+  int	   count;
+}
+@end
+
+@implementation Remover
+- (void) observeValueForKeyPath: (NSString *)keyPath
+		       ofObject: (id)object
+			 change: (NSDictionary *)change
+			context: (void *)context
+{
+  count++;
+  if (victim)
+    {
+      [subject removeObserver: victim forKeyPath: @"value"];
+      DESTROY(victim);
+    }
+}
+@end
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  Subject		*subject;
+  Remover		*remover;
+
+  /* The victim is registered first so that the change reaches the remover
+   * before it: notifications are delivered in reverse order of registration,
+   * so when the victim's turn comes it has already been deallocated. */
+  subject = AUTORELEASE([Subject new]);
+  remover = AUTORELEASE([Remover new]);
+  remover->subject = subject;
+  remover->victim = [Victim new];
+  [subject addObserver: remover->victim
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+	       context: NULL];
+  [subject addObserver: remover
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+	       context: NULL];
+  [subject setValue: 1];
+  PASS(0 == victimNotifications,
+    "an observer removed and deallocated during delivery is not messaged")
+  PASS(1 == remover->count,
+    "the observer which removed it is notified once")
+  [subject setValue: 2];
+  PASS(2 == remover->count,
+    "and keeps receiving changes")
+  PASS(0 == victimNotifications,
+    "while the deallocated observer stays unnotified")
+  [subject removeObserver: remover forKeyPath: @"value"];
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
## Problem

Since #743, `_dispatchDidChange` delivers notifications in two phases: pending notifications are collected under the change lock, then `-observeValueForKeyPath:ofObject:change:context:` is called after the locks are dropped. `keyObserver.isRemoved` is only checked during the collection phase, and `_NSKVOKeypathObserver` holds its `observer` unretained (`assign`, matching the reference platform).

If an observer's `-observeValueForKeyPath:...` removes **another** observer of the same change and that observer is then deallocated — a common pattern where the first notification tears down UI whose components each observe the same object and remove themselves in `dealloc` — the delivery loop still messages it. Depending on whether the freed memory has been reused, this is either a crash in `objc_msgSend` (with libobjc2, a null-pointer dereference at a small offset, since `object_dispose` clears the isa) or a notification delivered after `removeObserver:` returned. We hit the crash variant in a production Android application, 100% reproducibly, whenever a KVO change caused the observing UI to be torn down synchronously.

Before #743 this case was handled: the single-loop dispatch re-checked `isRemoved` immediately before each delivery.

## Reproduction

Two observers on the same key; the one notified first removes and releases the other mid-delivery:

```objc
@implementation Remover
- (void) observeValueForKeyPath: (NSString*)k ofObject: (id)o
                         change: (NSDictionary*)c context: (void*)x
{
  [subject removeObserver: victim forKeyPath: @"value"];
  DESTROY(victim);   // victim deallocated while the change is still being delivered
}
@end

[subject addObserver: victim  forKeyPath: @"value" options: ... context: NULL];
[subject addObserver: remover forKeyPath: @"value" options: ... context: NULL];
[subject setValue: 1];  // remover is notified first (reverse registration order),
                        // then the deallocated victim is messaged
```

## Fix

Hold the retained `_NSKVOKeyObserver` alongside each pending notification and re-check `isRemoved` at delivery time, skipping observers removed by an earlier delivery of the same change. This restores the guarantee that no notifications arrive after `removeObserver:` returns (which observer `dealloc` code relies on), while keeping delivery synchronous on the same stack as the change — the locking and deadlock-avoidance structure from #743 is unchanged.

`_dispatchWillChange` was audited for the same hazard: its `NSKeyValueObservingOptionPrior` delivery already sits behind a per-iteration `isRemoved` check and needs no change.

## Tests

Adds `Tests/base/NSKVOSupport/removalDuringDelivery.m`. Against current master (Android arm64, libobjc2):

```
Failed test: ... an observer removed and deallocated during delivery is not messaged
Passed test: ... the observer which removed it is notified once
Passed test: ... and keeps receiving changes
Failed test: ... while the deallocated observer stays unnotified
```

With this change all four pass, and the original application-level crash is confirmed fixed on device.