### PR TITLE
Fix strong-to-weak NSMapTable lookups after resizing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-09-07 Rupert Daniel <rupert@cancelmonday.com>
+
+        * Headers/GNUstepBase/GSIMap.h: When rehashing a table with strong
+        keys and weak values, hash the stored key rather than the nil key
+        returned by GSIMapWeakIsEmpty(), so entries stay reachable after
+        the table resizes.
+        * Tests/base/NSMapTable/weakGrowth.m: New regression test for
+        lookup, replacement and removal after growth with each combination
+        of strong and weak keys and values.
+
 2026-09-02 Richard Frith-Macdonald <rfm@gnu.org>
 
         * configure.ac: Add test for eventfd presence on linux and use it

--- a/Headers/GNUstepBase/GSIMap.h
+++ b/Headers/GNUstepBase/GSIMap.h
@@ -657,7 +657,14 @@ GSIMapRemangleBuckets(GSIMapTable map,
 		  GSIMapKey	key;
 
 		  GSIMapRemoveNodeFromBucket(old_buckets, node);
-		  key.addr = (uintptr_t)k;
+		  if (GSI_MAP_ZEROED(map) & 1)
+		    {
+		      key.addr = (uintptr_t)k;
+		    }
+		  else
+		    {
+		      key = GSI_MAP_READ_KEY(map, &node->key);
+		    }
 		  bkt = GSIMapPickBucket(GSI_MAP_HASH(map, key),
 		      new_buckets, new_bucketCount);
 		  GSIMapAddNodeToBucket(bkt, node);

--- a/Tests/base/NSMapTable/weakGrowth.m
+++ b/Tests/base/NSMapTable/weakGrowth.m
@@ -1,0 +1,150 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Insert enough entries to force the table to resize several times, keeping
+ * the keys and values alive externally, then check that every entry can
+ * still be found, replaced and removed through equal keys.
+ */
+int main(void)
+{
+  START_SET("NSMapTable growth with weak references")
+    NSPointerFunctionsOptions options[] = {
+      NSPointerFunctionsStrongMemory,
+      NSPointerFunctionsWeakMemory
+    };
+    const char *names[] = { "strong", "weak" };
+    NSUInteger k, v;
+
+    for (k = 0; k < 2; k++)
+      {
+        for (v = 0; v < 2; v++)
+          {
+            NSAutoreleasePool *pool = [NSAutoreleasePool new];
+            NSAutoreleasePool *operations;
+            NSMapTable *table;
+            NSMutableArray *keys = [NSMutableArray new];
+            NSMutableArray *values = [NSMutableArray new];
+            NSUInteger i;
+            NSUInteger expected;
+            BOOL ok;
+
+            table = [[NSMapTable alloc] initWithKeyOptions: options[k]
+                                             valueOptions: options[v]
+                                                 capacity: 0];
+            for (i = 0; i < 256; i++)
+              {
+                NSString *key = [[NSString alloc] initWithFormat:
+                  @"group-%lu", (unsigned long)i];
+                NSObject *value = [NSObject new];
+
+                [keys addObject: key];
+                [values addObject: value];
+                [table setObject: value forKey: key];
+                [key release];
+                [value release];
+              }
+
+            operations = [NSAutoreleasePool new];
+            PASS([table count] == 256,
+              "%s keys / %s values: growth preserves the count",
+              names[k], names[v]);
+            ok = YES;
+            for (i = 0; i < 256; i++)
+              {
+                NSString *key = [[keys objectAtIndex: i] mutableCopy];
+
+                if ([table objectForKey: key] != [values objectAtIndex: i])
+                  ok = NO;
+                [key release];
+              }
+            PASS(ok,
+              "%s keys / %s values: equal keys find all values after growth",
+              names[k], names[v]);
+
+            ok = YES;
+            for (i = 0; i < 256; i++)
+              {
+                NSObject *replacement = [NSObject new];
+
+                [table setObject: replacement forKey: [keys objectAtIndex: i]];
+                [values replaceObjectAtIndex: i withObject: replacement];
+                if ([table objectForKey: [keys objectAtIndex: i]] != replacement)
+                  ok = NO;
+                [replacement release];
+              }
+            PASS(ok && [table count] == 256,
+              "%s keys / %s values: replacing all values keeps the count",
+              names[k], names[v]);
+            [operations release];
+
+            if (v == 1)
+              [values replaceObjectAtIndex: 0 withObject: [NSNull null]];
+            if (k == 1)
+              [keys replaceObjectAtIndex: 1 withObject: [NSNull null]];
+
+            operations = [NSAutoreleasePool new];
+            if (v == 1)
+              PASS([table objectForKey: [keys objectAtIndex: 0]] == nil,
+                "%s keys / weak values: values remain weak after growth",
+                names[k]);
+            if (k == 1)
+              PASS([table objectForKey: @"group-1"] == nil,
+                "weak keys / %s values: keys remain weak after growth",
+                names[v]);
+
+            for (i = 256; i < 1024; i++)
+              {
+                NSString *key = [[NSString alloc] initWithFormat:
+                  @"group-%lu", (unsigned long)i];
+                NSObject *value = [NSObject new];
+
+                [keys addObject: key];
+                [values addObject: value];
+                [table setObject: value forKey: key];
+                [key release];
+                [value release];
+              }
+            ok = YES;
+            expected = 0;
+            for (i = 0; i < 1024; i++)
+              {
+                NSString *key = [keys objectAtIndex: i];
+                NSObject *value = [values objectAtIndex: i];
+
+                if ([key isKindOfClass: [NSNull class]]
+                  || [value isKindOfClass: [NSNull class]])
+                  continue;
+                expected++;
+                key = [key mutableCopy];
+                if ([table objectForKey: key] != value)
+                  ok = NO;
+                [key release];
+              }
+            PASS(ok,
+              "%s keys / %s values: surviving entries remain accessible after further growth",
+              names[k], names[v]);
+
+            for (i = 0; i < 1024; i++)
+              {
+                NSString *key = [keys objectAtIndex: i];
+
+                if ([key isKindOfClass: [NSNull class]])
+                  continue;
+                key = [key mutableCopy];
+                [table removeObjectForKey: key];
+                [key release];
+              }
+            PASS([table count] == 0,
+              "%s keys / %s values: removing all entries empties the table",
+              names[k], names[v]);
+            [operations release];
+
+            [table release];
+            [keys release];
+            [values release];
+            [pool release];
+          }
+      }
+  END_SET("NSMapTable growth with weak references")
+  return 0;
+}


### PR DESCRIPTION
## Summary

`NSMapTable` instances with strong keys and weak values (for example `+strongToWeakObjectsMapTable`) lose the ability to find their entries once the table resizes. The entries are still counted and enumerated, but `-objectForKey:` returns `nil` for them, `-setObject:forKey:` adds a duplicate node instead of replacing the existing one, and `-removeObjectForKey:` leaves the entry in place.

## Cause

`GSIMapRemangleBuckets()` in `Headers/GNUstepBase/GSIMap.h` relies on `GSIMapWeakIsEmpty()` to return the retained key of each surviving node so it can be rehashed into the new bucket array. That helper only loads the key when the keys are weak (`GSI_MAP_ZEROED(map) & 1`). When only the values are weak it leaves `k` as `nil`, so every node is rehashed with the hash of `nil` and lands in the wrong bucket.

## Fix

When keys are not weak, read the stored key with `GSI_MAP_READ_KEY()` instead of using the `nil` returned by the helper. The weak-key path is unchanged and still uses the retained key, and the existing `[k release]` stays balanced because `k` is `nil` in the strong-key case. Other callers of `GSIMapWeakIsEmpty()` only retain and release the key, so this is the only affected site.

## Test

`Tests/base/NSMapTable/weakGrowth.m` builds a table with capacity 0 for each combination of strong and weak keys and values, inserts 256 externally retained entries, and checks:

- `-count` is unchanged and every entry is found through a separately allocated equal key.
- Replacing every value keeps the count at 256, so no duplicate nodes were added.
- A released weak value, or a released weak key, is no longer found.
- After growing to 1024 entries, every surviving entry is still found.
- Removing every entry through equal keys empties the table.

Before the fix, the strong-key/weak-value case fails the four lookup, replacement and removal checks; the other three combinations pass. After the fix all 24 checks pass, and the existing `NSMapTable` tests (`basic`, `create`, `general`, `strongObjects`, `weakObjects`) are unaffected.

## Reproduction

A minimal standalone reproduction with the unpatched library:

```objc
NSMapTable *map = [NSMapTable strongToWeakObjectsMapTable];
NSMutableArray *owners = [NSMutableArray array];
for (int i = 0; i < 4096; i++) {
    NSObject *value = [NSObject new];
    [owners addObject: value];
    [map setObject: value forKey: [NSString stringWithFormat: @"key-%d", i]];
}
int missing = 0;
for (int i = 0; i < 4096; i++) {
    if ([map objectForKey: [NSString stringWithFormat: @"key-%d", i]] != owners[i]) missing++;
}
NSLog(@"count=%lu missing=%d", (unsigned long)map.count, missing);
```

Unpatched this reports `count=4096 missing=3446`, with the first entry becoming unreachable after the third insertion. A `strongToStrongObjectsMapTable`, or a strong-to-weak table preallocated with capacity 4096 so it never resizes, reports `missing=0`.

Verified on Android (aarch64, libobjc2 with the gnustep-2.2 ABI, NDK r27) against current `master`, running the six `Tests/base/NSMapTable` programs before and after the change: 87 passed / 4 failed before, 91 passed / 0 failed after.
